### PR TITLE
Fix CI: rustfmt the engine + parse multi-op CIGAR strings in the SAM reader

### DIFF
--- a/src/genomics/alignment.rs
+++ b/src/genomics/alignment.rs
@@ -122,11 +122,8 @@ pub fn banded_affine_align(
                 scores.mismatch_score
             };
 
-            let (best_prev, prev_id) = best3(
-                m_mat[i - 1][j - 1],
-                ix[i - 1][j - 1],
-                iy[i - 1][j - 1],
-            );
+            let (best_prev, prev_id) =
+                best3(m_mat[i - 1][j - 1], ix[i - 1][j - 1], iy[i - 1][j - 1]);
             m_mat[i][j] = best_prev + s;
             tb_m[i][j] = prev_id;
         }
@@ -263,7 +260,12 @@ fn compute_ref_start(
     }
 }
 
-fn compute_nm_md(reference_window: &[u8], read: &[u8], ref_start: usize, cigar: &[CigarOp]) -> (u32, String) {
+fn compute_nm_md(
+    reference_window: &[u8],
+    read: &[u8],
+    ref_start: usize,
+    cigar: &[CigarOp],
+) -> (u32, String) {
     let mut nm: u32 = 0;
     let mut md = String::new();
     let mut match_run: u32 = 0;
@@ -311,5 +313,3 @@ fn compute_nm_md(reference_window: &[u8], read: &[u8], ref_start: usize, cigar: 
     md.push_str(&match_run.to_string());
     (nm, md)
 }
-
-

--- a/src/genomics/bwt_aligner.rs
+++ b/src/genomics/bwt_aligner.rs
@@ -177,7 +177,9 @@ impl BWTAligner {
             let window_end = (start + read_upper.len() + band).min(self.reference.len());
             if window_start < window_end {
                 let window = &self.reference[window_start..window_end];
-                if let Some(refined) = banded_affine_align(window, &read_upper, band, AffineScores::default()) {
+                if let Some(refined) =
+                    banded_affine_align(window, &read_upper, band, AffineScores::default())
+                {
                     primary_position = Some((window_start + refined.ref_start) as u32);
                     cigar = refined.cigar;
                     nm = refined.nm;

--- a/src/genomics/eval/bed.rs
+++ b/src/genomics/eval/bed.rs
@@ -86,7 +86,9 @@ impl BedIndex {
             *intervals = merged;
         }
 
-        Ok(Self { intervals: per_chrom })
+        Ok(Self {
+            intervals: per_chrom,
+        })
     }
 
     /// Returns true if `(chrom, pos0)` is inside any interval.
@@ -107,9 +109,6 @@ impl BedIndex {
             Ok(i) => i,
             Err(i) => i,
         };
-        v.get(idx)
-            .is_some_and(|r| pos0 >= r.start && pos0 < r.end)
+        v.get(idx).is_some_and(|r| pos0 >= r.start && pos0 < r.end)
     }
 }
-
-

--- a/src/genomics/eval/compare.rs
+++ b/src/genomics/eval/compare.rs
@@ -120,5 +120,3 @@ fn variant_type(v: &NormalizedVariant) -> VariantType {
         VariantType::Indel
     }
 }
-
-

--- a/src/genomics/eval/mod.rs
+++ b/src/genomics/eval/mod.rs
@@ -12,5 +12,3 @@ pub use bed::{BedIndex, BedParseError};
 pub use compare::{compare_callsets, ComparisonReport, VariantType};
 pub use normalize::{normalize_variant, NormalizeError, NormalizedVariant};
 pub use vcf::{read_vcf_variants, VcfParseError, VcfVariant};
-
-

--- a/src/genomics/eval/normalize.rs
+++ b/src/genomics/eval/normalize.rs
@@ -37,10 +37,21 @@ pub struct NormalizedVariant {
 /// - uppercase alleles
 /// - trim common suffix then prefix (minimal representation)
 /// - best-effort left-alignment for indels within the provided reference slice
-pub fn normalize_variant(reference: &[u8], v: &VcfVariant) -> Result<NormalizedVariant, NormalizeError> {
+pub fn normalize_variant(
+    reference: &[u8],
+    v: &VcfVariant,
+) -> Result<NormalizedVariant, NormalizeError> {
     let mut pos0 = v.pos0;
-    let mut r = v.reference.iter().map(|b| b.to_ascii_uppercase()).collect::<Vec<u8>>();
-    let mut a = v.alternate.iter().map(|b| b.to_ascii_uppercase()).collect::<Vec<u8>>();
+    let mut r = v
+        .reference
+        .iter()
+        .map(|b| b.to_ascii_uppercase())
+        .collect::<Vec<u8>>();
+    let mut a = v
+        .alternate
+        .iter()
+        .map(|b| b.to_ascii_uppercase())
+        .collect::<Vec<u8>>();
 
     if pos0 as usize >= reference.len() {
         return Err(NormalizeError::OutOfBounds {
@@ -123,5 +134,3 @@ fn left_align(
     }
     Ok(())
 }
-
-

--- a/src/genomics/eval/vcf.rs
+++ b/src/genomics/eval/vcf.rs
@@ -112,5 +112,3 @@ fn parse_info(info: &str) -> BTreeMap<String, String> {
     }
     map
 }
-
-

--- a/src/genomics/fm_index.rs
+++ b/src/genomics/fm_index.rs
@@ -1,8 +1,8 @@
+use crate::genomics::suffix_array::{sais_u32, SuffixArrayError};
+use crate::genomics::FMInterval;
 use crate::genomics::{
     BaseCode, CompressedDNA, CompressedDNAError, RankSelectIndex, ALPHABET_SIZE,
 };
-use crate::genomics::suffix_array::{sais_u32, SuffixArrayError};
-use crate::genomics::FMInterval;
 use thiserror::Error;
 
 const SENTINEL_BYTE: u8 = b'$';
@@ -470,7 +470,11 @@ fn build_bwt_and_sa_samples(
 
     for (bwt_idx, &sa_idx_u32) in sa.iter().enumerate() {
         let sa_idx = sa_idx_u32 as usize;
-        let prev = if sa_idx == 0 { text.len() - 1 } else { sa_idx - 1 };
+        let prev = if sa_idx == 0 {
+            text.len() - 1
+        } else {
+            sa_idx - 1
+        };
         let ch = if prev == text.len() - 1 {
             SENTINEL_BYTE
         } else {

--- a/src/genomics/index/format.rs
+++ b/src/genomics/index/format.rs
@@ -154,5 +154,3 @@ pub struct SectionEntry {
 impl SectionEntry {
     pub const FIXED_SIZE: usize = 4 + 8 + 8;
 }
-
-

--- a/src/genomics/index/io.rs
+++ b/src/genomics/index/io.rs
@@ -94,7 +94,8 @@ impl IndexWriter {
         hasher.update(reference_payload);
         let reference_blake3 = *hasher.finalize().as_bytes();
 
-        let mut header = IndexHeader::new_v1(contigs.len() as u32, sa_sample_rate, reference_blake3);
+        let mut header =
+            IndexHeader::new_v1(contigs.len() as u32, sa_sample_rate, reference_blake3);
 
         // Reserve space for header.
         self.file.seek(SeekFrom::Start(0))?;
@@ -178,8 +179,9 @@ impl IndexReader {
         let header = read_header(bytes)?;
         validate_header(&header)?;
 
-        let version = IndexVersion::from_u16(header.version)
-            .ok_or_else(|| IndexIoError::Invalid(format!("unsupported index version {}", header.version)))?;
+        let version = IndexVersion::from_u16(header.version).ok_or_else(|| {
+            IndexIoError::Invalid(format!("unsupported index version {}", header.version))
+        })?;
         if version != IndexVersion::V1 {
             return Err(IndexIoError::Invalid(format!(
                 "unsupported index version {:?}",
@@ -242,7 +244,9 @@ fn read_contigs(
         .checked_add(contig_section.bytes as usize)
         .ok_or_else(|| IndexIoError::Invalid("contigs section overflow".to_string()))?;
     if end > bytes.len() {
-        return Err(IndexIoError::Invalid("contigs section out of bounds".to_string()));
+        return Err(IndexIoError::Invalid(
+            "contigs section out of bounds".to_string(),
+        ));
     }
 
     let mut contigs = Vec::with_capacity(header.contig_count as usize);
@@ -250,7 +254,9 @@ fn read_contigs(
         let name_len = read_u32(bytes, &mut offset)?;
         let name_len_usize: usize = name_len as usize;
         if offset + name_len_usize > end {
-            return Err(IndexIoError::Invalid("contig name out of bounds".to_string()));
+            return Err(IndexIoError::Invalid(
+                "contig name out of bounds".to_string(),
+            ));
         }
         let name = std::str::from_utf8(&bytes[offset..offset + name_len_usize])
             .map_err(|_| IndexIoError::Invalid("contig name not valid utf-8".to_string()))?
@@ -265,7 +271,9 @@ fn read_contigs(
 
 fn read_header(bytes: &[u8]) -> Result<IndexHeader, IndexIoError> {
     if bytes.len() < IndexHeader::FIXED_SIZE {
-        return Err(IndexIoError::Invalid("file too small for header".to_string()));
+        return Err(IndexIoError::Invalid(
+            "file too small for header".to_string(),
+        ));
     }
     let mut offset = 0usize;
     let mut magic = [0u8; 8];
@@ -331,13 +339,18 @@ fn write_section_table(mut w: impl Write, sections: &[SectionEntry]) -> Result<(
     Ok(())
 }
 
-fn read_section_table(bytes: &[u8], header: &IndexHeader) -> Result<Vec<SectionEntry>, IndexIoError> {
+fn read_section_table(
+    bytes: &[u8],
+    header: &IndexHeader,
+) -> Result<Vec<SectionEntry>, IndexIoError> {
     let mut offset = header.section_table_offset as usize;
     let end = offset
         .checked_add(header.section_table_bytes as usize)
         .ok_or_else(|| IndexIoError::Invalid("section table overflow".to_string()))?;
     if end > bytes.len() {
-        return Err(IndexIoError::Invalid("section table out of bounds".to_string()));
+        return Err(IndexIoError::Invalid(
+            "section table out of bounds".to_string(),
+        ));
     }
     let count = read_u32(bytes, &mut offset)? as usize;
     let mut sections = Vec::with_capacity(count);
@@ -426,10 +439,11 @@ mod tests {
         // Verify checksum matches the reference payload.
         let mut hasher = Hasher::new();
         hasher.update(reference_payload);
-        assert_eq!(*hasher.finalize().as_bytes(), loaded.header.reference_blake3);
+        assert_eq!(
+            *hasher.finalize().as_bytes(),
+            loaded.header.reference_blake3
+        );
 
         let _ = std::fs::remove_file(path);
     }
 }
-
-

--- a/src/genomics/index/mod.rs
+++ b/src/genomics/index/mod.rs
@@ -10,5 +10,3 @@ mod io;
 
 pub use format::IndexHeader;
 pub use io::{IndexReader, IndexWriter, ReferenceIndex};
-
-

--- a/src/genomics/mod.rs
+++ b/src/genomics/mod.rs
@@ -4,10 +4,10 @@
 //! This module exposes foundational components used by higher-level genomic
 //! algorithms (alignment, variant calling, etc.).
 
+mod alignment;
 mod block_alignment;
 mod bwt_aligner;
 mod compressed_dna;
-mod alignment;
 mod eval;
 mod fm_index;
 mod index;
@@ -15,10 +15,10 @@ mod io;
 mod pileup;
 mod pileup_stream;
 mod rank_select;
-mod sort;
 mod somatic;
-mod suffix_array;
+mod sort;
 mod statistics;
+mod suffix_array;
 mod types;
 mod variant_caller;
 mod vcf;
@@ -26,18 +26,17 @@ mod vcf;
 pub use block_alignment::{align_within_block, AlignmentError, BlockAlignmentSummary, FMInterval};
 pub use bwt_aligner::{AlignerError, AlignmentResult, BWTAligner};
 pub use compressed_dna::{AmbiguityMask, CompressedDNA, CompressedDNAError};
+pub use eval::{
+    compare_callsets, normalize_variant, read_vcf_variants, BedIndex, BedParseError,
+    ComparisonReport, NormalizeError, NormalizedVariant, VariantType, VcfParseError, VcfVariant,
+};
 pub use fm_index::{
     BWTBlock, BlockBoundary, BlockedFMIndex, CompressedBoundaries, FMIndexError, FmSymbol,
 };
 pub use index::{IndexHeader, IndexReader, IndexWriter, ReferenceIndex};
 pub use io::create_bam_writer;
-pub use sort::sort_bam_deterministic;
 pub use pileup::{PileupNode, PileupProcessor, PileupSummary, PileupWorkload};
 pub use pileup_stream::BamPileupStream;
-pub use eval::{
-    compare_callsets, normalize_variant, read_vcf_variants, BedIndex, BedParseError,
-    ComparisonReport, NormalizeError, NormalizedVariant, VariantType, VcfParseError, VcfVariant,
-};
 pub use rank_select::{
     BaseCode, RankSelectCheckpoint, RankSelectIndex, ALPHABET_SIZE, CHECKPOINT_STRIDE,
 };
@@ -45,6 +44,7 @@ pub use somatic::{
     render_somatic_vcf, write_somatic_vcf, SomaticCaller, SomaticCallerConfig, SomaticIndel,
     SomaticVariant,
 };
+pub use sort::sort_bam_deterministic;
 pub use statistics::{bayesian_variant_caller, VariantCall};
 pub use types::{AlignedRead, CigarOp, CigarOpKind};
 pub use variant_caller::{StreamingVariantCaller, Variant, VariantCallerError};

--- a/src/genomics/pileup_stream.rs
+++ b/src/genomics/pileup_stream.rs
@@ -110,7 +110,9 @@ impl BamPileupStream {
         // Pull in new reads whose start <= pos.
         loop {
             self.ensure_next_record_loaded()?;
-            let Some(rec) = self.next_record.take() else { break };
+            let Some(rec) = self.next_record.take() else {
+                break;
+            };
 
             if rec.is_unmapped() || !self.tid_matches(rec.tid()) {
                 // Skip other contigs/unmapped.
@@ -152,9 +154,8 @@ impl BamPileupStream {
             });
 
             // Maintain deterministic iteration order in the active set.
-            self.active.sort_by(|a, b| {
-                a.end.cmp(&b.end).then_with(|| a.start.cmp(&b.start))
-            });
+            self.active
+                .sort_by(|a, b| a.end.cmp(&b.end).then_with(|| a.start.cmp(&b.start)));
 
             self.next_record = None;
         }
@@ -232,5 +233,3 @@ fn is_simple_match_cigar(rec: &bam::Record) -> bool {
         None => false,
     }
 }
-
-

--- a/src/genomics/rank_select.rs
+++ b/src/genomics/rank_select.rs
@@ -89,7 +89,8 @@ impl RankSelectIndex {
         let len = sequence.len();
         let word_len = words_for_bits(len);
 
-        let mut bitvectors: [Vec<u64>; ALPHABET_SIZE] = std::array::from_fn(|_| vec![0u64; word_len]);
+        let mut bitvectors: [Vec<u64>; ALPHABET_SIZE] =
+            std::array::from_fn(|_| vec![0u64; word_len]);
         let mut totals = [0u32; ALPHABET_SIZE];
 
         for idx in 0..len {

--- a/src/genomics/somatic/mod.rs
+++ b/src/genomics/somatic/mod.rs
@@ -5,8 +5,6 @@
 mod model;
 mod vcf;
 
-pub use model::{SomaticCaller, SomaticCallerConfig, SomaticVariant};
 pub use model::SomaticIndel;
+pub use model::{SomaticCaller, SomaticCallerConfig, SomaticVariant};
 pub use vcf::{render_somatic_vcf, write_somatic_vcf};
-
-

--- a/src/genomics/somatic/model.rs
+++ b/src/genomics/somatic/model.rs
@@ -152,7 +152,9 @@ impl SomaticCaller {
             }
             let ref_base = reference[offset];
 
-            if let Some(call) = self.call_position(&chrom, pos, ref_base, t_node.as_ref(), n_node.as_ref()) {
+            if let Some(call) =
+                self.call_position(&chrom, pos, ref_base, t_node.as_ref(), n_node.as_ref())
+            {
                 out.push(call);
             }
         }
@@ -245,7 +247,11 @@ impl SomaticCaller {
         let n_alt = n_counts[alt_idx];
 
         let t_af = t_alt as f32 / t_depth as f32;
-        let n_af = if n_depth > 0 { n_alt as f32 / n_depth as f32 } else { 0.0 };
+        let n_af = if n_depth > 0 {
+            n_alt as f32 / n_depth as f32
+        } else {
+            0.0
+        };
 
         if t_af < self.cfg.min_tumor_af {
             return None;
@@ -254,7 +260,13 @@ impl SomaticCaller {
             return None;
         }
 
-        let llr = somatic_llr(t_alt, t_depth, n_alt, n_depth, self.cfg.sequencing_error_rate);
+        let llr = somatic_llr(
+            t_alt,
+            t_depth,
+            n_alt,
+            n_depth,
+            self.cfg.sequencing_error_rate,
+        );
         let qual = (llr / std::f64::consts::LN_10 * 10.0).max(0.0).min(200.0) as f32;
         if qual < self.cfg.min_quality {
             return None;
@@ -528,5 +540,3 @@ mod tests {
         assert!(call.is_none());
     }
 }
-
-

--- a/src/genomics/somatic/vcf.rs
+++ b/src/genomics/somatic/vcf.rs
@@ -47,5 +47,3 @@ pub fn render_somatic_vcf(variants: &[SomaticVariant]) -> Result<String> {
     write_somatic_vcf(&mut buffer, variants)?;
     String::from_utf8(buffer).map_err(|_| anyhow!("rendered VCF is not valid UTF-8"))
 }
-
-

--- a/src/genomics/sort.rs
+++ b/src/genomics/sort.rs
@@ -17,7 +17,11 @@ use rust_htslib::bam::Read as BamRead;
 ///
 /// - Uses stable sorting within each chunk.
 /// - Uses a deterministic k-way merge across chunk files.
-pub fn sort_bam_deterministic(input: impl AsRef<Path>, output: impl AsRef<Path>, memory_bytes: usize) -> Result<()> {
+pub fn sort_bam_deterministic(
+    input: impl AsRef<Path>,
+    output: impl AsRef<Path>,
+    memory_bytes: usize,
+) -> Result<()> {
     let input = input.as_ref();
     let output = output.as_ref();
 
@@ -40,12 +44,10 @@ pub fn sort_bam_deterministic(input: impl AsRef<Path>, output: impl AsRef<Path>,
     for rec_result in reader.records() {
         let rec = rec_result?;
         // rust-htslib does not expose raw record byte length; approximate.
-        let approx = 128usize
-            + rec.qname().len()
-            + rec.seq_len()
-            + rec.cigar().len() * 8;
+        let approx = 128usize + rec.qname().len() + rec.seq_len() + rec.cigar().len() * 8;
         if !current_chunk.is_empty() && current_bytes + approx > memory_bytes {
-            let chunk_path = spill_chunk(&header, &temp_dir, chunk_paths.len(), &mut current_chunk)?;
+            let chunk_path =
+                spill_chunk(&header, &temp_dir, chunk_paths.len(), &mut current_chunk)?;
             chunk_paths.push(chunk_path);
             current_bytes = 0;
         }
@@ -69,7 +71,12 @@ pub fn sort_bam_deterministic(input: impl AsRef<Path>, output: impl AsRef<Path>,
     Ok(())
 }
 
-fn spill_chunk(header: &bam::Header, dir: &Path, idx: usize, chunk: &mut Vec<Record>) -> Result<PathBuf> {
+fn spill_chunk(
+    header: &bam::Header,
+    dir: &Path,
+    idx: usize,
+    chunk: &mut Vec<Record>,
+) -> Result<PathBuf> {
     chunk.sort_by(|a, b| sort_key_cmp(a, b));
 
     let path = dir.join(format!("{idx:05}.bam"));
@@ -197,5 +204,3 @@ fn sort_key_cmp(a: &Record, b: &Record) -> Ordering {
         .then_with(|| a.is_reverse().cmp(&b.is_reverse()))
         .then_with(|| a.qname().cmp(b.qname()))
 }
-
-

--- a/src/genomics/suffix_array.rs
+++ b/src/genomics/suffix_array.rs
@@ -275,10 +275,7 @@ fn sais_impl(text: &[u32], max_symbol: u32) -> Vec<u32> {
 
     // Final induced sort using ordered LMS.
     let sa_final = induce_sort(text, max_symbol, &types, &ordered_lms);
-    sa_final
-        .into_iter()
-        .map(|v| v as u32)
-        .collect()
+    sa_final.into_iter().map(|v| v as u32).collect()
 }
 
 #[cfg(test)]
@@ -306,5 +303,3 @@ mod tests {
         assert_eq!(sa, naive_sa(&text));
     }
 }
-
-

--- a/src/genomics/variant_caller.rs
+++ b/src/genomics/variant_caller.rs
@@ -97,8 +97,10 @@ impl StreamingVariantCaller {
         bam_path: impl AsRef<Path>,
     ) -> Result<Vec<Variant>, VariantCallerError> {
         let region = self.region_start..(self.region_start + self.reference.len() as u32);
-        let mut stream = BamPileupStream::new(bam_path, Arc::clone(&self.chrom), region)
-            .map_err(|e| VariantCallerError::Framework(FrameworkError::processor_failure(e.to_string())))?;
+        let mut stream =
+            BamPileupStream::new(bam_path, Arc::clone(&self.chrom), region).map_err(|e| {
+                VariantCallerError::Framework(FrameworkError::processor_failure(e.to_string()))
+            })?;
 
         let mut out = Vec::new();
         while let Some(node) = stream.next() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,15 @@ use std::time::Instant;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use rosalind::genomics::{
-    create_bam_writer, write_vcf, AlignedRead, BWTAligner, CigarOp, CigarOpKind,
-    sort_bam_deterministic, SomaticCaller, SomaticCallerConfig, SomaticIndel, SomaticVariant,
-    StreamingVariantCaller,
-    BedIndex, compare_callsets, read_vcf_variants,
+    compare_callsets, create_bam_writer, read_vcf_variants, sort_bam_deterministic, write_vcf,
+    AlignedRead, BWTAligner, BedIndex, CigarOp, CigarOpKind, SomaticCaller, SomaticCallerConfig,
+    SomaticIndel, SomaticVariant, StreamingVariantCaller,
 };
 use rosalind::util::rss::peak_rss_bytes;
+use rust_htslib::bam::Read as BamRead;
 use rust_htslib::bam::{
     self, record::Aux, record::Cigar as BamCigar, record::CigarString, record::Record,
 };
-use rust_htslib::bam::Read as BamRead;
 
 #[derive(Parser, Debug)]
 #[command(name = "rosalind", about = "Genomic analysis engine using O(√t) space")]
@@ -247,16 +246,8 @@ fn main() -> Result<()> {
             memory_mb,
         } => {
             run_somatic(
-                reference,
-                tumor,
-                tumor_r1,
-                tumor_r2,
-                normal,
-                normal_r1,
-                normal_r2,
-                output,
-                workdir,
-                memory_mb,
+                reference, tumor, tumor_r1, tumor_r2, normal, normal_r1, normal_r2, output,
+                workdir, memory_mb,
             )?;
         }
         Commands::EvalSomatic {
@@ -349,8 +340,9 @@ fn run_somatic(
     // Align tumor reads.
     let start_align_tumor = Instant::now();
     {
-        let mut writer = create_bam_writer(&tumor_bam, fasta.name.as_str(), fasta.sequence.len())
-            .with_context(|| format!("failed to create tumor BAM {}", tumor_bam.display()))?;
+        let mut writer =
+            create_bam_writer(&tumor_bam, fasta.name.as_str(), fasta.sequence.len())
+                .with_context(|| format!("failed to create tumor BAM {}", tumor_bam.display()))?;
         let mut aligner = BWTAligner::new(&reference)?;
 
         match resolve_reads(
@@ -494,10 +486,7 @@ fn write_combined_somatic_vcf(
             v.alternate.clone(),
             v.quality,
             v.filter,
-            format!(
-                "TSUP={};NSUP={}",
-                v.tumor_support, v.normal_support
-            ),
+            format!("TSUP={};NSUP={}", v.tumor_support, v.normal_support),
         ));
     }
 
@@ -514,12 +503,30 @@ fn write_combined_somatic_vcf(
 
     writeln!(writer, "##fileformat=VCFv4.3")?;
     writeln!(writer, "##source=Rosalind")?;
-    writeln!(writer, "##INFO=<ID=DP_T,Number=1,Type=Integer,Description=\"Tumor depth\">")?;
-    writeln!(writer, "##INFO=<ID=DP_N,Number=1,Type=Integer,Description=\"Normal depth\">")?;
-    writeln!(writer, "##INFO=<ID=AF_T,Number=1,Type=Float,Description=\"Tumor alt allele fraction\">")?;
-    writeln!(writer, "##INFO=<ID=AF_N,Number=1,Type=Float,Description=\"Normal alt allele fraction\">")?;
-    writeln!(writer, "##INFO=<ID=TSUP,Number=1,Type=Integer,Description=\"Tumor indel supporting reads\">")?;
-    writeln!(writer, "##INFO=<ID=NSUP,Number=1,Type=Integer,Description=\"Normal indel supporting reads\">")?;
+    writeln!(
+        writer,
+        "##INFO=<ID=DP_T,Number=1,Type=Integer,Description=\"Tumor depth\">"
+    )?;
+    writeln!(
+        writer,
+        "##INFO=<ID=DP_N,Number=1,Type=Integer,Description=\"Normal depth\">"
+    )?;
+    writeln!(
+        writer,
+        "##INFO=<ID=AF_T,Number=1,Type=Float,Description=\"Tumor alt allele fraction\">"
+    )?;
+    writeln!(
+        writer,
+        "##INFO=<ID=AF_N,Number=1,Type=Float,Description=\"Normal alt allele fraction\">"
+    )?;
+    writeln!(
+        writer,
+        "##INFO=<ID=TSUP,Number=1,Type=Integer,Description=\"Tumor indel supporting reads\">"
+    )?;
+    writeln!(
+        writer,
+        "##INFO=<ID=NSUP,Number=1,Type=Integer,Description=\"Normal indel supporting reads\">"
+    )?;
     writeln!(writer, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO")?;
 
     for (chrom, pos0, ref_allele, alt_allele, qual, filter, info) in records {
@@ -603,13 +610,14 @@ fn run_align(
 
     match reads {
         ResolvedReads::Single(records) => {
-            let alignments =
-                align_reads(&mut aligner, &records, max_mismatches).context("aligning reads failed")?;
+            let alignments = align_reads(&mut aligner, &records, max_mismatches)
+                .context("aligning reads failed")?;
             match format {
                 OutputFormat::Sam => {
                     if let Some(path) = output {
-                        let file = File::create(&path)
-                            .with_context(|| format!("failed to create SAM file {}", path.display()))?;
+                        let file = File::create(&path).with_context(|| {
+                            format!("failed to create SAM file {}", path.display())
+                        })?;
                         let mut writer = io::BufWriter::new(file);
                         write_sam_alignments(
                             &mut writer,
@@ -637,19 +645,22 @@ fn run_align(
                         anyhow!("--output <FILE> must be provided when writing BAM output")
                     })?;
                     let mut writer = create_bam_writer(&path, &fasta.name, fasta.sequence.len())
-                        .with_context(|| format!("failed to create BAM writer for {}", path.display()))?;
+                        .with_context(|| {
+                            format!("failed to create BAM writer for {}", path.display())
+                        })?;
                     write_bam_alignments(&mut writer, reference_offset, &records, &alignments)?;
                 }
             }
         }
         ResolvedReads::Paired(pairs) => {
-            let alignments =
-                align_pairs(&mut aligner, &pairs, max_mismatches).context("aligning reads failed")?;
+            let alignments = align_pairs(&mut aligner, &pairs, max_mismatches)
+                .context("aligning reads failed")?;
             match format {
                 OutputFormat::Sam => {
                     if let Some(path) = output {
-                        let file = File::create(&path)
-                            .with_context(|| format!("failed to create SAM file {}", path.display()))?;
+                        let file = File::create(&path).with_context(|| {
+                            format!("failed to create SAM file {}", path.display())
+                        })?;
                         let mut writer = io::BufWriter::new(file);
                         write_sam_alignments_paired(
                             &mut writer,
@@ -677,8 +688,15 @@ fn run_align(
                         anyhow!("--output <FILE> must be provided when writing BAM output")
                     })?;
                     let mut writer = create_bam_writer(&path, &fasta.name, fasta.sequence.len())
-                        .with_context(|| format!("failed to create BAM writer for {}", path.display()))?;
-                    write_bam_alignments_paired(&mut writer, reference_offset, &pairs, &alignments)?;
+                        .with_context(|| {
+                            format!("failed to create BAM writer for {}", path.display())
+                        })?;
+                    write_bam_alignments_paired(
+                        &mut writer,
+                        reference_offset,
+                        &pairs,
+                        &alignments,
+                    )?;
                 }
             }
         }
@@ -709,7 +727,9 @@ fn align_reads(
                         Some(aligner.fm_index().sa_at(alignment.interval.lower as usize))
                     }
                 })
-                .ok_or_else(|| anyhow!("alignment reported candidates but no position could be located"))?;
+                .ok_or_else(|| {
+                    anyhow!("alignment reported candidates but no position could be located")
+                })?;
             results.push(Some(AlignmentCandidate {
                 position,
                 mismatches: alignment.mismatches,
@@ -755,7 +775,9 @@ fn align_pairs(
                             Some(aligner.fm_index().sa_at(a1.interval.lower as usize))
                         }
                     })
-                    .ok_or_else(|| anyhow!("alignment reported candidates but no position could be located"))?,
+                    .ok_or_else(|| {
+                        anyhow!("alignment reported candidates but no position could be located")
+                    })?,
                 mismatches: a1.mismatches,
                 mapq: a1.mapq,
                 is_reverse: a1.is_reverse,
@@ -779,7 +801,9 @@ fn align_pairs(
                             Some(aligner.fm_index().sa_at(a2.interval.lower as usize))
                         }
                     })
-                    .ok_or_else(|| anyhow!("alignment reported candidates but no position could be located"))?,
+                    .ok_or_else(|| {
+                        anyhow!("alignment reported candidates but no position could be located")
+                    })?,
                 mismatches: a2.mismatches,
                 mapq: a2.mapq,
                 is_reverse: a2.is_reverse,
@@ -984,10 +1008,10 @@ fn normalize_read_name(raw: &str) -> String {
 }
 
 fn read_fastq_pairs(r1: &PathBuf, r2: &PathBuf) -> Result<Vec<FastqPair>> {
-    let mut r1_records = read_fastq(r1)
-        .with_context(|| format!("failed to read FASTQ R1 from {}", r1.display()))?;
-    let mut r2_records = read_fastq(r2)
-        .with_context(|| format!("failed to read FASTQ R2 from {}", r2.display()))?;
+    let mut r1_records =
+        read_fastq(r1).with_context(|| format!("failed to read FASTQ R1 from {}", r1.display()))?;
+    let mut r2_records =
+        read_fastq(r2).with_context(|| format!("failed to read FASTQ R2 from {}", r2.display()))?;
 
     if r1_records.len() != r2_records.len() {
         bail!(
@@ -1126,8 +1150,24 @@ fn write_sam_alignments_paired<W: Write>(
     }
 
     for (pair, (a1, a2)) in reads.iter().zip(alignments.iter()) {
-        write_one_sam_mate(writer, reference_name, reference_offset, &pair.r1, a1, a2, true)?;
-        write_one_sam_mate(writer, reference_name, reference_offset, &pair.r2, a2, a1, false)?;
+        write_one_sam_mate(
+            writer,
+            reference_name,
+            reference_offset,
+            &pair.r1,
+            a1,
+            a2,
+            true,
+        )?;
+        write_one_sam_mate(
+            writer,
+            reference_name,
+            reference_offset,
+            &pair.r2,
+            a2,
+            a1,
+            false,
+        )?;
     }
 
     writer.flush()?;
@@ -1381,7 +1421,11 @@ fn write_one_bam_mate(
     if let Some(m) = mate {
         bam_record.set_mtid(0);
         bam_record.set_mpos((m.position + reference_offset as usize) as i64);
-        bam_record.set_insert_size(compute_tlen(this.as_ref(), mate.as_ref(), record.sequence.len()));
+        bam_record.set_insert_size(compute_tlen(
+            this.as_ref(),
+            mate.as_ref(),
+            record.sequence.len(),
+        ));
     } else {
         bam_record.set_mtid(-1);
         bam_record.set_mpos(-1);
@@ -1503,9 +1547,12 @@ fn read_alignment_file(
     Ok(reads)
 }
 
-fn read_bam_alignment_file(path: &PathBuf, target_chrom: Option<&Arc<str>>) -> Result<Vec<AlignedRead>> {
-    let mut reader =
-        bam::Reader::from_path(path).with_context(|| format!("failed to open BAM {}", path.display()))?;
+fn read_bam_alignment_file(
+    path: &PathBuf,
+    target_chrom: Option<&Arc<str>>,
+) -> Result<Vec<AlignedRead>> {
+    let mut reader = bam::Reader::from_path(path)
+        .with_context(|| format!("failed to open BAM {}", path.display()))?;
     let header = reader.header().to_owned();
 
     let mut reads = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1618,20 +1618,51 @@ fn parse_cigar(cigar: &str, read_len: usize) -> Result<Vec<CigarOp>> {
     if cigar == "*" {
         bail!("variant calling requires mapped reads (CIGAR cannot be '*')");
     }
-    if !cigar.ends_with('M') {
-        bail!("only match operations (M) are supported in CIGAR strings");
+
+    let mut ops = Vec::new();
+    let mut run = String::new();
+    let mut read_consuming: usize = 0;
+
+    for ch in cigar.chars() {
+        if ch.is_ascii_digit() {
+            run.push(ch);
+            continue;
+        }
+        let len: u32 = run
+            .parse()
+            .with_context(|| format!("invalid CIGAR run length in '{cigar}'"))?;
+        run.clear();
+        // Map operations the same way `read_bam_alignment_file` does; skip ops
+        // that `CigarOpKind` does not represent (e.g. N/P), mirroring that reader.
+        let kind = match ch {
+            'M' | '=' | 'X' => CigarOpKind::Match,
+            'I' => CigarOpKind::Insertion,
+            'D' => CigarOpKind::Deletion,
+            'S' => CigarOpKind::SoftClip,
+            'H' => CigarOpKind::HardClip,
+            _ => continue,
+        };
+        // M/=/X, I, and S consume read bases; D and H do not.
+        if matches!(
+            kind,
+            CigarOpKind::Match | CigarOpKind::Insertion | CigarOpKind::SoftClip
+        ) {
+            read_consuming += len as usize;
+        }
+        ops.push(CigarOp::new(kind, len));
     }
-    let len: u32 = cigar[..cigar.len() - 1]
-        .parse()
-        .with_context(|| format!("invalid CIGAR length in '{}'", cigar))?;
-    if len as usize != read_len {
-        bail!(
-            "CIGAR length {} does not match read length {}",
-            len,
-            read_len
-        );
+
+    if !run.is_empty() {
+        bail!("CIGAR '{cigar}' ends with a run length but no operation");
     }
-    Ok(vec![CigarOp::new(CigarOpKind::Match, len)])
+    if ops.is_empty() {
+        bail!("CIGAR '{cigar}' contains no supported operations");
+    }
+    if read_consuming != read_len {
+        bail!("CIGAR '{cigar}' consumes {read_consuming} read bases but the read has {read_len}");
+    }
+
+    Ok(ops)
 }
 
 #[cfg(test)]
@@ -1656,6 +1687,42 @@ mod tests {
         let path = temp_file_path(suffix);
         fs::write(&path, contents).expect("failed to write temp file");
         path
+    }
+
+    #[test]
+    fn parse_cigar_handles_multi_op_indels() {
+        // The exact CIGAR the SAM reader previously choked on (regression).
+        // 146M + 2I + 2M consumes 150 read bases.
+        let ops = parse_cigar("146M2I2M", 150).expect("multi-op CIGAR should parse");
+        assert_eq!(
+            ops,
+            vec![
+                CigarOp::new(CigarOpKind::Match, 146),
+                CigarOp::new(CigarOpKind::Insertion, 2),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_cigar_handles_match_softclip_and_deletion() {
+        assert_eq!(
+            parse_cigar("150M", 150).unwrap(),
+            vec![CigarOp::new(CigarOpKind::Match, 150)]
+        );
+        // Soft-clips consume read bases (5 + 140 + 5 = 150).
+        let sc = parse_cigar("5S140M5S", 150).unwrap();
+        assert_eq!(sc[0], CigarOp::new(CigarOpKind::SoftClip, 5));
+        assert_eq!(sc[2], CigarOp::new(CigarOpKind::SoftClip, 5));
+        // Deletions consume reference only, so read-consuming length is 20.
+        let del = parse_cigar("10M2D10M", 20).unwrap();
+        assert_eq!(del[1], CigarOp::new(CigarOpKind::Deletion, 2));
+    }
+
+    #[test]
+    fn parse_cigar_rejects_length_mismatch_and_star() {
+        assert!(parse_cigar("100M", 150).is_err());
+        assert!(parse_cigar("*", 0).is_err());
     }
 
     #[test]

--- a/src/util/mmap.rs
+++ b/src/util/mmap.rs
@@ -67,5 +67,3 @@ impl Drop for MmapReadOnly {
         }
     }
 }
-
-

--- a/src/util/rss.rs
+++ b/src/util/rss.rs
@@ -26,5 +26,3 @@ pub fn peak_rss_bytes() -> u64 {
         raw
     }
 }
-
-

--- a/tests/bam_sort.rs
+++ b/tests/bam_sort.rs
@@ -33,7 +33,12 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
         let mut writer = bam::Writer::from_path(&input, &header, bam::Format::Bam).unwrap();
 
         let mut r1 = Record::new();
-        r1.set(b"readB", Some(&CigarString::from(vec![Cigar::Match(4)])), b"ACGT", b"IIII");
+        r1.set(
+            b"readB",
+            Some(&CigarString::from(vec![Cigar::Match(4)])),
+            b"ACGT",
+            b"IIII",
+        );
         r1.set_tid(0);
         r1.set_pos(10);
         r1.set_flags(0);
@@ -41,7 +46,12 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
         writer.write(&r1).unwrap();
 
         let mut r2 = Record::new();
-        r2.set(b"readA", Some(&CigarString::from(vec![Cigar::Match(4)])), b"ACGT", b"IIII");
+        r2.set(
+            b"readA",
+            Some(&CigarString::from(vec![Cigar::Match(4)])),
+            b"ACGT",
+            b"IIII",
+        );
         r2.set_tid(0);
         r2.set_pos(5);
         r2.set_flags(0);
@@ -49,7 +59,12 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
         writer.write(&r2).unwrap();
 
         let mut r3 = Record::new();
-        r3.set(b"readC", Some(&CigarString::from(vec![Cigar::Match(4)])), b"ACGT", b"IIII");
+        r3.set(
+            b"readC",
+            Some(&CigarString::from(vec![Cigar::Match(4)])),
+            b"ACGT",
+            b"IIII",
+        );
         r3.set_tid(0);
         r3.set_pos(10);
         r3.set_flags(0x10); // reverse
@@ -80,5 +95,3 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
     let _ = std::fs::remove_file(input);
     let _ = std::fs::remove_file(output);
 }
-
-

--- a/tests/clinical_eval_gates.rs
+++ b/tests/clinical_eval_gates.rs
@@ -36,5 +36,3 @@ chr1\t31\t.\tA\tT\t50\tPASS\t.
     assert!(rep.precision() > 0.0);
     assert!(rep.recall() > 0.0);
 }
-
-

--- a/tests/pileup_stream.rs
+++ b/tests/pileup_stream.rs
@@ -33,7 +33,12 @@ fn pileup_stream_counts_depth() {
         let mut writer = bam::Writer::from_path(&input, &header, bam::Format::Bam).unwrap();
 
         let mut r1 = Record::new();
-        r1.set(b"read1", Some(&CigarString::from(vec![Cigar::Match(4)])), b"ACGT", b"IIII");
+        r1.set(
+            b"read1",
+            Some(&CigarString::from(vec![Cigar::Match(4)])),
+            b"ACGT",
+            b"IIII",
+        );
         r1.set_tid(0);
         r1.set_pos(4); // covers 4..8
         r1.set_flags(0);
@@ -41,7 +46,12 @@ fn pileup_stream_counts_depth() {
         writer.write(&r1).unwrap();
 
         let mut r2 = Record::new();
-        r2.set(b"read2", Some(&CigarString::from(vec![Cigar::Match(4)])), b"TTTT", b"IIII");
+        r2.set(
+            b"read2",
+            Some(&CigarString::from(vec![Cigar::Match(4)])),
+            b"TTTT",
+            b"IIII",
+        );
         r2.set_tid(0);
         r2.set_pos(5); // covers 5..9
         r2.set_flags(0);
@@ -70,5 +80,3 @@ fn pileup_stream_counts_depth() {
     let _ = std::fs::remove_file(input);
     let _ = std::fs::remove_file(sorted);
 }
-
-

--- a/tests/rss_budget.rs
+++ b/tests/rss_budget.rs
@@ -28,5 +28,3 @@ fn rss_peak_is_bounded_for_small_workloads() {
         cap_mb
     );
 }
-
-

--- a/tests/somatic_indels.rs
+++ b/tests/somatic_indels.rs
@@ -70,5 +70,3 @@ fn somatic_indel_emits_simple_insertion() {
     let _ = std::fs::remove_file(tumor_bam);
     let _ = std::fs::remove_file(normal_bam);
 }
-
-

--- a/tests/truthset_validation.rs
+++ b/tests/truthset_validation.rs
@@ -119,7 +119,10 @@ fn alignment_truth_exact_matches_map_to_expected_position() {
     for start in 0..(reference.len() - 8) {
         let read = &reference[start..start + 8];
         let res = aligner.align_read(read).unwrap();
-        assert!(res.primary_position.is_some(), "expected mapping for start={start}");
+        assert!(
+            res.primary_position.is_some(),
+            "expected mapping for start={start}"
+        );
         let mapped = res.primary_position.unwrap() as usize;
 
         // This reference is highly repetitive; accept any exact-match location.
@@ -135,5 +138,3 @@ fn alignment_truth_exact_matches_map_to_expected_position() {
         );
     }
 }
-
-


### PR DESCRIPTION
## Summary

Fixes the two CI failures that surfaced once the engine landed on `main`:

- **`rust` job (`cargo fmt --all -- --check`):** the merged engine sources were never run through rustfmt. Applied `cargo fmt --all` (mechanical reformat only).
- **`cli-e2e` job (Call variants):** the SAM reader's `parse_cigar` only accepted a single `<N>M` op and errored on multi-op CIGARs like `146M2I2M` that the banded-affine aligner emits — so `align | variants` failed on realistic reads. Generalized `parse_cigar` to parse a full multi-op CIGAR (M/=/X, I, D, S, H), mirroring `read_bam_alignment_file`'s op mapping, with a read-consuming-length sanity check; added unit tests.

(The pileup's indel *projection* correctness is tracked separately for the Phase A2 rebuild; this PR makes `variants` read the aligner's output and emit a VCF.)

## Test plan

- `cargo fmt --all -- --check` clean; `cargo test` green (incl. new `parse_cigar` tests); `cargo build --examples` + `cargo doc --no-deps` ok.
- Reproduced the full cli-e2e locally: `generate_toy_data` → `align` (emits a `146M2I2M` read) → `variants` exits 0 and writes a VCF (12,074 records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
