### PR TITLE
Phase A foundation: canonical core types + streaming pileup kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,161 +1,98 @@
 # Rosalind
 
-**Deterministic genomics engine for on-prem tumor/normal WGS. Built for clinic- and hospital-grade reproducibility on consumer hardware.**
+A deterministic, low-memory genomics engine in Rust for read alignment and variant calling on commodity hardware.
 
-**Rosalind** is a Rust engine for genome alignment, streaming variant calling, and custom bioinformatics analytics that runs on commodity or edge hardware. It achieves **O(√t)** working memory, deterministic replay, and drop-in extensibility for new pipelines (Rust plugins or Python bindings). Traditional pipelines often assume 50-100+ gigabytes of RAM, well-provisioned data centers, and uninterrupted connectivity; Rosalind is designed for the opposite: hospital workstations, clinic laptops, field kits, and classrooms.
-
----
-
-## Quick Overview
-- **Core problem**: existing WGS stacks are powerful but operationally heavy: nondeterminism, complex infra, and cloud-first assumptions can make clinical reproducibility and on-site operation painful.
-- **Rosalind’s answer**: prioritize **deterministic correctness** and **on-prem operation** for tumor/normal WGS pipelines. Memory is allowed to scale to practical consumer limits (e.g., single-digit GBs to ~10GB) while keeping resource usage predictable and auditable.
-- **How you use it**: run the CLI for end-to-end workflows, embed the Rust APIs, or extend via plugins/Python for bespoke analytics.
-
-See [At a Glance](#at-a-glance), [How It Compares](#how-it-compares), and [What O(√t) memory means](#what-o√t-memory-means-and-what-t-is) for deeper context.
+Rosalind streams variant calling over coordinate-sorted alignments with a working set bounded by local read coverage rather than by file size, and emits BAM/VCF that are designed to be bit-for-bit reproducible across runs. It is built to be embedded and extended: a Rust library and CLI you can call directly, add plugins to, or drive from Python.
 
 ---
 
-## At a Glance
-- **Deterministic end-to-end** – primary artifacts are designed to be bit-for-bit identical across repeated runs given the same inputs/config.
-- **Clinic-ready operation model** – runs on hospital desktops and field laptops so PHI can stay on-site.
-- **Standards-first** – interoperable BAM/VCF emission (with deterministic canonicalization).
-- **Composable extensions** – plugins/Python bindings for custom analytics without forking the pipeline.
+## What it does today
+
+- **Alignment** — Builds a Burrows–Wheeler / FM-index (SA-IS suffix array with blocked rank/select) over a reference contig and aligns reads via exact-match seeding, deterministic diagonal chaining, and banded affine-gap refinement. Emits SAM or BGZF-compressed BAM.
+- **Coordinate sort** — A deterministic external merge sort (spills to disk) that orders a BAM by position within a configurable memory budget.
+- **Germline variant calling** — Streams a pileup over a coordinate-sorted BAM and calls SNVs to VCF, keeping the in-memory working set proportional to coverage, not to the size of the input.
+- **Somatic (tumor/normal) calling** — Calls somatic SNVs and simple indels from a paired tumor/normal BAM set using a deterministic binomial log-likelihood-ratio model with explicit depth and allele-fraction filters.
+- **Truth-set evaluation** — Compares a call set against a truth VCF over confident regions (BED), with variant normalization (left-align + trim) and precision / recall / F1.
+- **Extensibility** — Implement the `GenomicPlugin` trait to run custom per-block analyses on the same bounded-memory evaluator (an example RNA-seq coverage plugin is included), or call the PyO3 bindings from Python.
+- **Determinism** — Primary artifacts are emitted in a canonical, stable order and are designed to be byte-for-byte identical across repeated runs given identical inputs and configuration. See [`docs/determinism.md`](docs/determinism.md).
+
+## Current scope
+
+Rosalind operates on a **single reference contig per run**, reads **uncompressed FASTQ** and FASTA, and runs **single-threaded**. Variant calling is **single-sample** (germline) or a **tumor/normal pair** (somatic); calling is SNV-focused, with simple indels in the somatic path. Alignment uses exact-match seeding. The FM-index is built in memory at the start of each run (memory proportional to the reference); the bounded-memory property applies to the streaming pileup and variant-calling stages. These boundaries define what the engine targets well today — small-to-moderate references, targeted regions, and per-sample streaming workloads.
+
+## Who it's for
+
+- **Edge, field, and low-resource settings** — sequencing on a laptop or portable device where large servers aren't available and predictable memory matters more than peak throughput.
+- **Reproducibility-sensitive work** — pipelines where byte-identical, auditable outputs are a first-class requirement.
+- **Teaching and learning** — a readable, end-to-end Rust implementation of FM-index alignment, streaming pileup, and variant calling to study, modify, and extend.
+- **Builders** — anyone who wants a hackable Rust genomics engine to embed, extend with plugins, or drive from Python, rather than a black-box pipeline.
+- **Somatic SNV / simple-indel exploration** on small references and targeted regions.
 
 ---
 
-## Why Rosalind Matters
-1. **Clinical genomics on laptops** – In many hospitals outside major research centers, the fastest available hardware is a shared desktop with 8–16 GB RAM. Rosalind lets clinicians align patient genomes and call variants in a single shift without renting cloud machines or shipping sensitive data off-site.
-2. **Outbreak monitoring at the edge** – During field responses (Ebola, Zika, SARS-CoV-2), portable sequencers and laptops are common, but high-memory servers are not. Rosalind streams reads, calls variants on the fly, and tolerates intermittent connectivity, enabling decisions while still on-site.
-3. **Population-scale research** – Universities or small labs may have access to mid-tier clusters but still need to process cohorts of thousands. Rosalind keeps per-sample memory flat, so more genomes can be processed in parallel on cost-efficient instances.
-4. **Education and outreach** – Students can experiment with alignment, variant calling, and plugin development on personal machines, making computational genomics coursework more hands-on and equitable.
-5. **Custom analytics** – Developers can plug in coverage dashboards, quality metrics, or single-cell style aggregations while benefiting from the same space guarantees, simplifying the path from prototype to production.
+## Install & build
 
----
-
-## Key Guarantees
-- **Deterministic artifacts**: BAM/VCF outputs are produced in a canonical, stable order and are designed to be bit-for-bit reproducible given identical inputs and configuration.
-- **Explicit determinism contract**: see `docs/determinism.md` for what is covered, what isn’t, and the engineering rules required to preserve determinism.
-- **Predictable resource profile**: memory and disk usage are bounded by explicit configuration and tested with real process measurements (not just logical counters).
-
-### What O(√t) memory means (and what 't' is)
-- `t` ≈ total bases processed. For 30× human whole-genome sequencing: coverage `C ≈ 30`, genome size `G ≈ 3.1×10⁹`, so `t ≈ C × G ≈ 9.3×10¹⁰`.
-- `√t ≈ 3.0×10⁵`, which sets the block buffer size. The height-compressed merge stack is `log₂(t) ≈ 36` levels—negligible compared with the block.
-- Working set ≈ `(α + β) · √t + γ`. With α ≈ 64–128 B per active position, whole-genome runs sit around 30–80 MB; even conservative assumptions keep the bound <100 MB.
-- The bound holds because only the current block, rolling boundary, and compact merge stack reside in memory; older state is recomputed on demand.
-- The FM-index/reference can be memory-mapped, so the O(√t) claim concerns Rosalind’s dynamic working set relative to dataset size.
-
----
-
-## Why This Is Different
-- **Partition-invariant determinism** – bit-for-bit identical outputs across runs, regardless of block size or partitioning; ideal for clinical audits, SOP lock-down, and incident investigation.
-- **Strict, test-enforced O(√t) memory** – whole-genome runs fit in well under 100 MB; CI gates fail if the bound regresses.
-- **Full-history equivalence** – recomputation (not truncation) guarantees identical results to an unbounded-memory evaluation.
-- **True streaming reads → variants** – no need to materialize large intermediates; reduces IO/storage pressure and time-to-first-result.
-- **Standards without heavyweight infra** – interoperable SAM/BAM/VCF emission while retaining streaming and memory advantages.
-- **Cache-resident execution** – keeping state in L1/L2 minimizes cache misses and paging on modest hardware, improving real-world throughput outside of large servers.
-- **Composable extensions that inherit guarantees** – plugins and Python bindings share the same compressed evaluator and workspace pool, preserving memory bounds and determinism.
-
-### Clinical Relevance
-- Keeps PHI on-site—runs comfortably on 8–16 GB hospital desktops and field laptops without cloud transfer.
-- Bit-for-bit reproducibility simplifies CAP/CLIA audits, SOP lock-down, and incident review.
-- Predictable <100 MB working set avoids OOMs and keeps shared schedulers/workstations stable.
-- Streaming-friendly operation tolerates intermittent connectivity and minimizes temp-file churn in the field.
-
----
-
-## How It Compares
-| Capability | Rosalind | Typical Stack |
-| --- | --- | --- |
-| Peak RAM (WGS) | `<100 MB` working set; no multi-GB temp files | `1–16+ GB` RAM plus large intermediates |
-| Determinism | Bit-for-bit identical outputs; partition invariant | Often varies with thread ordering or sharding |
-| Partition invariance | Validated in CI across block sizes | Repartitioning can alter outputs |
-| Streaming outputs | Reads → SAM/BAM → VCF without materializing huge files | Batch stages typically require full intermediates |
-| Standards | SAM/BAM/VCF with streaming-friendly pipeline | Standards supported, but streaming often limited |
-| On-prem edge viability | Runs on 8–16 GB laptops; PHI stays on-site | Assumes high-RAM servers or cloud resources |
-| Guardrails/tests | CI enforces O(√t), determinism, property tests | Unit tests common; resource/determinism guards rare |
-
----
-
-## Core Capabilities
-- **FM-index Alignment** – Blocked Burrows–Wheeler/FM-index search with per-block rank/select checkpoints uses only O(√t) working state, making it practical to align entire reference genomes on a mid-spec laptop.
-- **Streaming Variant Calling** – On-the-fly pileups with Bayesian scoring keep memory bounded while emitting variants live; ideal for remote surveillance, bedside genomics, or interactive notebooks.
-- **Standards-compliant outputs** – Interoperable SAM/BAM/VCF with streaming-friendly IO, minimizing large intermediate files and sort/index overhead.
-- **Plugin & Python Ecosystem** – Implement the `GenomicPlugin` trait or call into the PyO3 bindings to add custom analyses without duplicating memory—e.g., RNA expression summaries or coverage drop-out checks for diagnostics.
-- **Rolling Boundary** – During DFS evaluation only the latest block summary is retained; older summaries are discarded, guaranteeing `O(b + T + log T) = O(√t)`.
-
----
-
-## How Rosalind Achieves O(√t) Space
-1. **Block decomposition** – Workloads are partitioned into √t blocks with deterministic summaries; only one block’s buffer is in memory at a time, avoiding whole-read caches.
-2. **Height-compressed trees** – Child summaries merge in an implicit tree of height O(log√t); pointerless DFS stores just 2 bits per level and recomputes endpoints on the fly.
-3. **Streaming ledger** – Two bits per block track completion, preventing duplicate merges or stored intermediate trees.
-4. **Workspace pooling** – A single reusable allocation is shared across components (alignment, pileups, plugins), avoiding allocator churn and preserving the bound.
-5. **Execution flow** – *(reads)* → block alignment → rolling boundary update → tree merge → streaming outputs (variants, metrics, analytics). This pipeline mirrors typical aligner + variant-caller workflows, but with drastically lower memory.
-
----
-
-## Repository Layout
-- `src/framework/` – Generic compressed evaluator and configuration helpers.
-- `src/genomics/` – FM-index, alignment summaries, pileups, variant calling, and shared types.
-- `src/plugin/` – Plugin trait, executor, registry, and example RNA-seq quantification plugin.
-- `src/python_bindings/` – PyO3 bridge exposing Rosalind to Python.
-- `src/main.rs` – Command-line interface (align/variants subcommands).
-- `examples/` – CLI examples (including `verify_installation.rs`) and the scale performance benchmark; includes small synthetic datasets for experimentation.
-- `scripts/` – Utility scripts (toy dataset generation, SAM vs BAM benchmarking).
-- `tests/` – Unit, property, and integration tests (alignment, variant calling, space bounds).
-- `tests/common/`, `tests/snapshots/` – Snapshot harness and golden fixtures used by CLI/VCF tests.
-
----
-
-## Install & Build
 ### Prerequisites
 - Rust 1.72+ (`rustup` recommended)
-- Python 3.9+ (for PyO3 bindings; set `PYO3_PYTHON=/path/to/python` if the default interpreter is unsuitable)
-- Native compression headers for BAM output (`libbz2-dev` & `liblzma-dev` on Debian/Ubuntu, `brew install bzip2 xz` on macOS)
+- Native compression headers for BAM output: `libbz2-dev` & `liblzma-dev` on Debian/Ubuntu, `brew install bzip2 xz` on macOS
+- Python 3.9+ (only for the PyO3 bindings; set `PYO3_PYTHON=/path/to/python` if the default interpreter is unsuitable)
 
 ### Build
 ```bash
 git clone https://github.com/logannye/rosalind.git
 cd rosalind
-cargo test           # run the full suite
 cargo build --release
-```
-
-Verify the CLI is available:
-
-```bash
+cargo test            # run the full suite
 cargo run --release -- --help
 ```
 
-Optional: run the smoke test example to confirm the full pipeline:
-
-```bash
-cargo run --example verify_installation
-```
-
-To use Rosalind in another crate:
-
+Use Rosalind as a library in another crate:
 ```toml
 [dependencies]
 rosalind = { path = "./rosalind" }
 ```
 
-Sample data: `examples/data/` contains small FASTA/FASTQ snippets and alignment inputs mirroring the “Quick Start” commands, so you can reproduce the workflows without hunting for external datasets.
-
-Need something bigger? Generate a deterministic ~10× toy genome with:
-
+Bundled sample data lives in `examples/data/` (small FASTA/FASTQ + alignments) so the commands below run without external downloads. For a larger, deterministic toy dataset:
 ```bash
 python scripts/generate_toy_data.py examples/data/illumina_toy
-cat examples/data/illumina_toy/SHA256SUMS
 ```
-
-The script emits `reference.fa`, paired `reads_R1.fastq`/`reads_R2.fastq`, and reproducible SHA256 checksums so larger demos can be cached or shared safely.
 
 ---
 
-## Quick Start
-### 1. Align reads (Rust API)
-Ideal for embedding Rosalind in your own pipeline or unit tests.
+## Use it
+
+### Command line
+
+```bash
+# 1. Align FASTQ reads to a reference contig → SAM (stdout) or BAM (to disk)
+cargo run --release -- align \
+  --reference examples/data/ref.fa \
+  --reads examples/data/reads.fastq \
+  --format sam \
+  --max-mismatches 2 > examples/data/alignments.sam
+
+cargo run --release -- align \
+  --reference examples/data/ref.fa \
+  --reads examples/data/reads.fastq \
+  --format bam \
+  --output examples/data/alignments.bam
+
+# 2. Call germline SNVs from the alignments → VCF (stdout, or --output FILE)
+cargo run --release -- variants \
+  --reference examples/data/ref.fa \
+  --alignments examples/data/alignments.sam \
+  --mapq-threshold 10
+```
+
+Other subcommands (run `rosalind <subcommand> --help` for exact flags):
+- `rosalind sort` — deterministic coordinate sort of a BAM within a memory budget.
+- `rosalind somatic` — tumor/normal somatic SNV + simple-indel calling from a paired BAM set over a region.
+- `rosalind eval-somatic` — compare a call set to a truth VCF over confident regions.
+
+`align` indexes the first FASTA record; additional records are ignored with a warning (single-contig scope). `variants` reads coordinate-sorted SAM/BAM alignments.
+
+### Rust API
+
 ```rust
 use rosalind::genomics::{BWTAligner, AlignmentResult};
 
@@ -164,9 +101,7 @@ fn align_reads(reads: &[Vec<u8>], reference: &[u8]) -> anyhow::Result<Vec<Alignm
     aligner.align_batch(reads.iter().map(|r| r.as_slice()))
 }
 ```
-Each `AlignmentResult` includes FM intervals (candidate positions), mismatch counts, and heuristic scores—sufficient to drive downstream filtering or assembly logic.
 
-### 2. Call variants (Rust API)
 ```rust
 use rosalind::genomics::{AlignedRead, StreamingVariantCaller};
 
@@ -177,65 +112,20 @@ fn call_variants(reads: Vec<AlignedRead>, reference: &[u8]) -> anyhow::Result<Ve
     caller.call_variants(reads)
 }
 ```
-Each `Variant` reports position, reference/alternate alleles, allele fraction, and quality—enough to feed clinical reporting, surveillance dashboards, or QC scripts.
 
-### 3. Command line
-Perfect for pilots, demos, or quick analyses with sample data.
-```bash
-# Align FASTQ reads against the bundled reference and capture SAM output
-cargo run --release -- align \
-  --reference examples/data/ref.fa \
-  --reads examples/data/reads.fastq \
-  --format sam \
-  --max-mismatches 2 \
-  --reference-offset 0 > examples/data/alignments.sam
-
-# Emit coordinate-sorted BAM directly to disk (recommended for downstream tooling)
-cargo run --release -- align \
-  --reference examples/data/ref.fa \
-  --reads examples/data/reads.fastq \
-  --format bam \
-  --output examples/data/alignments.bam
-
-# Call variants from the SAM/BAM alignments (VCF to stdout by default)
-cargo run --release -- variants \
-  --reference examples/data/ref.fa \
-  --alignments examples/data/alignments.sam \
-  --mapq-threshold 10 \
-  --region-start 0
-
-# Or write the VCF to disk
-cargo run --release -- variants \
-  --reference examples/data/ref.fa \
-  --alignments examples/data/alignments.sam \
-  --output examples/data/variants.vcf
-```
-
-> **Note:** `rosalind align` indexes the first FASTA record via the O(√t) FM-index before emitting SAM/BAM output. Additional records are ignored (a warning is printed) until multi-contig sequencing is supported.
-
-Key knobs:
-- `--max-mismatches` bounds per-read Hamming distance during seeding.
-- `--format {sam|bam}` toggles between plain-text SAM and BGZF-compressed BAM (requires `--output` for BAM).
-- `--mapq-threshold` filters low-confidence alignments before variant calling.
-- `--region-start` allows offsetting reported genomic coordinates for tiled analyses.
-- `--output/-o` writes results to disk instead of stdout for both subcommands.
-
-### 4. Python bindings
-Great for exploratory analysis, rapid prototyping, or teaching.
-
-Install the bindings with [maturin](python/README.md):
+### Python
 
 ```bash
 pip install maturin
 maturin develop --release
 ```
-
 ```python
 from rosalind_py import PyGenomicEngine
+
 engine = PyGenomicEngine()
 print(engine.list_plugins())
 
-# region_start, region_end, reads[(pos, seq)], block_size
+# Per-base coverage over a region via the example plugin.
 depth = engine.run_rna_seq_plugin(
     region_start=100_000,
     region_end=101_000,
@@ -243,72 +133,30 @@ depth = engine.run_rna_seq_plugin(
     block_size=512,
 )
 ```
-The example plugin emits per-base coverage suitable for expression quantification or QC charts.
 
 ---
 
-## Verify the Guarantees
-| Command | Purpose |
-| --- | --- |
-| `cargo test --test space_bounds` | Verifies O(√t) bound, component limits, and √t scaling ratios; includes assert-based checks. |
-| `./scripts/run_scale_test.sh` | Runs the long-form benchmark; exits non-zero if the bound or sublinear scaling checks are violated (use `--csv` to capture output). |
-| `cargo run --example scale_performance_test` | Prints per-scale metrics and component breakdowns for manual inspection (leaf buffer, stack depth, ledger). |
-| `cargo test` | Runs all unit/integration tests covering alignment, variant calling, plugins, and supporting modules. |
-| `cargo test --test determinism` | Confirms bit-for-bit identical outputs across repeated runs given the same inputs/params. |
-| `cargo test --test fm_index_props` | Property tests that validate FM-index rank/total invariants against naive counting. |
-| `cargo test --test golden_vcf` | Snapshot test for stable VCF rendering; refresh with `ROSALIND_UPDATE_SNAPSHOTS=1`. |
+## Extend
 
-### Reproducibility & Validation
-- `cargo test --test determinism` — locks down partition-invariant, bit-for-bit outputs for auditability and SOPs.
-- `cargo test --test fm_index_props` — property-based checks for FM-index rank/total invariants.
-- `ROSALIND_UPDATE_SNAPSHOTS=1 cargo test` — refreshes golden VCF/SAM outputs when expected results change; the default run verifies no drift.
-- Together with CI enforcement of the O(√t) bound, these tests provide a defensible validation story for regulated or clinical environments.
-
-See `docs/determinism.md` for determinism testing and canonicalization rules.
-
-### Benchmarks & Snapshots
-- `python scripts/benchmark_formats.py --release` – compare SAM vs BAM throughput using the bundled toy dataset (it will be generated on first run).
-- Refresh golden outputs with `ROSALIND_UPDATE_SNAPSHOTS=1 cargo test`.
-
-### Notes on Guarantees and Trade-offs
-- Variant scoring remains statistical (Bayesian), but execution is deterministic—no sampling or thread-order nondeterminism—simplifying validation.
-- FM-index seeding is exact over the indexed sequence; MAPQ/filters are explicit and covered by tests.
-- Recomputing block boundaries to preserve the space bound can add CPU vs server-optimized pipelines; in exchange, you get predictable, cache-friendly performance on commodity hardware.
+- **Rust plugins** — implement `GenomicPlugin` (see `src/plugin/examples.rs`) to run custom per-block analyses (coverage, QC counts, domain-specific summaries) on the same bounded-memory evaluator.
+- **CLI subcommands** — add workflows in `src/main.rs`.
+- **Python** — drive the engine from `rosalind_py.PyGenomicEngine` alongside pandas / NumPy / scikit-learn.
 
 ---
 
-## Extend Rosalind
-- **Rust plugins**: implement `GenomicPlugin` to process blocks with custom summaries and merges (see `src/plugin/examples.rs`). Handy for adding expression metrics, QC counts, or domain-specific analytics.
-- **CLI extensions**: add subcommands in `src/main.rs` to orchestrate new workflows, such as `rosalind coverage` or `rosalind qc`.
-- **Python orchestration**: use `rosalind_py.PyGenomicEngine` to blend Rosalind with pandas, scikit-learn, or visualization libraries.
-- **Sample datasets**: the `examples/data/` directory shows how to package synthetic or anonymized data for reproducible demos.
+## Tests
+
+```bash
+cargo test                          # full unit + integration suite
+cargo test --test determinism       # byte-identical outputs across repeated runs
+cargo test --test space_bounds      # working-set scaling checks for the streaming evaluator
+cargo test --test fm_index_props    # property tests: FM-index rank/total invariants vs. naive counts
+cargo test --test golden_vcf        # snapshot test for stable VCF rendering
+```
+Refresh golden snapshots with `ROSALIND_UPDATE_SNAPSHOTS=1 cargo test`. See [`docs/determinism.md`](docs/determinism.md) for the determinism contract and canonicalization rules.
 
 ---
 
-## Troubleshooting
-- `cargo run` fails with “bin not found” → rerun `cargo build --release` and ensure you invoke `cargo run --release -- …`.
-- CLI complains about missing files → verify the sample data exists in `examples/data/` or provide your own reference/reads.
-- `ImportError: rosalind_py` → run `maturin develop --release` (see [python/README.md](python/README.md)) or export `PYO3_PYTHON=/path/to/python3.9+`.
-- Build errors on install → confirm `rustc --version` ≥ 1.72 and `cargo clean` before rebuilding.
-- Writing BAM without `--output` → specify a filename via `-o`/`--output`; BAM is binary and cannot be streamed to stdout.
+## License
 
----
-
-## Contributing
-Rosalind welcomes pull requests that:
-- Add domain pipelines (RNA-seq, metagenomics, QC dashboards).
-- Improve FM-index performance (SIMD rank/select, multi-threaded DFS paths).
-- Expand Python bindings or add CLI subcommands for new workflows.
-
-Before submitting, ensure `cargo fmt`, `cargo clippy`, and `cargo test` pass.
-
----
-
-## License & Support
-- Licensed under Apache-2.0 + MIT dual license.
-- Use GitHub Issues for bugs and feature requests.
-- Community Discord coming soon (ideal for sharing plugins, datasets, or course material).
-
----
-
-**Built for researchers, clinicians, educators, and developers who need genome-scale analysis without genome-scale infrastructure.**
+Dual-licensed under Apache-2.0 and MIT. Use GitHub Issues for bugs and feature requests.

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,0 +1,65 @@
+## Determinism Contract
+
+Rosalind’s primary product guarantee is **bit-for-bit reproducibility**: given identical inputs and configuration, Rosalind produces identical outputs across runs.
+
+This document defines what is (and is not) covered by that guarantee, and the engineering constraints required to preserve it.
+
+### Definitions
+
+- **Deterministic output**: the emitted bytes of primary artifacts (BAM/VCF/JSON manifests) are identical across repeated runs with the same inputs and configuration, on the same Rosalind version and target platform.
+- **Canonicalization**: where file formats permit multiple equivalent encodings (e.g., header ordering), Rosalind defines and emits a canonical form.
+- **Stable ordering**: when results are produced from unordered collections or parallel execution, Rosalind explicitly defines a stable sort order and uses it everywhere.
+
+### Covered inputs
+
+Determinism is guaranteed with respect to:
+
+- **Reference**: the exact FASTA bytes (including contig names and sequences) used for indexing and calling.
+- **Reads**: the exact FASTQ bytes (including read names and base qualities).
+- **Configuration**: all CLI flags / config file values, including thread count and memory limits.
+- **Rosalind version**: the exact crate version and build profile.
+
+### Covered outputs (v1 target)
+
+Rosalind aims to guarantee deterministic bytes for:
+
+- **BAM/CRAM**: alignment records and headers emitted by Rosalind.
+- **VCF**: variant records and headers emitted by Rosalind.
+- **Run manifest**: a machine-readable file recording inputs, parameters, and versions.
+
+### Not covered (unless explicitly stated)
+
+- **Wall-clock timestamps** in logs or headers (Rosalind should avoid emitting them into primary artifacts).
+- **OS-dependent path prefixes** in provenance unless normalized.
+- **Nondeterministic hardware behavior** outside our control (e.g., bit flips, kernel bugs).
+
+### Engineering rules (hard requirements)
+
+To preserve determinism, core pipeline code must follow these rules:
+
+1. **No unordered iteration in output-critical paths**:
+   - Do not rely on iteration order of `HashMap`/`HashSet`.
+   - Prefer `BTreeMap`/`BTreeSet` or sort keys before emitting results.
+2. **Explicit tie-breakers**:
+   - Whenever two candidates have the same primary score, define secondary keys (position, strand, read name, etc.).
+3. **Deterministic sorting**:
+   - Use stable sorts where key collisions are possible.
+   - Define a single canonical ordering for records (e.g., coordinate sort with full tie-break key).
+4. **Deterministic parallelism**:
+   - Parallel execution is allowed only when results are combined via an explicitly ordered reduction.
+   - Otherwise, default to single-threaded execution for output-critical stages.
+5. **Numerics**:
+   - Avoid `f32` for ranking/tie-breaks in persisted outputs.
+   - When floating point is necessary, use `f64` and ensure reductions are performed in a stable order.
+6. **Canonical output emission**:
+   - Canonicalize headers and record ordering.
+   - Do not emit run-dependent data (timestamps, randomized IDs) into primary artifacts.
+
+### Determinism testing
+
+Rosalind should maintain:
+
+- **Repeat-run tests**: run the same pipeline twice and compare output bytes.
+- **Thread-count invariance tests** (when multithreading is added): `--threads 1` vs `--threads N` must match.
+
+

--- a/docs/superpowers/plans/2026-05-26-phase-a1-core-foundation.md
+++ b/docs/superpowers/plans/2026-05-26-phase-a1-core-foundation.md
@@ -57,13 +57,11 @@ Create `src/core/mod.rs`:
 //! Note: this module is named `core`; inside the crate always reference it as
 //! `crate::core::…`. Reach the std `core` crate (rarely needed) as `::core::…`.
 
-pub mod budget;
 pub mod error;
-pub mod locus;
-pub mod record;
-pub mod sequence;
 
 pub use error::CoreError;
+// Later tasks add `pub mod locus/budget/sequence/record;` + their re-exports as
+// each file is created; declaring them before the files exist would not compile.
 ```
 
 - [ ] **Step 2: Write the failing test**
@@ -280,9 +278,10 @@ impl ContigSet {
 }
 ```
 
-In `src/core/mod.rs`, add under the existing re-export:
+In `src/core/mod.rs`, add the module declaration and its re-exports:
 
 ```rust
+pub mod locus;
 pub use locus::{Contig, ContigSet, Locus, Position};
 ```
 
@@ -390,6 +389,7 @@ impl WorkingSet {
 In `src/core/mod.rs`, add:
 
 ```rust
+pub mod budget;
 pub use budget::{MemoryBudget, WorkingSet};
 ```
 
@@ -530,6 +530,7 @@ pub fn allele_index(base: u8) -> Option<usize> {
 In `src/core/mod.rs`, add:
 
 ```rust
+pub mod sequence;
 pub use sequence::{allele_index, BaseCode};
 ```
 
@@ -848,6 +849,7 @@ impl AlignedRead {
 In `src/core/mod.rs`, add:
 
 ```rust
+pub mod record;
 pub use record::{AlignedRead, CigarOp, CigarOpKind, RefBase, SamFlags};
 ```
 

--- a/docs/superpowers/plans/2026-05-26-phase-a1-core-foundation.md
+++ b/docs/superpowers/plans/2026-05-26-phase-a1-core-foundation.md
@@ -1,0 +1,882 @@
+# Phase A1 — `core` Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create Rosalind's shared core type layer — the contig-aware, 64-bit-safe coordinate model, the canonical CIGAR-aware aligned-read record, the base/allele model, the memory-budget model, and the typed error taxonomy — that every later layer (pileup, call, io, index, align) builds on.
+
+**Architecture:** A new crate-root module `core` with five focused submodules (`error`, `locus`, `sequence`, `record`, `budget`). Self-contained and fully unit-tested; **no existing consumers are migrated in A1** (the legacy `genomics::types` continues to compile unchanged). Later plans (A2, A5) migrate consumers onto these types and delete the legacy ones.
+
+**Tech Stack:** Rust 2021, `thiserror` (already a dependency), `std`. No new dependencies.
+
+---
+
+## Conventions for this plan
+
+- **Branch, never main.** Before Task 1, create a feature branch or worktree (repo policy: branch + PR, never commit to `main`). Example: `git switch -c rosalind/phase-a1-core`.
+- **Commit trailer.** Every commit ends with the co-author trailer, shown in each commit step.
+- **Module name note (`core`).** This module is named `core` to match the architecture doc. A crate-root `mod core` shadows the std `core` crate for *bare* `core::…` paths within this crate. Rule for contributors: inside the crate, reference these types as `crate::core::…`, and reach the std core crate (rarely needed) as `::core::…`. The codebase uses `std::…`, so this is a non-issue in practice.
+- **Lint posture.** `lib.rs` sets `#![warn(missing_docs, missing_debug_implementations)]`. Every public item below has a doc comment and derives `Debug`.
+- **Test filtering.** Unit tests live in each module's `#[cfg(test)] mod tests`. Run a module's tests with `cargo test core::<module>`. Before an implementation exists, the test will fail to **compile** (type not yet defined) — that is the expected "red" state for Rust TDD.
+
+---
+
+## File Structure
+
+- Create `src/core/mod.rs` — module root + re-exports (`pub use …`). One responsibility: assemble the core layer's public surface.
+- Create `src/core/error.rs` — `CoreError` typed taxonomy.
+- Create `src/core/locus.rs` — `Contig`, `Position`, `Locus`, `ContigSet` (per-contig `u32`, 64-bit-safe global offsets).
+- Create `src/core/sequence.rs` — `BaseCode`, `allele_index`, IUPAC→N folding.
+- Create `src/core/record.rs` — `CigarOpKind` (incl. `RefSkip`), `CigarOp`, `SamFlags`, `AlignedRead`, `RefBase`, CIGAR projection.
+- Create `src/core/budget.rs` — `MemoryBudget`, `WorkingSet`.
+- Modify `src/lib.rs` — add `pub mod core;` and a doc line.
+
+---
+
+## Task 1: Module skeleton + typed errors (`core::error`)
+
+**Files:**
+- Modify: `src/lib.rs` (add `pub mod core;`)
+- Create: `src/core/mod.rs`
+- Create: `src/core/error.rs`
+- Test: `src/core/error.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Wire the module into the crate**
+
+In `src/lib.rs`, add to the module list (next to the other `pub mod` lines):
+
+```rust
+/// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
+pub mod core;
+```
+
+Create `src/core/mod.rs`:
+
+```rust
+//! Core types — the lingua franca shared by every Rosalind layer.
+//!
+//! Note: this module is named `core`; inside the crate always reference it as
+//! `crate::core::…`. Reach the std `core` crate (rarely needed) as `::core::…`.
+
+pub mod budget;
+pub mod error;
+pub mod locus;
+pub mod record;
+pub mod sequence;
+
+pub use error::CoreError;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/core/error.rs`:
+
+```rust
+//! Typed error taxonomy for the Rosalind core/library layer.
+//!
+//! The CLI boundary maps these into `anyhow`; library code returns `CoreError`.
+
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_exceeded_displays_both_numbers() {
+        let e = CoreError::BudgetExceeded { needed: 4096, budget: 1024 };
+        let msg = e.to_string();
+        assert!(msg.contains("4096"), "message should report needed bytes: {msg}");
+        assert!(msg.contains("1024"), "message should report budget bytes: {msg}");
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test core::error`
+Expected: FAIL — does not compile (`cannot find type CoreError in this scope`).
+
+- [ ] **Step 4: Implement `CoreError`**
+
+Insert above the `#[cfg(test)]` block in `src/core/error.rs`:
+
+```rust
+/// Errors produced by the Rosalind core/library layer.
+#[derive(Debug, Error)]
+pub enum CoreError {
+    /// A streaming stage's working set would exceed the declared budget.
+    #[error("memory budget exceeded: working set {needed} bytes > budget {budget} bytes")]
+    BudgetExceeded {
+        /// Bytes the stage would require.
+        needed: u64,
+        /// Bytes the caller permitted.
+        budget: u64,
+    },
+    /// An input record could not be interpreted.
+    #[error("malformed record: {0}")]
+    MalformedRecord(String),
+    /// A contig id was not present in the active `ContigSet`.
+    #[error("invalid contig id {0}")]
+    InvalidContig(u32),
+    /// An underlying I/O failure.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test core::error`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib.rs src/core/mod.rs src/core/error.rs
+git commit -m "feat(core): scaffold core module + CoreError taxonomy" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Coordinate model (`core::locus`)
+
+**Files:**
+- Create: `src/core/locus.rs`
+- Modify: `src/core/mod.rs` (re-exports)
+- Test: `src/core/locus.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/locus.rs`:
+
+```rust
+//! Contig-aware genomic coordinates. Per-contig positions are `u32`; the
+//! concatenated-genome offset used by the multi-contig FM-index (Phase B) is
+//! 64-bit-safe, so no single coordinate space is capped at 4.29 Gbp.
+
+use std::sync::Arc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contig_set_assigns_ids_and_global_offsets() {
+        let mut set = ContigSet::new();
+        let chr1 = set.push("chr1", 1_000);
+        let chr2 = set.push("chr2", 500);
+
+        assert_eq!(chr1, 0);
+        assert_eq!(chr2, 1);
+        assert_eq!(set.by_id(chr1).unwrap().global_offset, 0);
+        assert_eq!(set.by_id(chr2).unwrap().global_offset, 1_000);
+        assert_eq!(set.by_name("chr2").unwrap().id, 1);
+        assert_eq!(set.total_length(), 1_500);
+    }
+
+    #[test]
+    fn loci_order_by_contig_then_position() {
+        let a = Locus { contig: 0, pos: Position(100) };
+        let b = Locus { contig: 0, pos: Position(200) };
+        let c = Locus { contig: 1, pos: Position(0) };
+        assert!(a < b && b < c);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test core::locus`
+Expected: FAIL — does not compile (`ContigSet`, `Locus`, `Position` undefined).
+
+- [ ] **Step 3: Implement the coordinate types**
+
+Insert above the `#[cfg(test)]` block in `src/core/locus.rs`:
+
+```rust
+/// A reference contig (chromosome / sequence) with a stable id.
+#[derive(Debug, Clone)]
+pub struct Contig {
+    /// Dense 0-based id (index into the `ContigSet`).
+    pub id: u32,
+    /// Contig name as it appears in the reference / SAM `@SQ`.
+    pub name: Arc<str>,
+    /// Length in bases.
+    pub length: u32,
+    /// 0-based offset of this contig within the concatenated genome
+    /// (64-bit-safe; used by the multi-contig index in Phase B).
+    pub global_offset: u64,
+}
+
+/// A 0-based position within a single contig.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Position(pub u32);
+
+/// A canonical genomic coordinate: a contig id plus a position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Locus {
+    /// Contig id (index into the originating `ContigSet`).
+    pub contig: u32,
+    /// 0-based position within the contig.
+    pub pos: Position,
+}
+
+/// The ordered set of reference contigs: name<->id lookup and global offsets.
+#[derive(Debug, Clone, Default)]
+pub struct ContigSet {
+    contigs: Vec<Contig>,
+}
+
+impl ContigSet {
+    /// Create an empty contig set.
+    pub fn new() -> Self {
+        Self { contigs: Vec::new() }
+    }
+
+    /// Append a contig, assigning the next id and the running global offset.
+    /// Returns the new contig's id.
+    pub fn push(&mut self, name: impl Into<Arc<str>>, length: u32) -> u32 {
+        let id = self.contigs.len() as u32;
+        let global_offset = self
+            .contigs
+            .last()
+            .map_or(0, |c| c.global_offset + c.length as u64);
+        self.contigs.push(Contig { id, name: name.into(), length, global_offset });
+        id
+    }
+
+    /// Look up a contig by id.
+    pub fn by_id(&self, id: u32) -> Option<&Contig> {
+        self.contigs.get(id as usize)
+    }
+
+    /// Look up a contig by name.
+    pub fn by_name(&self, name: &str) -> Option<&Contig> {
+        self.contigs.iter().find(|c| c.name.as_ref() == name)
+    }
+
+    /// Number of contigs.
+    pub fn len(&self) -> usize {
+        self.contigs.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.contigs.is_empty()
+    }
+
+    /// Iterate contigs in id order.
+    pub fn iter(&self) -> impl Iterator<Item = &Contig> {
+        self.contigs.iter()
+    }
+
+    /// Total length of the concatenated genome (64-bit-safe).
+    pub fn total_length(&self) -> u64 {
+        self.contigs
+            .last()
+            .map_or(0, |c| c.global_offset + c.length as u64)
+    }
+}
+```
+
+In `src/core/mod.rs`, add under the existing re-export:
+
+```rust
+pub use locus::{Contig, ContigSet, Locus, Position};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test core::locus`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/locus.rs src/core/mod.rs
+git commit -m "feat(core): contig-aware, 64-bit-safe coordinate model" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Memory budget model (`core::budget`)
+
+**Files:**
+- Create: `src/core/budget.rs`
+- Modify: `src/core/mod.rs`
+- Test: `src/core/budget.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/budget.rs`:
+
+```rust
+//! Memory-as-a-contract primitives. Streaming stages report a `WorkingSet`
+//! bound so a run can be checked against a `MemoryBudget` *before* it starts
+//! (the foundation for `rosalind plan`).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_admits_within_and_rejects_beyond() {
+        let budget = MemoryBudget::from_mb(2);
+        assert!(budget.admits(1_000_000));
+        assert!(!budget.admits(3 * 1024 * 1024));
+    }
+
+    #[test]
+    fn unlimited_admits_everything_and_working_set_checks_fit() {
+        assert!(MemoryBudget::unlimited().admits(u64::MAX));
+        let ws = WorkingSet { bytes: 512 };
+        assert!(ws.fits(MemoryBudget::from_mb(1)));
+        assert!(!WorkingSet { bytes: 5 * 1024 * 1024 }.fits(MemoryBudget::from_mb(1)));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test core::budget`
+Expected: FAIL — does not compile (`MemoryBudget`, `WorkingSet` undefined).
+
+- [ ] **Step 3: Implement the budget types**
+
+Insert above the `#[cfg(test)]` block:
+
+```rust
+/// A declared cap on a streaming stage's working set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryBudget {
+    /// Maximum permitted working-set size, in bytes.
+    pub bytes: u64,
+}
+
+impl MemoryBudget {
+    /// A budget expressed in mebibytes.
+    pub fn from_mb(mb: u64) -> Self {
+        Self { bytes: mb.saturating_mul(1024 * 1024) }
+    }
+
+    /// An effectively unbounded budget.
+    pub fn unlimited() -> Self {
+        Self { bytes: u64::MAX }
+    }
+
+    /// Whether a working set of `working_set_bytes` is permitted.
+    pub fn admits(self, working_set_bytes: u64) -> bool {
+        working_set_bytes <= self.bytes
+    }
+}
+
+/// A reported working-set bound for a streaming stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkingSet {
+    /// Estimated peak working-set size, in bytes.
+    pub bytes: u64,
+}
+
+impl WorkingSet {
+    /// Whether this working set fits within `budget`.
+    pub fn fits(self, budget: MemoryBudget) -> bool {
+        budget.admits(self.bytes)
+    }
+}
+```
+
+In `src/core/mod.rs`, add:
+
+```rust
+pub use budget::{MemoryBudget, WorkingSet};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test core::budget`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/budget.rs src/core/mod.rs
+git commit -m "feat(core): MemoryBudget/WorkingSet (memory-as-a-contract)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Base / allele model (`core::sequence`)
+
+**Files:**
+- Create: `src/core/sequence.rs`
+- Modify: `src/core/mod.rs`
+- Test: `src/core/sequence.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/sequence.rs`:
+
+```rust
+//! Canonical DNA base model. Exact bases are A/C/G/T (U folds to T); every
+//! other byte — including IUPAC ambiguity codes — folds to `N` (lossy but
+//! explicit). `N` is not a callable allele.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_bases_map_directly_and_u_folds_to_t() {
+        assert_eq!(BaseCode::from_ascii_lossy(b'a'), BaseCode::A);
+        assert_eq!(BaseCode::from_ascii_lossy(b'C'), BaseCode::C);
+        assert_eq!(BaseCode::from_ascii_lossy(b'u'), BaseCode::T);
+        assert_eq!(BaseCode::from_ascii_lossy(b'T'), BaseCode::T);
+    }
+
+    #[test]
+    fn ambiguous_and_unknown_fold_to_n_and_are_not_exact() {
+        assert_eq!(BaseCode::from_ascii_lossy(b'R'), BaseCode::N); // IUPAC purine
+        assert_eq!(BaseCode::from_ascii_lossy(b'.'), BaseCode::N);
+        assert!(!BaseCode::is_exact(b'R'));
+        assert!(BaseCode::is_exact(b'g'));
+    }
+
+    #[test]
+    fn allele_index_is_some_for_acgt_and_none_for_n() {
+        assert_eq!(allele_index(b'A'), Some(0));
+        assert_eq!(allele_index(b'T'), Some(3));
+        assert_eq!(allele_index(b'N'), None);
+        assert_eq!(allele_index(b'R'), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test core::sequence`
+Expected: FAIL — does not compile (`BaseCode`, `allele_index` undefined).
+
+- [ ] **Step 3: Implement the base model**
+
+Insert above the `#[cfg(test)]` block:
+
+```rust
+/// A canonical DNA base. `N` represents any non-ACGT / ambiguous base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaseCode {
+    /// Adenine.
+    A,
+    /// Cytosine.
+    C,
+    /// Guanine.
+    G,
+    /// Thymine (also the fold target for uracil `U`).
+    T,
+    /// Any non-ACGT / ambiguous base.
+    N,
+}
+
+impl BaseCode {
+    /// Allele index 0..=3 for A/C/G/T; `None` for `N` (not a callable allele).
+    pub fn allele_index(self) -> Option<usize> {
+        match self {
+            BaseCode::A => Some(0),
+            BaseCode::C => Some(1),
+            BaseCode::G => Some(2),
+            BaseCode::T => Some(3),
+            BaseCode::N => None,
+        }
+    }
+
+    /// Canonical uppercase ASCII byte for this base.
+    pub fn to_ascii(self) -> u8 {
+        match self {
+            BaseCode::A => b'A',
+            BaseCode::C => b'C',
+            BaseCode::G => b'G',
+            BaseCode::T => b'T',
+            BaseCode::N => b'N',
+        }
+    }
+
+    /// Map an ASCII byte to a `BaseCode`. A/C/G/T (any case) map directly,
+    /// `U`/`u` fold to `T`, and every other byte folds to `N`.
+    pub fn from_ascii_lossy(b: u8) -> BaseCode {
+        match b.to_ascii_uppercase() {
+            b'A' => BaseCode::A,
+            b'C' => BaseCode::C,
+            b'G' => BaseCode::G,
+            b'T' | b'U' => BaseCode::T,
+            _ => BaseCode::N,
+        }
+    }
+
+    /// Whether `b` is a recognized exact base (A/C/G/T/U). Bytes that fold to
+    /// `N` return `false`; callers use this to count ambiguity warnings.
+    pub fn is_exact(b: u8) -> bool {
+        matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'U')
+    }
+}
+
+/// Convenience: allele index 0..=3 for an ASCII base, or `None` for N/other.
+pub fn allele_index(base: u8) -> Option<usize> {
+    BaseCode::from_ascii_lossy(base).allele_index()
+}
+```
+
+In `src/core/mod.rs`, add:
+
+```rust
+pub use sequence::{allele_index, BaseCode};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test core::sequence`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/sequence.rs src/core/mod.rs
+git commit -m "feat(core): BaseCode/allele model with explicit IUPAC->N folding" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Canonical record + CIGAR projection (`core::record`)
+
+This is the most important task in A1: the CIGAR-aware projection here is the
+single source of truth the pileup kernel (A2) uses, and it is what makes the
+engine correct on indels, soft-clips, ref-skips, and **long reads**.
+
+**Files:**
+- Create: `src/core/record.rs`
+- Modify: `src/core/mod.rs`
+- Test: `src/core/record.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/core/record.rs`:
+
+```rust
+//! The canonical aligned-read record and CIGAR projection.
+//!
+//! SEQ is stored forward-reference-oriented (as in SAM/BAM); strand is
+//! metadata and is never applied to the bytes. Records are read-length-
+//! agnostic — short Illumina reads and long Nanopore/PacBio reads are handled
+//! identically.
+
+use std::sync::Arc;
+
+use crate::core::locus::Position;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(kind: CigarOpKind, len: u32) -> CigarOp {
+        CigarOp::new(kind, len)
+    }
+
+    fn read(pos: u32, cigar: Vec<CigarOp>, seq: &[u8]) -> AlignedRead {
+        AlignedRead {
+            contig: 0,
+            pos: Position(pos),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar,
+            seq: Arc::from(seq.to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; seq.len()].into_boxed_slice()),
+        }
+    }
+
+    #[test]
+    fn ref_span_and_end_are_cigar_derived_not_seq_len() {
+        // 3M1D2M consumes 6 reference bases from 5 read bases.
+        let r = read(100, vec![op(CigarOpKind::Match, 3), op(CigarOpKind::Deletion, 1), op(CigarOpKind::Match, 2)], b"ACGTT");
+        assert_eq!(r.ref_span(), 6);
+        assert_eq!(r.end(), 106);
+    }
+
+    #[test]
+    fn projection_handles_softclip_insertion_deletion_refskip() {
+        // 2S 3M 1I 2M 1D 2M  over seq positions; ref starts at 50.
+        // read offsets: [0,1]=softclip, [2,3,4]=M, [5]=I, [6,7]=M, (1D no read), [8,9]=M
+        let r = read(
+            50,
+            vec![
+                op(CigarOpKind::SoftClip, 2),
+                op(CigarOpKind::Match, 3),
+                op(CigarOpKind::Insertion, 1),
+                op(CigarOpKind::Match, 2),
+                op(CigarOpKind::Deletion, 1),
+                op(CigarOpKind::Match, 2),
+            ],
+            b"NNACGTTGAA", // 10 bases: 2 clipped + 3 + 1 ins + 2 + 2
+        );
+        let proj = r.projected_bases();
+        let pairs: Vec<(u32, usize)> = proj.iter().map(|p| (p.ref_pos, p.read_offset)).collect();
+        assert_eq!(
+            pairs,
+            vec![
+                (50, 2), (51, 3), (52, 4), // first 3M
+                (53, 6), (54, 7),          // 2M after the 1I (read offset skips 5)
+                (56, 8), (57, 9),          // 2M after the 1D (ref skips 55)
+            ]
+        );
+        // Soft-clipped and inserted read bases never appear in the projection.
+        assert!(!pairs.iter().any(|(_, off)| *off == 0 || *off == 1 || *off == 5));
+    }
+
+    #[test]
+    fn refskip_consumes_reference_only_like_a_long_intron() {
+        // 2M 100N 2M (spliced long read): ref advances over the skip, no bases there.
+        let r = read(0, vec![op(CigarOpKind::Match, 2), op(CigarOpKind::RefSkip, 100), op(CigarOpKind::Match, 2)], b"ACGT");
+        let proj = r.projected_bases();
+        assert_eq!(proj.first().unwrap().ref_pos, 0);
+        assert_eq!(proj.last().unwrap().ref_pos, 103);
+        assert_eq!(proj.len(), 4);
+        assert_eq!(r.ref_span(), 104);
+    }
+
+    #[test]
+    fn long_read_projects_every_match_base() {
+        // Read-length-agnostic: a 5000-base full-match "long read".
+        let seq = vec![b'A'; 5000];
+        let r = read(1000, vec![op(CigarOpKind::Match, 5000)], &seq);
+        let proj = r.projected_bases();
+        assert_eq!(proj.len(), 5000);
+        assert_eq!(proj[0], RefBase { ref_pos: 1000, read_offset: 0 });
+        assert_eq!(proj[4999], RefBase { ref_pos: 5999, read_offset: 4999 });
+    }
+
+    #[test]
+    fn sam_flags_decode_common_bits() {
+        let f = SamFlags(SamFlags::REVERSE | SamFlags::DUPLICATE);
+        assert!(f.is_reverse());
+        assert!(f.is_duplicate());
+        assert!(!f.is_secondary());
+        assert!(!f.is_unmapped());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test core::record`
+Expected: FAIL — does not compile (`CigarOp`, `CigarOpKind`, `SamFlags`, `AlignedRead`, `RefBase` undefined).
+
+- [ ] **Step 3: Implement the record types and projection**
+
+Insert above the `#[cfg(test)]` block in `src/core/record.rs`:
+
+```rust
+/// CIGAR operation kind (SAM). Consuming semantics follow the SAM spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CigarOpKind {
+    /// Alignment match or mismatch (`M`/`=`/`X`): consumes ref and read.
+    Match,
+    /// Insertion to the reference (`I`): consumes read only.
+    Insertion,
+    /// Deletion from the reference (`D`): consumes ref only.
+    Deletion,
+    /// Skipped reference region (`N`, e.g. an intron): consumes ref only.
+    RefSkip,
+    /// Soft clip (`S`): read bases present but unaligned; consumes read only.
+    SoftClip,
+    /// Hard clip (`H`): trimmed bases absent from the read; consumes neither.
+    HardClip,
+}
+
+impl CigarOpKind {
+    /// Whether this op consumes reference bases.
+    pub fn consumes_ref(self) -> bool {
+        matches!(self, CigarOpKind::Match | CigarOpKind::Deletion | CigarOpKind::RefSkip)
+    }
+
+    /// Whether this op consumes read/query bases.
+    pub fn consumes_read(self) -> bool {
+        matches!(self, CigarOpKind::Match | CigarOpKind::Insertion | CigarOpKind::SoftClip)
+    }
+}
+
+/// A single CIGAR operation with its run length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CigarOp {
+    /// The operation kind.
+    pub kind: CigarOpKind,
+    /// Number of bases the operation spans.
+    pub len: u32,
+}
+
+impl CigarOp {
+    /// Construct a CIGAR operation.
+    pub fn new(kind: CigarOpKind, len: u32) -> Self {
+        Self { kind, len }
+    }
+}
+
+/// SAM flag bitset (the subset Rosalind uses).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SamFlags(pub u16);
+
+impl SamFlags {
+    /// Template has multiple segments (paired).
+    pub const PAIRED: u16 = 0x1;
+    /// Each segment properly aligned (proper pair).
+    pub const PROPER_PAIR: u16 = 0x2;
+    /// Segment unmapped.
+    pub const UNMAPPED: u16 = 0x4;
+    /// Segment reverse-strand.
+    pub const REVERSE: u16 = 0x10;
+    /// Secondary alignment.
+    pub const SECONDARY: u16 = 0x100;
+    /// PCR or optical duplicate.
+    pub const DUPLICATE: u16 = 0x400;
+    /// Supplementary alignment.
+    pub const SUPPLEMENTARY: u16 = 0x800;
+
+    /// Whether the given flag bit is set.
+    pub fn contains(self, bit: u16) -> bool {
+        self.0 & bit != 0
+    }
+
+    /// Segment is unmapped.
+    pub fn is_unmapped(self) -> bool {
+        self.contains(Self::UNMAPPED)
+    }
+
+    /// Segment maps to the reverse strand (metadata only — SEQ stays forward).
+    pub fn is_reverse(self) -> bool {
+        self.contains(Self::REVERSE)
+    }
+
+    /// Alignment is secondary.
+    pub fn is_secondary(self) -> bool {
+        self.contains(Self::SECONDARY)
+    }
+
+    /// Alignment is supplementary.
+    pub fn is_supplementary(self) -> bool {
+        self.contains(Self::SUPPLEMENTARY)
+    }
+
+    /// Read is a PCR/optical duplicate.
+    pub fn is_duplicate(self) -> bool {
+        self.contains(Self::DUPLICATE)
+    }
+}
+
+/// One projected base: a read base aligned to a specific reference position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefBase {
+    /// 0-based reference position.
+    pub ref_pos: u32,
+    /// Offset of the base within the read's `seq`/`qual`.
+    pub read_offset: usize,
+}
+
+/// A read aligned to a single contig.
+///
+/// `seq` is uppercase ASCII in forward-reference orientation; `pos` is the
+/// 0-based leftmost reference coordinate. Read-length-agnostic.
+#[derive(Debug, Clone)]
+pub struct AlignedRead {
+    /// Contig id (index into the originating `ContigSet`).
+    pub contig: u32,
+    /// 0-based leftmost reference coordinate.
+    pub pos: Position,
+    /// Mapping quality (Phred-scaled).
+    pub mapq: u8,
+    /// SAM flags.
+    pub flags: SamFlags,
+    /// CIGAR describing the alignment.
+    pub cigar: Vec<CigarOp>,
+    /// Read sequence, uppercase ASCII, forward orientation.
+    pub seq: Arc<[u8]>,
+    /// Per-base Phred qualities (parallel to `seq`).
+    pub qual: Arc<[u8]>,
+}
+
+impl AlignedRead {
+    /// Reference bases spanned by the alignment (sum of ref-consuming ops).
+    pub fn ref_span(&self) -> u32 {
+        self.cigar.iter().filter(|o| o.kind.consumes_ref()).map(|o| o.len).sum()
+    }
+
+    /// Half-open reference end coordinate. CIGAR-derived — never `pos + seq_len`.
+    pub fn end(&self) -> u32 {
+        self.pos.0 + self.ref_span()
+    }
+
+    /// Project each `Match` base to its reference position by walking the CIGAR.
+    /// Insertions/soft-clips consume read only; deletions/ref-skips consume ref
+    /// only; hard-clips consume neither. This is the single CIGAR projection the
+    /// pileup kernel consumes.
+    pub fn projected_bases(&self) -> Vec<RefBase> {
+        let mut out = Vec::new();
+        let mut ref_pos = self.pos.0;
+        let mut read_off: usize = 0;
+        for op in &self.cigar {
+            match op.kind {
+                CigarOpKind::Match => {
+                    for _ in 0..op.len {
+                        out.push(RefBase { ref_pos, read_offset: read_off });
+                        ref_pos += 1;
+                        read_off += 1;
+                    }
+                }
+                CigarOpKind::Insertion | CigarOpKind::SoftClip => {
+                    read_off += op.len as usize;
+                }
+                CigarOpKind::Deletion | CigarOpKind::RefSkip => {
+                    ref_pos += op.len;
+                }
+                CigarOpKind::HardClip => {}
+            }
+        }
+        out
+    }
+}
+```
+
+In `src/core/mod.rs`, add:
+
+```rust
+pub use record::{AlignedRead, CigarOp, CigarOpKind, RefBase, SamFlags};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test core::record`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the whole suite + lints**
+
+Run: `cargo test` — Expected: all existing tests still pass plus the new `core::*` tests.
+Run: `cargo build` — Expected: no `missing_docs`/`missing_debug_implementations` warnings from `src/core/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/record.rs src/core/mod.rs
+git commit -m "feat(core): canonical AlignedRead + CIGAR projection (indel/clip/refskip/long-read)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage** (Phase A spec §3.1 `core/`): `locus` ✔ (Task 2), `sequence` with IUPAC→N fold ✔ (Task 4), `record` with `RefSkip`, `SamFlags`, CIGAR-derived `end()`, projection, read-length-agnostic ✔ (Task 5), `budget` ✔ (Task 3), `error` ✔ (Task 1). The architecture doc's `core/sequence` 2-bit packing re-home is intentionally **deferred** — the calling vertical doesn't need 2-bit packing; the FM-index keeps using `compressed_dna` until Phase B re-homes it. Noted as out-of-scope for A1.
+- **Placeholder scan:** none — every step contains complete code and exact commands.
+- **Type consistency:** `Position`, `ContigSet`, `BaseCode`, `allele_index`, `CigarOpKind` (incl. `RefSkip`), `CigarOp::new`, `SamFlags`, `AlignedRead` fields (`contig`, `pos`, `mapq`, `flags`, `cigar`, `seq`, `qual`), `RefBase { ref_pos, read_offset }`, `MemoryBudget`/`WorkingSet`, `CoreError` — names used in tests match the implementations and the re-exports in `core/mod.rs`.
+
+## Definition of done (A1)
+
+`cargo test` green (new `core::*` tests + all pre-existing tests); `cargo build` warning-clean for `src/core/`; legacy `genomics::types` untouched and still compiling; all work on a feature branch, not `main`.

--- a/docs/superpowers/plans/2026-05-26-phase-a2-pileup-kernel.md
+++ b/docs/superpowers/plans/2026-05-26-phase-a2-pileup-kernel.md
@@ -1,0 +1,1068 @@
+# Phase A2 — Streaming Pileup Kernel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Rosalind's single streaming pileup engine — CIGAR-aware, read-filtered, strand-aware, bounded-memory — over the A1 `core` types, as a public substrate that callers (A3), plugins, and (later) Python all consume.
+
+**Architecture:** A new crate-root `pileup` module. A `PileupEngine<S: ReadSource>` consumes coordinate-sorted `core::AlignedRead`s from a `ReadSource` (an in-memory `SliceSource` here; a BAM source is deferred to A5) and yields one `PileupColumn` per covered reference position. It projects read bases onto reference coordinates with `core::AlignedRead::projected_bases` (so indels/soft-clips/ref-skips are handled correctly), uses the **forward-oriented** SEQ directly (fixing the legacy reverse-strand double-complement), maintains a bounded active-read set, and walks empty positions with a **loop** (fixing the legacy recursion). The legacy `genomics::pileup`/`pileup_stream` are left untouched; A5 migrates the calling path onto this engine.
+
+**Tech Stack:** Rust 2021, the A1 `core` module (`crate::core`), `std` only. No new dependencies, no `rust_htslib` coupling in this module.
+
+---
+
+## Conventions for this plan
+
+- **Branch:** execute on `rosalind/phase-a1-core` (the rebuild branch — A2 stacks on A1's `core`). Never `main`.
+- **Commit trailer:** every commit ends with the co-author trailer shown in each commit step.
+- **Module name (`pileup`):** lives at the crate root as `crate::pileup` (peer of `crate::core` and `crate::genomics`). It is distinct from the legacy `crate::genomics::pileup`; do not modify the legacy module.
+- **Lint posture:** `lib.rs` sets `#![warn(missing_docs, missing_debug_implementations)]`. Every public item needs a `///` doc comment and a `Debug` impl (derive). Private types used inside a public `#[derive(Debug)]` struct (e.g. `ActiveRead` inside `PileupEngine`) also derive `Debug`.
+- **Test filtering:** unit tests live in each module's `#[cfg(test)] mod tests`. Run a module's tests with `cargo test pileup::<module>`. A test that references an undefined item fails to **compile** — that is the expected "red" state.
+- **No `genomics` coupling:** this module imports only from `crate::core` and `std`.
+
+---
+
+## File Structure
+
+- Create `src/pileup/mod.rs` — module root + `pub use` surface.
+- Create `src/pileup/column.rs` — `Obs`, `PileupColumn` and its derived views.
+- Create `src/pileup/source.rs` — `ReadSource` trait + `SliceSource`.
+- Create `src/pileup/engine.rs` — `PileupParams`, `SkipCounts`, private `ActiveRead`, `PileupEngine`.
+- Modify `src/lib.rs` — add `pub mod pileup;` (next to `pub mod core;`).
+
+---
+
+## Task 1: Module skeleton + `PileupColumn` (`pileup::column`)
+
+**Files:**
+- Modify: `src/lib.rs` (add `pub mod pileup;`)
+- Create: `src/pileup/mod.rs`
+- Create: `src/pileup/column.rs`
+- Test: `src/pileup/column.rs`
+
+- [ ] **Step 1: Wire the module.** In `src/lib.rs`, add near `pub mod core;`:
+```rust
+/// The streaming pileup kernel: one CIGAR-aware, filtered, bounded-memory engine.
+pub mod pileup;
+```
+Create `src/pileup/mod.rs`:
+```rust
+//! The streaming pileup kernel.
+//!
+//! `PileupEngine` consumes coordinate-sorted reads and yields one `PileupColumn`
+//! per covered reference position. It is the single substrate that variant
+//! callers and plugins build on. Reference as `crate::pileup::…`.
+
+pub mod column;
+
+pub use column::{Obs, PileupColumn};
+```
+
+- [ ] **Step 2: Write the failing test.** Create `src/pileup/column.rs`:
+```rust
+//! The per-position pileup column and its observations — the public substrate
+//! type produced by `PileupEngine` and consumed by callers and plugins.
+
+use crate::core::Locus;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Position;
+
+    fn obs(allele: u8, reverse: bool) -> Obs {
+        Obs { allele, base_qual: 30, mapq: 60, reverse }
+    }
+
+    #[test]
+    fn depth_allele_and_strand_counts() {
+        let col = PileupColumn {
+            locus: Locus { contig: 0, pos: Position(100) },
+            ref_base: b'A',
+            obs: vec![obs(0, false), obs(0, true), obs(1, false)],
+        };
+        assert_eq!(col.depth(), 3);
+        assert_eq!(col.allele_counts(), [2, 1, 0, 0]);
+        // [allele][0=fwd,1=rev]: A has 1 fwd + 1 rev, C has 1 fwd.
+        let sc = col.strand_counts();
+        assert_eq!(sc[0], [1, 1]);
+        assert_eq!(sc[1], [1, 0]);
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails.** Run: `cargo test pileup::column`
+Expected: FAIL — does not compile (`Obs`, `PileupColumn` undefined).
+
+- [ ] **Step 4: Implement the types.** Insert above the `#[cfg(test)]` block in `src/pileup/column.rs`:
+```rust
+/// One base observation at a pileup position. Only callable (A/C/G/T) bases are
+/// recorded; `allele` is the 0..=3 index (A=0, C=1, G=2, T=3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Obs {
+    /// Allele index 0..=3 (A/C/G/T).
+    pub allele: u8,
+    /// Base quality (Phred) of the observed base.
+    pub base_qual: u8,
+    /// Mapping quality of the read this observation came from.
+    pub mapq: u8,
+    /// Whether the read maps to the reverse strand (for strand-bias use).
+    pub reverse: bool,
+}
+
+/// All callable observations stacked at a single reference position.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PileupColumn {
+    /// The reference coordinate of this column.
+    pub locus: Locus,
+    /// The reference base at this locus (uppercase ASCII; `b'N'` if unknown).
+    pub ref_base: u8,
+    /// Callable observations, in deterministic (active-read insertion) order.
+    pub obs: Vec<Obs>,
+}
+
+impl PileupColumn {
+    /// Number of callable observations.
+    pub fn depth(&self) -> u32 {
+        self.obs.len() as u32
+    }
+
+    /// Per-allele observation counts, indexed `[A, C, G, T]`.
+    pub fn allele_counts(&self) -> [u32; 4] {
+        let mut counts = [0u32; 4];
+        for o in &self.obs {
+            counts[o.allele as usize] += 1;
+        }
+        counts
+    }
+
+    /// Per-allele, per-strand counts: `[allele][0 = forward, 1 = reverse]`.
+    pub fn strand_counts(&self) -> [[u32; 2]; 4] {
+        let mut counts = [[0u32; 2]; 4];
+        for o in &self.obs {
+            counts[o.allele as usize][o.reverse as usize] += 1;
+        }
+        counts
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes.** Run: `cargo test pileup::column` — Expected: PASS (1 test).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/lib.rs src/pileup/mod.rs src/pileup/column.rs
+git commit -m "feat(pileup): scaffold pileup module + PileupColumn substrate type" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Read source (`pileup::source`)
+
+**Files:**
+- Create: `src/pileup/source.rs`
+- Modify: `src/pileup/mod.rs`
+- Test: `src/pileup/source.rs`
+
+- [ ] **Step 1: Write the failing test.** Create `src/pileup/source.rs`:
+```rust
+//! Read sources feed coordinate-sorted reads into the pileup engine. `SliceSource`
+//! is an in-memory source (used by the Rust API and tests); a BAM-backed source
+//! lands when the calling path is migrated.
+
+use crate::core::{AlignedRead, CoreError};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{CigarOp, CigarOpKind, Position, SamFlags};
+    use std::sync::Arc;
+
+    fn read(contig: u32, pos: u32) -> AlignedRead {
+        AlignedRead {
+            contig,
+            pos: Position(pos),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![CigarOp::new(CigarOpKind::Match, 4)],
+            seq: Arc::from(b"ACGT".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        }
+    }
+
+    #[test]
+    fn slice_source_yields_reads_sorted_by_contig_then_pos() {
+        let mut src = SliceSource::new(vec![read(1, 50), read(0, 200), read(0, 100)]);
+        let mut order = Vec::new();
+        while let Some(r) = src.next_read().unwrap() {
+            order.push((r.contig, r.pos.0));
+        }
+        assert_eq!(order, vec![(0, 100), (0, 200), (1, 50)]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails.** Run: `cargo test pileup::source`
+Expected: FAIL — does not compile (`SliceSource`, `ReadSource` undefined).
+
+- [ ] **Step 3: Implement the source.** Insert above the `#[cfg(test)]` block:
+```rust
+/// A source of coordinate-sorted aligned reads for the pileup engine.
+///
+/// Implementations MUST yield reads sorted ascending by `(contig, pos)`.
+pub trait ReadSource {
+    /// Return the next read, or `None` when exhausted.
+    fn next_read(&mut self) -> Result<Option<AlignedRead>, CoreError>;
+}
+
+/// An in-memory read source. Sorts the provided reads by `(contig, pos)` on
+/// construction so callers need not pre-sort.
+#[derive(Debug)]
+pub struct SliceSource {
+    reads: std::vec::IntoIter<AlignedRead>,
+}
+
+impl SliceSource {
+    /// Build a source from reads (sorted by `(contig, pos)` here).
+    pub fn new(mut reads: Vec<AlignedRead>) -> Self {
+        reads.sort_by(|a, b| a.contig.cmp(&b.contig).then(a.pos.0.cmp(&b.pos.0)));
+        Self { reads: reads.into_iter() }
+    }
+}
+
+impl ReadSource for SliceSource {
+    fn next_read(&mut self) -> Result<Option<AlignedRead>, CoreError> {
+        Ok(self.reads.next())
+    }
+}
+```
+In `src/pileup/mod.rs`, add:
+```rust
+pub mod source;
+pub use source::{ReadSource, SliceSource};
+```
+
+- [ ] **Step 4: Run the test to verify it passes.** Run: `cargo test pileup::source` — Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/pileup/source.rs src/pileup/mod.rs
+git commit -m "feat(pileup): ReadSource trait + in-memory SliceSource" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Engine configuration (`PileupParams`, `SkipCounts`)
+
+**Files:**
+- Create: `src/pileup/engine.rs`
+- Modify: `src/pileup/mod.rs`
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the failing test.** Create `src/pileup/engine.rs`:
+```rust
+//! The streaming pileup engine: CIGAR-aware, read-filtered, strand-aware,
+//! bounded-memory. Yields one `PileupColumn` per covered reference position.
+
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+
+use crate::core::{allele_index, AlignedRead, CoreError, Locus, Position, WorkingSet};
+use crate::pileup::column::{Obs, PileupColumn};
+use crate::pileup::source::ReadSource;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_params_skip_noise_and_keep_quality_open() {
+        let p = PileupParams::default();
+        assert!(p.skip_secondary && p.skip_supplementary && p.skip_duplicate);
+        assert_eq!(p.min_mapq, 0);
+        assert_eq!(p.min_base_qual, 0);
+    }
+
+    #[test]
+    fn skip_counts_total_sums_all_reasons() {
+        let s = SkipCounts {
+            unmapped: 1,
+            wrong_contig: 2,
+            secondary: 3,
+            supplementary: 4,
+            duplicate: 5,
+            low_mapq: 6,
+        };
+        assert_eq!(s.total(), 21);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails.** Run: `cargo test pileup::engine`
+Expected: FAIL — does not compile (`PileupParams`, `SkipCounts` undefined; unused imports also error under the test build, which is fine — they are used once the engine lands in Task 4).
+
+- [ ] **Step 3: Implement the config types.** Insert above the `#[cfg(test)]` block (the `use` lines above stay; `#[allow(unused_imports)]` is NOT needed once Task 4 adds the engine — but to keep this task compiling on its own, temporarily prefix the not-yet-used imports). Replace the `use` block at the top of the file with:
+```rust
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+
+#[allow(unused_imports)]
+use crate::core::{allele_index, AlignedRead, CoreError, Locus, Position, WorkingSet};
+#[allow(unused_imports)]
+use crate::pileup::column::{Obs, PileupColumn};
+#[allow(unused_imports)]
+use crate::pileup::source::ReadSource;
+```
+Then add the config types:
+```rust
+/// Read-level filters applied as reads enter the pileup.
+#[derive(Debug, Clone)]
+pub struct PileupParams {
+    /// Minimum mapping quality; reads below this are skipped.
+    pub min_mapq: u8,
+    /// Minimum base quality; observations below this are dropped.
+    pub min_base_qual: u8,
+    /// Skip secondary alignments (SAM flag 0x100).
+    pub skip_secondary: bool,
+    /// Skip supplementary alignments (SAM flag 0x800).
+    pub skip_supplementary: bool,
+    /// Skip PCR/optical duplicates (SAM flag 0x400).
+    pub skip_duplicate: bool,
+}
+
+impl Default for PileupParams {
+    fn default() -> Self {
+        Self {
+            min_mapq: 0,
+            min_base_qual: 0,
+            skip_secondary: true,
+            skip_supplementary: true,
+            skip_duplicate: true,
+        }
+    }
+}
+
+/// Counts of reads skipped during pileup, by reason (surfaced to callers/CLI).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SkipCounts {
+    /// Reads with the unmapped flag set.
+    pub unmapped: u64,
+    /// Reads on a contig other than the target.
+    pub wrong_contig: u64,
+    /// Secondary alignments skipped.
+    pub secondary: u64,
+    /// Supplementary alignments skipped.
+    pub supplementary: u64,
+    /// Duplicate reads skipped.
+    pub duplicate: u64,
+    /// Reads below the MAPQ threshold.
+    pub low_mapq: u64,
+}
+
+impl SkipCounts {
+    /// Total reads skipped across all reasons.
+    pub fn total(&self) -> u64 {
+        self.unmapped
+            + self.wrong_contig
+            + self.secondary
+            + self.supplementary
+            + self.duplicate
+            + self.low_mapq
+    }
+}
+```
+In `src/pileup/mod.rs`, add:
+```rust
+pub mod engine;
+pub use engine::{PileupEngine, PileupParams, SkipCounts};
+```
+> Note: `pub use engine::PileupEngine` will not compile until Task 4 defines `PileupEngine`. Add only `pub use engine::{PileupParams, SkipCounts};` in THIS task; add `PileupEngine` to the re-export in Task 4.
+
+- [ ] **Step 4: Run the test to verify it passes.** Run: `cargo test pileup::engine` — Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/pileup/engine.rs src/pileup/mod.rs
+git commit -m "feat(pileup): PileupParams + SkipCounts" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: The engine — advance, CIGAR-aware tally, Iterator (`PileupEngine`)
+
+This is the heart. It fixes two legacy bugs: (1) the reverse-strand **double-complement** — we read the **forward-oriented** SEQ directly; (2) the empty-position **recursion** — we loop. Filtering is added in Task 6; this task ingests all mapped reads on the target contig.
+
+**Files:**
+- Modify: `src/pileup/engine.rs`
+- Modify: `src/pileup/mod.rs` (add `PileupEngine` to re-export)
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add to `src/pileup/engine.rs`'s `#[cfg(test)] mod tests`:
+```rust
+    use crate::core::{CigarOp, CigarOpKind, SamFlags};
+    use crate::pileup::source::SliceSource;
+
+    // Build a fully-matched read at `pos` on contig 0 with the given seq.
+    fn mread(pos: u32, seq: &[u8], reverse: bool) -> AlignedRead {
+        let mut flags = SamFlags::default();
+        if reverse {
+            flags = SamFlags(SamFlags::REVERSE);
+        }
+        AlignedRead {
+            contig: 0,
+            pos: Position(pos),
+            mapq: 60,
+            flags,
+            cigar: vec![CigarOp::new(CigarOpKind::Match, seq.len() as u32)],
+            seq: Arc::from(seq.to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; seq.len()].into_boxed_slice()),
+        }
+    }
+
+    fn engine(reads: Vec<AlignedRead>, reference: &[u8]) -> PileupEngine<SliceSource> {
+        PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..reference.len() as u32,
+            PileupParams::default(),
+        )
+    }
+
+    fn columns(mut e: PileupEngine<SliceSource>) -> Vec<PileupColumn> {
+        let mut out = Vec::new();
+        while let Some(c) = e.next() {
+            out.push(c.expect("pileup column"));
+        }
+        out
+    }
+
+    #[test]
+    fn reverse_strand_reads_are_not_complemented() {
+        // Regression: forward and reverse-strand reads carrying the SAME forward
+        // SEQ must contribute the SAME allele. (Legacy code complemented reverse
+        // reads, corrupting ~half the data.)
+        let reference = b"AAAAA";
+        // Both reads observe 'G' at ref position 2 (SEQ is forward-oriented).
+        let fwd = mread(0, b"AAGAA", false);
+        let rev = mread(0, b"AAGAA", true);
+        let cols = columns(engine(vec![fwd, rev], reference));
+        let at2 = cols.iter().find(|c| c.locus.pos.0 == 2).expect("column at pos 2");
+        // Both observe G (allele 2); none observe C (allele 1, the complement of G).
+        assert_eq!(at2.allele_counts(), [0, 0, 2, 0]);
+    }
+
+    #[test]
+    fn basic_ungapped_pileup_counts() {
+        let reference = b"ACGTACGT";
+        let reads = vec![mread(0, b"ACGT", false), mread(2, b"GTAC", false)];
+        let cols = columns(engine(reads, reference));
+        // Position 2 is covered by both reads: read1 offset2='G', read2 offset0='G'.
+        let at2 = cols.iter().find(|c| c.locus.pos.0 == 2).unwrap();
+        assert_eq!(at2.depth(), 2);
+        assert_eq!(at2.ref_base, b'G');
+        assert_eq!(at2.allele_counts(), [0, 0, 2, 0]);
+        // Only covered positions are emitted (no empty columns).
+        assert!(cols.iter().all(|c| c.depth() > 0));
+    }
+
+    #[test]
+    fn sparse_coverage_skips_empty_positions_without_recursion() {
+        // A large gap between two reads must not overflow the stack (loop, not
+        // recursion) and must emit no empty columns.
+        let mut reference = vec![b'A'; 100_000];
+        reference[0] = b'C';
+        reference[99_999] = b'C';
+        let reads = vec![mread(0, b"C", false), mread(99_999, b"C", false)];
+        let cols = columns(engine(reads, &reference));
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].locus.pos.0, 0);
+        assert_eq!(cols[1].locus.pos.0, 99_999);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.** Run: `cargo test pileup::engine`
+Expected: FAIL — does not compile (`PileupEngine` undefined).
+
+- [ ] **Step 3: Implement the engine.** Remove the three `#[allow(unused_imports)]` lines added in Task 3 (the imports are now used). Add to `src/pileup/engine.rs` (above the `#[cfg(test)]` block):
+```rust
+/// A read currently overlapping the cursor, with its CIGAR projection precomputed.
+#[derive(Debug)]
+struct ActiveRead {
+    /// Half-open reference end (CIGAR-derived) — used to expire the read.
+    end: u32,
+    /// Map from reference position to read offset for this read's Match bases.
+    ref_to_read: HashMap<u32, usize>,
+    /// Read sequence (forward-reference orientation).
+    seq: Arc<[u8]>,
+    /// Per-base qualities (parallel to `seq`).
+    qual: Arc<[u8]>,
+    /// Mapping quality.
+    mapq: u8,
+    /// Reverse-strand flag (metadata only — never applied to `seq`).
+    reverse: bool,
+}
+
+/// Streaming, CIGAR-aware, bounded-memory pileup over one contig region.
+///
+/// Yields one [`PileupColumn`] per covered reference position. The working set
+/// is bounded by local read coverage, not by input size.
+#[derive(Debug)]
+pub struct PileupEngine<S: ReadSource> {
+    source: S,
+    reference: Arc<[u8]>,
+    contig: u32,
+    region: Range<u32>,
+    params: PileupParams,
+    active: Vec<ActiveRead>,
+    next_read: Option<AlignedRead>,
+    pos: u32,
+    skips: SkipCounts,
+    source_done: bool,
+}
+
+impl<S: ReadSource> PileupEngine<S> {
+    /// Create an engine over `reference` bytes for `contig`, covering `region`
+    /// (0-based half-open; `reference[0]` is the base at `region.start`).
+    pub fn new(
+        source: S,
+        reference: Arc<[u8]>,
+        contig: u32,
+        region: Range<u32>,
+        params: PileupParams,
+    ) -> Self {
+        let pos = region.start;
+        Self {
+            source,
+            reference,
+            contig,
+            region,
+            params,
+            active: Vec::new(),
+            next_read: None,
+            pos,
+            skips: SkipCounts::default(),
+            source_done: false,
+        }
+    }
+
+    /// Reads skipped so far, by reason. Final after iteration completes.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skips
+    }
+
+    /// Whether the read passes flag/MAPQ filters (contig + unmapped handled in
+    /// `advance_to`). Added in Task 6; here it accepts every read.
+    fn passes_filters(&mut self, _read: &AlignedRead) -> bool {
+        true
+    }
+
+    /// Precompute a read's reference→read-offset map and add it to the active set.
+    fn ingest(&mut self, read: AlignedRead) {
+        let end = read.end();
+        let mut ref_to_read = HashMap::new();
+        for rb in read.projected_bases() {
+            ref_to_read.insert(rb.ref_pos, rb.read_offset);
+        }
+        self.active.push(ActiveRead {
+            end,
+            ref_to_read,
+            seq: Arc::clone(&read.seq),
+            qual: Arc::clone(&read.qual),
+            mapq: read.mapq,
+            reverse: read.flags.is_reverse(),
+        });
+    }
+
+    /// Expire reads that no longer cover `pos`, then pull in reads starting at or
+    /// before `pos`. Reads are coordinate-sorted, so we stop at the first read
+    /// that starts after `pos` on the target contig.
+    fn advance_to(&mut self, pos: u32) -> Result<(), CoreError> {
+        self.active.retain(|r| r.end > pos);
+        loop {
+            if self.next_read.is_none() && !self.source_done {
+                match self.source.next_read()? {
+                    Some(r) => self.next_read = Some(r),
+                    None => self.source_done = true,
+                }
+            }
+            // Peek the routing fields without holding a borrow across `take`.
+            let (rc, rp, unmapped) = match self.next_read.as_ref() {
+                Some(r) => (r.contig, r.pos.0, r.flags.is_unmapped()),
+                None => break,
+            };
+            if unmapped {
+                self.next_read.take();
+                self.skips.unmapped += 1;
+                continue;
+            }
+            match rc.cmp(&self.contig) {
+                std::cmp::Ordering::Greater => break, // sorted: no more target-contig reads
+                std::cmp::Ordering::Less => {
+                    self.next_read.take();
+                    self.skips.wrong_contig += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if rp > pos {
+                        break; // future read on our contig
+                    }
+                    let read = self.next_read.take().unwrap();
+                    if !self.passes_filters(&read) {
+                        continue;
+                    }
+                    if read.end() <= pos {
+                        continue; // does not reach the cursor
+                    }
+                    self.ingest(read);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the column at the current cursor from the active set.
+    fn build_column(&self) -> PileupColumn {
+        let ref_idx = (self.pos - self.region.start) as usize;
+        let ref_base = self.reference.get(ref_idx).copied().unwrap_or(b'N');
+        let mut obs = Vec::new();
+        for r in &self.active {
+            if let Some(&off) = r.ref_to_read.get(&self.pos) {
+                // Forward orientation — read the stored SEQ byte directly. No
+                // complement (this is the reverse-strand fix).
+                let base = r.seq.get(off).copied().unwrap_or(b'N');
+                let bq = r.qual.get(off).copied().unwrap_or(0);
+                if bq < self.params.min_base_qual {
+                    continue;
+                }
+                if let Some(allele) = allele_index(base) {
+                    obs.push(Obs {
+                        allele: allele as u8,
+                        base_qual: bq,
+                        mapq: r.mapq,
+                        reverse: r.reverse,
+                    });
+                }
+            }
+        }
+        PileupColumn {
+            locus: Locus { contig: self.contig, pos: Position(self.pos) },
+            ref_base,
+            obs,
+        }
+    }
+}
+
+impl<S: ReadSource> Iterator for PileupEngine<S> {
+    type Item = Result<PileupColumn, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Loop over empty positions (no recursion → bounded stack, any gap size).
+        while self.pos < self.region.end {
+            let pos = self.pos;
+            if let Err(e) = self.advance_to(pos) {
+                self.pos = self.region.end;
+                return Some(Err(e));
+            }
+            let column = self.build_column();
+            self.pos += 1;
+            if !column.obs.is_empty() {
+                return Some(Ok(column));
+            }
+        }
+        None
+    }
+}
+```
+In `src/pileup/mod.rs`, change the engine re-export to include `PileupEngine`:
+```rust
+pub use engine::{PileupEngine, PileupParams, SkipCounts};
+```
+
+- [ ] **Step 4: Run the tests to verify they pass.** Run: `cargo test pileup::engine` — Expected: PASS (5 tests: 2 from Task 3 + 3 here).
+
+- [ ] **Step 5: Run the whole suite + build.** Run: `cargo test` — all pass. Run: `cargo build` — no `missing_docs`/`missing_debug_implementations` warnings from `src/pileup/`.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/pileup/engine.rs src/pileup/mod.rs
+git commit -m "feat(pileup): PileupEngine (CIGAR-aware tally, forward-strand fix, empty-position loop)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CIGAR projection correctness (indel / soft-clip / ref-skip / long read)
+
+These tests confirm the engine's `core::projected_bases`-driven tally places bases at correct reference coordinates for non-trivial CIGARs. They should pass against the Task-4 engine; if any fails, it reveals an engine bug to fix before proceeding.
+
+**Files:**
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the tests.** Add to the `#[cfg(test)] mod tests` block:
+```rust
+    #[test]
+    fn insertion_bases_do_not_shift_downstream_reference_positions() {
+        // 2M 1I 2M: read offsets 0,1 -> ref 10,11; offset 2 = inserted (no ref);
+        // offsets 3,4 -> ref 12,13.
+        let reference = b"AAAAAAAAAAAAAAAA"; // 16 'A'
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(10),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Insertion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"CCAGT".to_vec().into_boxed_slice()), // 2M=CC, 1I=A (inserted), 2M=GT
+            qual: Arc::from(vec![30u8; 5].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        // ref 10 <- offset0 'C'; ref 11 <- offset1 'C'; ref 12 <- offset3 'G'; ref 13 <- offset4 'T'.
+        // offset2 'A' is the inserted base — correctly absent from every reference column.
+        let get = |p: u32| cols.iter().find(|c| c.locus.pos.0 == p).map(|c| c.allele_counts());
+        assert_eq!(get(10), Some([0, 1, 0, 0])); // C
+        assert_eq!(get(11), Some([0, 1, 0, 0])); // C
+        assert_eq!(get(12), Some([0, 0, 1, 0])); // G  (offset3)
+        assert_eq!(get(13), Some([0, 0, 0, 1])); // T  (offset4)
+    }
+
+    #[test]
+    fn deletion_leaves_a_reference_gap_with_no_observation() {
+        // 2M 1D 2M starting at ref 0: ref 0,1 observed; ref 2 deleted (no obs);
+        // ref 3,4 observed.
+        let reference = b"AAAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(0),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Deletion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"GGGG".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![0, 1, 3, 4]); // ref 2 (deleted) emits no column
+    }
+
+    #[test]
+    fn soft_clipped_bases_are_excluded() {
+        // 2S 3M: first 2 read bases are clipped; only the 3 matched bases pile up.
+        let reference = b"AAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(1),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::SoftClip, 2),
+                CigarOp::new(CigarOpKind::Match, 3),
+            ],
+            seq: Arc::from(b"TTCGA".to_vec().into_boxed_slice()), // TT clipped; CGA match ref 1,2,3
+            qual: Arc::from(vec![30u8; 5].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![1, 2, 3]);
+        // The clipped 'T's (allele 3) never appear; ref 1 sees 'C' (allele 1).
+        let at1 = cols.iter().find(|c| c.locus.pos.0 == 1).unwrap();
+        assert_eq!(at1.allele_counts(), [0, 1, 0, 0]);
+    }
+
+    #[test]
+    fn long_read_piles_up_every_matched_base() {
+        // Read-length-agnostic: a 5000-base full-match read covers 5000 positions.
+        let reference = vec![b'A'; 6000];
+        let seq = vec![b'C'; 5000];
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(1000),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![CigarOp::new(CigarOpKind::Match, 5000)],
+            seq: Arc::from(seq.into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 5000].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], &reference));
+        assert_eq!(cols.len(), 5000);
+        assert_eq!(cols.first().unwrap().locus.pos.0, 1000);
+        assert_eq!(cols.last().unwrap().locus.pos.0, 5999);
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+    }
+```
+
+- [ ] **Step 2: Run the tests.** Run: `cargo test pileup::engine` — Expected: PASS (9 tests total). If a projection test fails, STOP and report it as an engine bug (do not adjust the test to match buggy behavior).
+
+- [ ] **Step 3: Commit.**
+```bash
+git add src/pileup/engine.rs
+git commit -m "test(pileup): CIGAR projection correctness (indel/softclip/refskip/long-read)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Read-level filtering + per-base quality floor
+
+The Task-4 engine ingests all mapped target-contig reads. Now wire `PileupParams` so secondary/supplementary/duplicate/low-MAPQ reads are skipped (counted), and low-base-quality observations dropped.
+
+**Files:**
+- Modify: `src/pileup/engine.rs` (replace the stub `passes_filters`)
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the failing tests.** Add to the `#[cfg(test)] mod tests` block:
+```rust
+    fn flagged_read(pos: u32, seq: &[u8], flag_bits: u16) -> AlignedRead {
+        let mut r = mread(pos, seq, false);
+        r.flags = SamFlags(flag_bits);
+        r
+    }
+
+    #[test]
+    fn filters_skip_secondary_supplementary_and_duplicate_reads() {
+        let reference = b"AAAAA";
+        let reads = vec![
+            mread(0, b"CCCCC", false),                          // kept
+            flagged_read(0, b"GGGGG", SamFlags::SECONDARY),     // skipped
+            flagged_read(0, b"GGGGG", SamFlags::SUPPLEMENTARY), // skipped
+            flagged_read(0, b"GGGGG", SamFlags::DUPLICATE),     // skipped
+        ];
+        let mut e = engine(reads, reference);
+        let cols = {
+            let mut out = Vec::new();
+            while let Some(c) = e.next() {
+                out.push(c.unwrap());
+            }
+            out
+        };
+        // Only the kept read's 'C' (allele 1) appears at every position.
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+        let s = e.skip_counts();
+        assert_eq!((s.secondary, s.supplementary, s.duplicate), (1, 1, 1));
+    }
+
+    #[test]
+    fn filters_skip_low_mapq_reads() {
+        let reference = b"AAAAA";
+        let mut low = mread(0, b"GGGGG", false);
+        low.mapq = 3;
+        let reads = vec![mread(0, b"CCCCC", false), low];
+        let params = PileupParams { min_mapq: 10, ..PileupParams::default() };
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..5,
+            params,
+        );
+        let mut cols = Vec::new();
+        while let Some(c) = e.next() {
+            cols.push(c.unwrap());
+        }
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+        assert_eq!(e.skip_counts().low_mapq, 1);
+    }
+
+    #[test]
+    fn low_base_quality_observations_are_dropped() {
+        let reference = b"AAAAA";
+        let mut r = mread(0, b"GGGGG", false);
+        r.qual = Arc::from(vec![2u8; 5].into_boxed_slice()); // below the floor
+        let params = PileupParams { min_base_qual: 20, ..PileupParams::default() };
+        let mut e = PileupEngine::new(
+            SliceSource::new(vec![r]),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..5,
+            params,
+        );
+        // All observations dropped → no columns emitted.
+        assert!(e.next().is_none());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.** Run: `cargo test pileup::engine`
+Expected: FAIL — the secondary/supplementary/duplicate/low-MAPQ reads are currently NOT skipped (the stub `passes_filters` returns `true`), so allele counts and skip counts are wrong. (The low-base-quality test already passes via `build_column`'s `min_base_qual` check; that is expected.)
+
+- [ ] **Step 3: Implement filtering.** Replace the stub `passes_filters` in `src/pileup/engine.rs` with:
+```rust
+    /// Whether the read passes flag/MAPQ filters. (Contig routing and the
+    /// unmapped flag are handled in `advance_to`.)
+    fn passes_filters(&mut self, read: &AlignedRead) -> bool {
+        let f = read.flags;
+        if self.params.skip_secondary && f.is_secondary() {
+            self.skips.secondary += 1;
+            return false;
+        }
+        if self.params.skip_supplementary && f.is_supplementary() {
+            self.skips.supplementary += 1;
+            return false;
+        }
+        if self.params.skip_duplicate && f.is_duplicate() {
+            self.skips.duplicate += 1;
+            return false;
+        }
+        if read.mapq < self.params.min_mapq {
+            self.skips.low_mapq += 1;
+            return false;
+        }
+        true
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass.** Run: `cargo test pileup::engine` — Expected: PASS (12 tests total).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/pileup/engine.rs
+git commit -m "feat(pileup): read-level filtering (secondary/supplementary/duplicate/MAPQ) + skip accounting" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Bounded-memory reporting (`current_working_set`)
+
+Expose the engine's working set so a run can be checked against a `MemoryBudget` (the foundation for the Phase D memory contract), and prove it is bounded by local coverage, not input size.
+
+**Files:**
+- Modify: `src/pileup/engine.rs`
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the failing test.** Add to the `#[cfg(test)] mod tests` block:
+```rust
+    use crate::core::MemoryBudget;
+
+    #[test]
+    fn working_set_is_bounded_by_coverage_not_input_size() {
+        // 50,000 short reads tiled across the reference at depth ~1: the active
+        // set (and thus the working set) stays tiny throughout iteration.
+        let reference = vec![b'A'; 50_000];
+        let reads: Vec<AlignedRead> =
+            (0..50_000u32).map(|p| mread(p, b"C", false)).collect();
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.into_boxed_slice()),
+            0,
+            0..50_000,
+            PileupParams::default(),
+        );
+        let budget = MemoryBudget::from_mb(1);
+        let mut max_ws = 0u64;
+        while let Some(c) = e.next() {
+            let _ = c.unwrap();
+            let ws = e.current_working_set();
+            max_ws = max_ws.max(ws.bytes);
+            assert!(ws.fits(budget), "working set {} exceeded 1 MiB", ws.bytes);
+        }
+        // Sanity: peak working set is far below what holding all reads would cost.
+        assert!(max_ws < 64 * 1024, "peak working set unexpectedly large: {max_ws}");
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails.** Run: `cargo test pileup::engine`
+Expected: FAIL — does not compile (`current_working_set` undefined).
+
+- [ ] **Step 3: Implement the reporter.** Add this method inside `impl<S: ReadSource> PileupEngine<S>` (next to `skip_counts`):
+```rust
+    /// Current working-set estimate: bounded by the active read set (local
+    /// coverage), independent of total input size. Foundation for `rosalind plan`.
+    pub fn current_working_set(&self) -> WorkingSet {
+        // Each active read costs roughly its projection map (16 B/entry) plus a
+        // small constant for handles; plus a fixed engine overhead.
+        let active_bytes: u64 = self
+            .active
+            .iter()
+            .map(|r| (r.ref_to_read.len() as u64) * 16 + 64)
+            .sum();
+        WorkingSet { bytes: active_bytes + 256 }
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes.** Run: `cargo test pileup::engine` — Expected: PASS (13 tests total).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/pileup/engine.rs
+git commit -m "feat(pileup): current_working_set() reporter (bounded-memory contract foundation)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Determinism + the open-substrate demonstration
+
+Lock in determinism (the moat) and prove the engine is consumer-agnostic by computing a non-caller analysis (per-base coverage) over the column stream.
+
+**Files:**
+- Test: `src/pileup/engine.rs`
+
+- [ ] **Step 1: Write the tests.** Add to the `#[cfg(test)] mod tests` block:
+```rust
+    #[test]
+    fn shuffled_source_yields_identical_columns() {
+        // SliceSource sorts on construction, so a shuffled input must produce the
+        // exact same column sequence (deterministic output).
+        let reference = b"ACGTACGTACGT";
+        let make = |order: Vec<(u32, &'static [u8])>| {
+            let reads: Vec<AlignedRead> =
+                order.into_iter().map(|(p, s)| mread(p, s, false)).collect();
+            columns(engine(reads, reference))
+        };
+        let a = make(vec![(0, b"AAAA"), (4, b"CCCC"), (8, b"GGGG")]);
+        let b = make(vec![(8, b"GGGG"), (0, b"AAAA"), (4, b"CCCC")]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn engine_is_an_open_substrate_for_arbitrary_per_locus_analysis() {
+        // A non-caller consumer: compute per-position coverage directly from the
+        // PileupColumn stream — no variant calling involved.
+        let reference = b"AAAAAAAA";
+        let reads = vec![mread(0, b"CCCC", false), mread(2, b"CCCC", false)];
+        let mut coverage = Vec::new();
+        let mut e = engine(reads, reference);
+        while let Some(c) = e.next() {
+            let col = c.unwrap();
+            coverage.push((col.locus.pos.0, col.depth()));
+        }
+        // pos 0,1 depth 1; pos 2,3 depth 2; pos 4,5 depth 1.
+        assert_eq!(
+            coverage,
+            vec![(0, 1), (1, 1), (2, 2), (3, 2), (4, 1), (5, 1)]
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests.** Run: `cargo test pileup::engine` — Expected: PASS (15 tests total).
+
+- [ ] **Step 3: Run the whole suite + build + fmt.** Run: `cargo test` (all pass), `cargo build` (no `src/pileup/` warnings), `cargo fmt --all -- --check` (clean).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add src/pileup/engine.rs
+git commit -m "test(pileup): determinism + open-substrate (coverage) demonstration" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage** (Phase A spec §3.2 `pileup/`): `ReadSource` + adapters ✔ (Task 2; BamSource deferred to A5, noted); `PileupEngine` ✔ (Task 4); CIGAR projection (M/=/X, I, S, D, N, H) ✔ via `core::projected_bases` (Tasks 4–5); read filtering + `SkipCounts` ✔ (Task 6); per-observation strand ✔ (`Obs.reverse`, Task 1); deterministic ordering ✔ (Task 8); bounded active set + `working_set_bound` ✔ (Tasks 4, 7); empty-position **loop** ✔ (Task 4); reverse-strand fix (forward SEQ) ✔ (Task 4); `PileupColumn` substrate ✔ (Task 1); non-caller consumer ✔ (Task 8). The genotype model is Phase A3; wiring the calling path + a BAM source is Phase A5 — both correctly out of scope here.
+- **Placeholder scan:** none — every step has complete code + exact commands. The one cross-task dependency (the `#[allow(unused_imports)]` shim in Task 3, removed in Task 4) is called out explicitly so Task 3 compiles standalone.
+- **Type consistency:** `Obs { allele:u8, base_qual:u8, mapq:u8, reverse:bool }`, `PileupColumn { locus, ref_base, obs }` with `depth()/allele_counts()/strand_counts()`, `ReadSource::next_read() -> Result<Option<AlignedRead>, CoreError>`, `SliceSource::new(Vec<AlignedRead>)`, `PileupParams` fields, `SkipCounts` fields + `total()`, `PileupEngine::new(source, reference, contig, region, params)` + `skip_counts()` + `current_working_set() -> WorkingSet`, and the `core` API (`AlignedRead.{contig,pos,mapq,flags,cigar,seq,qual}`, `projected_bases()`, `end()`, `SamFlags::{is_unmapped,is_reverse,is_secondary,is_supplementary,is_duplicate}` + the flag consts, `allele_index`, `Locus`, `Position`, `MemoryBudget`, `WorkingSet`, `CoreError`) — names used in tests match the implementations and the A1 `core` module.
+
+## Definition of done (A2)
+
+`cargo test` green (15 new `pileup::*` tests + the existing suite); `cargo build` warning-clean for `src/pileup/`; `cargo fmt --all -- --check` clean; the legacy `genomics::pileup`/`pileup_stream` untouched; all work on `rosalind/phase-a1-core`.

--- a/docs/superpowers/specs/2026-05-26-phase-a-unified-pileup-genotype-design.md
+++ b/docs/superpowers/specs/2026-05-26-phase-a-unified-pileup-genotype-design.md
@@ -1,0 +1,240 @@
+# Phase A — The pileup kernel + calling vertical + reproducibility receipt
+
+**Status:** Spec for review — 2026-05-26. First vertical slice of the target architecture
+(`2026-05-26-rosalind-target-architecture.md`).
+
+**One-line goal.** Stand up Rosalind's defining primitive — a single CIGAR-aware, filtered,
+strand-aware, **budget-honoring, read-length-agnostic streaming pileup kernel** over
+target-shaped `core` types — make variant calling its *first consumer* with **calibrated,
+abstention-aware** confidence, emit **spec-valid** VCF, and wrap every run in a **verifiable
+reproducibility receipt**. On real coordinate-sorted reads (reverse-strand, indel-bearing,
+soft-clipped, short or long), Rosalind produces correct, deterministic, trustworthy output that
+builders can also consume as a library.
+
+This slice is deliberately broader than a bug-fix sprint: it lays the `core` types and the
+public kernel API that every later phase builds on, and it demonstrates four of the five product
+promises (deterministic, standards, verifiable reproducibility, embeddable) end-to-end on day
+one. Guided by the core principle: *most uniquely valuable to edge builders.*
+
+---
+
+## 1. Success criteria (definition of done)
+
+- **Correct:** reverse-strand reads contribute correct alleles; indel/soft-clip/refskip reads
+  contribute matched bases at correct reference coordinates; **long reads** (indel-rich) handled
+  identically to short reads. No silently-dropped reads — skips are counted by reason.
+- **Kernel/substrate:** the pileup engine is a public, documented, consumer-agnostic API
+  yielding `PileupColumn`s; no htslib types leak into public signatures; the same stream that
+  feeds the caller can feed a plugin. A worked example consumes columns without the caller.
+- **Calibrated & honest:** germline calls carry true Phred `QUAL`/`GQ` from a genotype-likelihood
+  model and an explicit FILTER vocabulary; below-evidence sites are flagged/abstained, never
+  emitted as confident calls.
+- **Standards:** germline + somatic VCF pass `bcftools view` (CI when available), with
+  `##fileformat`, `##contig`, typed `##INFO`/`##FORMAT`/`##FILTER`, and `FORMAT` + sample
+  column(s) (germline 1 sample; somatic `TUMOR`/`NORMAL`).
+- **Verifiable:** every `variants`/`somatic` run emits a JSON receipt (tool version, normalized
+  input paths, BLAKE3 content hashes of inputs + params + outputs); a second run reproduces it
+  byte-for-byte.
+- **Budget-aware:** the engine exposes `working_set_bound()` and accepts a `MemoryBudget`; the
+  active-set bound is documented (foundation for `rosalind plan`).
+- **Deterministic:** identical inputs → byte-identical VCF + receipt; shuffled reads → identical
+  calls. Public `call_variants(Vec<AlignedRead>)` API preserved.
+- `CompressedEvaluator`/`PileupProcessor` off the calling path (retained for plugins).
+
+---
+
+## 2. Scope
+
+**In:** `core/` (locus, sequence, record, **budget**, error); the public `pileup/` engine;
+`call/germline` (calibrated diploid biallelic SNV GL model) + re-homed `call/somatic`;
+`io/vcf` (spec-valid writer); a **minimal `provenance/`** receipt for `variants`/`somatic`; the
+correctness fixes (§7); the migration (§8); a worked "plugin consumes the column stream"
+example; long-read correctness + tests.
+
+**Out (deferred, by design):** germline **indel calling** (C) — indel reads are *handled* by
+the pileup, not *called*; multi-allelic decomposition (biallelic only); MAPQ *calibration*
+(D/align) — A applies the filter with existing MAPQ; full `rosalind plan`/`verify` subcommands
+and region/`.csi` fetch + whole-genome multi-contig iteration (B/D) — A uses the single-region
+model on contig-aware types; the Python binding (Phase P) — but the API is shaped for it now;
+mate-overlap dedup, strand-bias *filter*, BAQ (C) — A collects per-strand counts so the filter
+is a drop-in; rayon (D).
+
+---
+
+## 3. New & changed modules
+
+### 3.1 `core/` (NEW — the lingua franca)
+- **`locus`**: `Contig {id, name, length}`, `Position(u32)`, `Locus {contig, pos}`; `ContigSet`
+  (name↔id, 64-bit-safe global offsets for B). Phase A is single-contig but uses these types.
+- **`sequence`**: 2-bit DNA (from `compressed_dna`); non-ACGT folds to `N` with a *counted
+  warning* (not a hard error); ambiguity mask preserved (lossless serialize). `BaseCode` is the
+  single source of truth (today duplicated in 4 files).
+- **`record`**: canonical `AlignedRead` — `contig, pos, mapq, flags (SAM bitflags), cigar:
+  Vec<CigarOp>, seq, qual`. `CigarOpKind` gains `RefSkip`. `ref_span()/end()` CIGAR-derived.
+  SEQ forward-oriented; strand is metadata, never applied to bytes. **Read-length-agnostic.**
+- **`budget`**: `MemoryBudget` (declared cap) + a `WorkingSet` model streaming stages report.
+- **`error`**: `thiserror` taxonomy.
+
+### 3.2 `pileup/` (REWRITE — the public kernel)
+- **`PileupParams { min_mapq, min_base_qual, skip_secondary, skip_supplementary,
+  skip_duplicate }`**; optional `MemoryBudget`.
+- **`ReadSource`** trait yielding coordinate-sorted `AlignedRead`s; adapters: `BamSource` (lazy
+  `bam::Record → AlignedRead`, bounded — conversion happens *here*, htslib stays internal) and
+  `SliceSource` (pre-sorted `&[AlignedRead]`).
+- **`PileupEngine`** — `Iterator<Item = Result<PileupColumn>>`. Responsibilities: CIGAR
+  projection (Match/Equal/Diff → ref+read/emit base; Ins/SoftClip → read-only; Del/RefSkip →
+  ref-only/no obs; HardClip → neither); read-level filtering with a `SkipCounts` accumulator
+  (unmapped/wrong_contig/secondary/supplementary/duplicate/low_mapq/malformed); per-observation
+  strand; deterministic active-set + intra-column observation order; **bounded active set**
+  (expired by CIGAR-derived `end`); **empty stretches advance by loop, not recursion** (fixes
+  `pileup_stream.rs:192`); `working_set_bound()` reporting; budget honored or fail-fast.
+- **`PileupColumn { locus, ref_base, obs: Vec<Obs> }`**, `Obs { allele: u8, bq: u8, reverse:
+  bool, mapq: u8 }`; derived `allele_counts()`, `strand_counts()`, `depth()`. **This is the
+  public substrate type** — stable, documented, designed for callers, plugins, and (Phase P)
+  Python/ML consumers. A `tests/`-level example shows a non-caller consumer (e.g. a coverage/
+  per-base-feature reducer) over the same stream.
+
+### 3.3 `call/` (NEW germline; re-home somatic) — calibrated & abstention-aware
+- **`call::germline(column, params) -> GermlineSite`** — the GL model (§5). Returns a *site
+  decision* including possible abstention: a confident variant (`PASS`), a low-confidence
+  variant (`LowQual`/`LowDepth`), or no-call. Honest by default: thin evidence is flagged, not
+  emitted as a confident call.
+- **`call::somatic(tumor, normal, params) -> Option<SomaticCall>`** — existing exact f64
+  binomial LLR moved here verbatim, fed corrected columns; tumor/normal co-walk driver over two
+  `PileupEngine`s.
+- `GermlineCall`/`SomaticCall` carry GT/GQ/PL/AD/DP/QUAL/FILTER (+ tumor/normal AD/DP/AF).
+
+### 3.4 `io/vcf` (REWRITE — one spec-valid emitter)
+- `VcfHeader` builder: `##fileformat=VCFv4.2`, `##contig` from `ContigSet`, typed
+  `##INFO=<DP,AF>`, `##FORMAT=<GT,GQ,DP,AD,PL>`, `##FILTER=<PASS,LowQual,LowDepth>`, then
+  `#CHROM…FORMAT\t<sample(s)>`. `VcfRecord` model + writer; germline 1 sample, somatic
+  `TUMOR`/`NORMAL`. Deterministic ordering preserved.
+
+### 3.5 `provenance/` (NEW — minimal receipt)
+- `RunManifest { tool_version, subcommand, inputs:[{path_normalized, blake3}], params,
+  outputs:[{path, blake3}], created_utc? }` serialized as canonical JSON (sorted keys, no
+  timestamps in the hashed core). `variants`/`somatic` write `<output>.manifest.json`. BLAKE3
+  is already a dependency. Full `provenance` module + `rosalind verify` is Phase D; A emits the
+  receipt and a determinism test hashes it.
+
+---
+
+## 4. Data flow
+- **Germline, BAM:** `BamSource → PileupEngine → call::germline → VcfWriter (+ manifest)`.
+- **Germline, in-memory/SAM:** load reads → **sort by pos** → `SliceSource` → same engine →
+  same writer. `StreamingVariantCaller` re-implemented over the engine; public
+  `call_variants(Vec<AlignedRead>)` preserved.
+- **Somatic:** two engines (tumor, normal) co-walked by position → `call::somatic` → writer with
+  two sample columns (+ manifest).
+- **Substrate demo:** `BamSource/SliceSource → PileupEngine → custom reducer` (no caller),
+  proving the kernel is consumer-agnostic.
+
+---
+
+## 5. The genotype model (minimal, standard, calibrated, abstention-aware)
+
+Reference `R`, candidate alt `A` = most-supported non-ref allele (biallelic). Per observation
+base `bᵢ`, base-quality `qᵢ`, error `εᵢ = 10^(−qᵢ/10)`:
+```
+P(bᵢ | X)      = 1 − εᵢ  if bᵢ == X else εᵢ/3
+P(bᵢ | hom R)  = P(bᵢ | R)
+P(bᵢ | hom A)  = P(bᵢ | A)
+P(bᵢ | het RA) = ½·P(bᵢ | R) + ½·P(bᵢ | A)
+```
+Accumulate log-likelihoods (f64, fixed order) for `{0/0, 0/1, 1/1}`; apply a configurable prior
+(default heterozygosity θ = 1e-3: `P(0/1)=θ`, `P(1/1)=θ/2`, `P(0/0)=1−1.5θ`).
+- **PL**: Phred `−10·log10 L(g)`, normalized min=0, cap 255.
+- **GT** = argmax posterior (argmin PL). **GQ** = second-smallest PL, cap 99. **QUAL** =
+  `−10·log10 P(0/0 | data)` (true Phred site-is-variant). **AD/DP** as counts.
+
+**Abstention/honesty rules (the unique-value posture):**
+- Emit a record only when `GT ≠ 0/0`. `FILTER = LowDepth` if `DP < min_depth`; `LowQual` if
+  `QUAL < min_qual`; else `PASS`.
+- Defaults tuned to *not overcall*: when evidence is insufficient the site is filtered, not
+  confidently called. Confidence is calibrated (PL/QUAL derived from the model, not a heuristic),
+  so a downstream/field user can trust the numbers and threshold for their risk tolerance.
+- Determinism: f64, fixed summation order; identical across runs.
+
+---
+
+## 6. VCF output contract (germline example)
+```
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=248956422>
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Alt allele fraction">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths (ref,alt)">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Phred genotype likelihoods">
+##FILTER=<ID=LowQual,Description="QUAL below threshold">
+##FILTER=<ID=LowDepth,Description="Depth below threshold">
+#CHROM POS ID REF ALT QUAL FILTER INFO        FORMAT         SAMPLE
+chr1   101 .  A   G   48.0 PASS    DP=30;AF=0.5 GT:GQ:DP:AD:PL 0/1:48:30:15,15:48,0,49
+```
+Somatic adds `TUMOR`/`NORMAL` columns and retains tumor/normal AF/DP.
+
+---
+
+## 7. Correctness fixes folded in
+1. **Reverse strand**: use forward SEQ directly; delete complement+offset-flip
+   (`pileup_stream.rs:33-42`, `somatic/model.rs:325-327`).
+2. **CIGAR-aware projection** (§3.2): stop dropping non-simple-match reads; `end()` = ref span.
+3. **Read filters** in-engine.
+4. **Empty-position recursion → loop** (`pileup_stream.rs:192`).
+5. **`checked_sub`** on offsets (`variant_caller.rs:125`).
+6. **Skip-and-count** replaces the SAM-path `bail!` and silent `continue`s; summary logged.
+
+---
+
+## 8. Migration / deprecation
+- `StreamingVariantCaller` re-implemented over `PileupEngine`; `call_variants(Vec<AlignedRead>)`
+  preserved.
+- `statistics::bayesian_variant_caller` **deleted** → `call::germline`.
+- `main.rs::parse_cigar` generalized → full CIGAR parser.
+- `somatic/model.rs` LLR + co-walk → `call/`; reverse-complement bug removed.
+- `PileupProcessor`/`PileupSummary`/`PileupWorkload` + `CompressedEvaluator` retained,
+  re-exported, **documented plugin-facing**, off the calling path.
+- `vcf.rs` + `somatic/vcf.rs` string writers replaced by `io/vcf`.
+
+---
+
+## 9. Error handling
+Typed library errors; `anyhow` only at the CLI. **Lenient by default** (malformed/filtered reads
+counted + skipped, never abort); IO/parse failures propagate. (`--strict` later.)
+
+---
+
+## 10. Testing (TDD — failing test first)
+- **Reverse-strand regression** (± strand over a known SNV → identical correct counts) — written
+  first, proves the bug before any change.
+- **CIGAR projection** (I/D/S/N land correctly; clipped/inserted excluded; previously-dropped
+  reads now contribute).
+- **Long-read correctness** (a long, indel-rich read piles up identically to its short-read
+  equivalents) — guards read-length-agnosticism.
+- **Filtering** (secondary/supplementary/duplicate/low-MAPQ excluded; `SkipCounts` exact).
+- **Genotype/calibration** (hand-computed PL/GT/GQ/QUAL for hom-ref (20,0), het (~15,15),
+  hom-alt (0,20); **abstention** at low depth (2,1) → LowDepth not a confident call;
+  QUAL monotonic with evidence).
+- **VCF validity** (parse + header tags + FORMAT/sample well-formed; `bcftools view` round-trip
+  in CI when available).
+- **Substrate** (the non-caller column-stream example produces expected per-base output).
+- **Determinism + receipt** (twice → byte-identical VCF *and* manifest; shuffled reads →
+  identical calls).
+- **End-to-end smoke** (synthetic ref + ± strand + indel + a long read → align → sort →
+  variants → expected VCF + manifest). Update `golden_vcf`.
+
+---
+
+## 11. Risks & mitigations
+- *Reverse-strand fix rests on "BAM SEQ is forward-oriented."* True per SAM spec; **the failing
+  regression test is written first** to prove it on this code before changing anything.
+- *Public API stability* — preserve `call_variants`; cover with a test; public-API surface test
+  asserts no htslib types leak.
+- *Somatic two-sample VCF is downstream-visible* — note in CHANGELOG (more conformant).
+- *Scope creep into C* — hard boundary: biallelic SNV genotyping only; indels/multi-allelic/
+  SB-filter explicitly out. The pileup *handles* indel/long reads; the caller does not *emit*
+  indels.
+- *Manifest determinism* — canonical JSON (sorted keys), no timestamps in the hashed core;
+  covered by the receipt determinism test.

--- a/docs/superpowers/specs/2026-05-26-rosalind-target-architecture.md
+++ b/docs/superpowers/specs/2026-05-26-rosalind-target-architecture.md
@@ -1,0 +1,205 @@
+# Rosalind — Target Architecture & Rebuild Plan
+
+**Status:** Approved direction — 2026-05-26. Living document.
+
+**Context.** Rosalind is a Rust genomics engine (alignment + germline/somatic variant
+calling) pitched for *deterministic, bounded-memory, on-prem/edge* genomics, built over a
+square-root-space evaluation framework (inspired by Williams 2025 *Simulating Time With
+Square-Root Space* and Cook–Mertz 2024 tree evaluation). A structured audit (2026-05) found
+genuine, well-built foundations but a large gap between positioning and implementation, plus
+several bugs that make outputs **silently wrong on real data**. The repo is gaining forks.
+This document defines the architecture we are rebuilding *toward*. Effort is not the
+constraint; the quality, uniqueness, and legibility of the engine for the people who build on
+it is the sole objective.
+
+---
+
+## 1. North star — the unique bet
+
+**Rosalind is the bounded-memory, deterministic, streaming genomics *kernel* that edge builders
+compute on.** Not another monolithic CLI that races GATK on accuracy, but the thing that
+exists where the ecosystem has a hole:
+
+- a **library-first** engine whose core primitive — a streaming, CIGAR-aware **pileup column
+  stream** — is a public, embeddable substrate;
+- where **memory is a contract you declare**, not an outcome you hope for (decisive on edge
+  devices with fixed RAM and no swap, where OOM means a dead run);
+- where **reproducibility is a verifiable artifact** a third party can check without re-running;
+- where **confidence is calibrated and honest** — the engine abstains rather than overcalls
+  when evidence is thin (a confident wrong call is the worst outcome in the field, where you
+  can't re-run or get a second opinion);
+- over which anyone can compute **arbitrary per-locus analytics — including on-device ML
+  features — across a whole genome on a laptop, deterministically, within a fixed budget.**
+
+We win by being the trustworthy, embeddable, predictable kernel for genomics at the edge — for
+hospital laptops, portable sequencers (MinION in the field), classrooms, and researchers who
+want to *build on* a genomics engine rather than shell out to one. Variant calling is the first
+consumer of the kernel, not the whole product.
+
+Non-goals (on purpose, so the promises are airtight): out-accuracy-ing GATK/DeepVariant on
+benchmarks; cloud/cluster-scale orchestration; supporting every exotic format.
+
+---
+
+## 2. The five promises (each becomes CI-enforced, not asserted)
+
+These are the product. Today most are merely claimed; the rebuild makes each an enforced
+invariant.
+
+| Promise | What it means | Enforcement |
+|---|---|---|
+| **Deterministic** | Byte-identical artifacts for identical inputs+config | Repeat-run byte-equality; shuffled-input → identical calls; (Phase D) `--threads 1` vs `N` equality |
+| **Memory is a contract** | You declare a budget; the engine honors it or refuses *up front* with a computed requirement. `rosalind plan` reports the working-set envelope before running | Real-RSS gate while running the CLI on *growing* inputs: assert flat working set + that declared budgets are honored (replaces today's tautological counter). Honest caveat: index *build* is O(reference), documented separately |
+| **Standards-compliant** | BAM/VCF the ecosystem accepts | `samtools quickcheck` / `bcftools view` / `bcftools norm` validate emitted artifacts in CI when available |
+| **Verifiable reproducibility** | A content-addressed *receipt* (tool version + hashes of inputs, params, outputs) a third party can verify without re-running | JSON manifest emitted by every subcommand; hashed in the determinism test; a `rosalind verify` path re-checks a receipt |
+| **Embeddable / composable** | Library-first; the pileup column stream is a public, documented, Python-exposed substrate for arbitrary (ML/QC/coverage) analytics; pipe-native CLI | Public-API test (no htslib types leak); a worked plugin + a Python streaming example; API-stability commitment on `core` types |
+
+---
+
+## 3. Design tenets that make us uniquely valuable
+
+1. **Memory as a contract.** Every streaming stage exposes a provable working-set bound and
+   accepts a `MemoryBudget`; the engine adapts blocking to honor it or fails fast with the
+   computed requirement. `rosalind plan` answers "will this run in 2 GB?" before you commit.
+2. **The pileup is an open substrate.** Variant calling is *a* consumer of the
+   `PileupColumn` stream — coverage, QC, methylation, and ML feature extraction are equal
+   citizens via the plugin/iterator API, all inheriting the memory + determinism guarantees.
+3. **Library-first, embeddable, pipe-native.** Clean typed Rust API + a thin Python binding
+   exposing the streaming primitive; the CLI is a thin client; subcommands compose over pipes
+   without mandatory big intermediates (field/disk-scarce reality).
+4. **Edge-data realism.** Read-length-agnostic and robust to indel-rich **long reads**
+   (Nanopore/PacBio — the actual edge-sequencing modality); transparent gzip/bgzf; honest
+   handling of real references (N runs, IUPAC, many contigs).
+5. **Honest, calibrated confidence over overcalling.** Calls carry true Phred-scaled,
+   well-calibrated confidence and an explicit FILTER vocabulary; below-evidence sites are
+   flagged/abstained, never emitted as confident calls. (Mirrors the abstention-aware posture:
+   don't pretend to predict where evidence is insufficient.)
+6. **Verifiable reproducibility.** A portable receipt makes "this artifact came from exactly
+   these inputs, params, and tool version" checkable by anyone — the auditability story made
+   real and unique.
+
+---
+
+## 4. Target module map
+
+The lingua franca is `core`; every other layer is built over it. Annotated **KEEP** /
+**REWRITE** / **NEW** / **SEPARATE**.
+
+```
+core/        coordinate model + canonical records — shared by everything
+  locus        Contig + Position; per-contig u32, global 64-bit-safe SA offset   NEW
+  sequence     2-bit DNA + explicit IUPAC/N handling                             REWRITE (from compressed_dna)
+  record       Read / AlignedRead: CIGAR, SAM flags, MAPQ, strand, tags          REWRITE (from types.rs)
+  budget       MemoryBudget + working-set model                                  NEW
+  error        typed library error taxonomy                                      NEW
+io/          the standards boundary (streaming, pipe-native)
+  fasta        multi-contig, streaming                                           REWRITE
+  fastq        streaming, gzip/bgzf transparent decompression                    REWRITE
+  bam          read/write, deterministic sort, .csi index                        KEEP sort + EXTEND
+  vcf          header model + record model → one spec-valid emitter              REWRITE
+index/       FM-index/SA as a build-once → serialize → mmap-load artifact         KEEP kernels + REWRITE persistence
+align/       seed → chain → extend → alignment (real MAPQ, soft-clip, contigs)    KEEP math + REWRITE (later phase)
+pileup/      THE single streaming, CIGAR-aware, filtered, bounded engine          REWRITE  ← the kernel; public substrate
+call/        pure scoring over columns: germline GL model; somatic LLR; (later) indels  NEW germline + KEEP somatic (re-homed)
+eval/        truth-set comparison (precision/recall, normalize, BED)              KEEP (+ fix left-align)
+provenance/  content-addressed run manifest + `verify`                           NEW (pulled early)
+framework/   bounded map-reduce substrate (space + ledger + tree)                KEEP — for PLUGINS, off the calling path
+plugin/      GenomicPlugin extension surface over the column stream              KEEP (elevated to a first-class substrate API)
+bindings/py  thin Python API exposing the streaming pileup primitive            NEW (near phase)
+theory/      Williams/Cook–Mertz √t Turing-machine simulation demo               SEPARATE (feature `theory`, non-default)
+cli (main)   thin orchestration; typed errors → anyhow only here; pipe-native    REWRITE (slim the 1645-line main.rs)
+```
+
+**Public-API discipline (hard rule):** no third-party types (e.g. `rust_htslib::bam::Record`)
+appear in any public signature. Sources convert to owned `core` types at the boundary. `core`
+types carry an API-stability commitment so external/Python/plugin consumers can rely on them.
+
+---
+
+## 5. Core abstractions (get these right; everything follows)
+
+- **`Locus = (Contig, Position)`** — per-contig `u32` positions; the FM-index/SA over the
+  *concatenated* genome uses a **64-bit-safe global offset** (standard bwa/minimap2 model).
+  Removes the single-contig blocker and the 4.29 Gbp ceiling structurally.
+- **`AlignedRead`** (canonical) — contig-aware, CIGAR, SAM flags, MAPQ, strand, tags; SEQ stored
+  forward-reference-oriented; `end()` CIGAR-derived. Read-length-agnostic (Illumina or long
+  reads).
+- **`PileupColumn`** — the public substrate type: one reference position with
+  deterministically-ordered observations `{allele, base_qual, strand, mapq}`; size bounded by
+  *coverage*. Designed to be consumed by callers, plugins, and (via the Python binding) ML
+  pipelines; cheap aggregate views for featurization.
+- **`MemoryBudget`** — declared cap; streaming stages report `working_set_bound()` and honor or
+  refuse.
+- **`Call`** types; **typed library errors**; `anyhow` only at the CLI.
+
+---
+
+## 6. The streaming pileup engine — the kernel
+
+One engine: **contig-aware, CIGAR-aware, read-filtered, strand-aware, deterministic, bounded,
+budget-honoring, read-length-agnostic.** Sources: sorted BAM now → `IndexedReader::fetch`
+(Phase D) → in-memory sorted reads. Consumers: germline + somatic callers, plugins, Python.
+Clean rewrite (not a generalization of htslib-coupled `BamPileupStream`). This is the component
+we RSS-gate (promise #2), expose to Python (promise #5/embeddable), and let plugins extend
+(tenet #2).
+
+---
+
+## 7. Keep / rewrite / cut
+
+| Preserve (re-home/extend) | Rewrite (structurally wrong) | Separate / cut |
+|---|---|---|
+| SA-IS suffix array → 64-bit-safe | Pileup engine → one clean kernel | Theory layer → feature-gated `theory/` |
+| FM-index math → multi-contig, persistable | Germline caller → calibrated GL model | Unused deps `ff`, `ark-poly` → optional |
+| External merge BAM sort (`sort.rs`) | VCF layer → header+record model | Tautological space counter → real RSS gate |
+| Eval suite (+ fix left-align) | Core coordinate/record types (`core/`) | Heuristic `ledger.all_merges_complete()` |
+| Somatic LLR → `call/somatic` | Index persistence (serialize + mmap) | `unimplemented!()` stubs in `util/` |
+| Plugin trait (elevated to substrate API) | Read ingestion (stream, gzip, multi-contig) | |
+
+---
+
+## 8. Locked decisions (2026-05-26)
+
+- **Rebuild approach: evolve toward the target** — rewrite the wrong layers; re-home/extend the
+  correct tested kernels; each phase lands green; no throwaway of working code.
+- **Theory layer: separate as a feature-gated `theory/` demo**; `ff`/`ark-poly` become optional
+  (`theory = ["dep:ff","dep:ark-poly"]`); decoupled from the genomics core.
+- **Guiding principle for all open design choices:** maximize *unique* value to edge builders —
+  the kernel/substrate, memory-as-contract, calibrated honesty, verifiable reproducibility,
+  embeddability (§1, §3).
+
+---
+
+## 9. Sequencing
+
+1. **Phase A — the kernel + calling vertical + receipt.** `core/` (locus, sequence, record,
+   budget, `PileupColumn`), the public `pileup/` engine, `call/germline` (calibrated GL model)
+   + re-homed `call/somatic`, `io/vcf` (spec-valid), and a **minimal `provenance/` receipt** so
+   the first improved outputs are already verifiable. Detailed in
+   `2026-05-26-phase-a-unified-pileup-genotype-design.md`.
+2. **Phase B — make it real on a genome.** Index persistence (build-once → mmap), multi-contig,
+   streaming/gzip/multi-record ingestion, pipe-native composition.
+3. **Phase D — fast & honest, memory-as-contract.** rayon (deterministic), `.csi` region
+   `fetch`, **real RSS gates + `rosalind plan`** (budget envelope) + `rosalind verify` (receipt
+   check), honest memory docs.
+4. **Phase C — scoped calling.** Germline indels, richer read QC (mate-overlap dedup,
+   strand-bias filter, BQ/BAQ), long-read calling refinements.
+5. **Phase P — Python substrate binding.** Expose the `PileupColumn` stream + index/align/call
+   to Python with type stubs, pytest, and a wheel matrix (manylinux/macOS/aarch64). Sequenced
+   right after the engine API stabilizes (after A/B).
+6. **Phase E — interleaved.** Theory separation (§8), CI hardening (clippy `-D warnings`,
+   bcftools validation, wheels), README-honesty pass.
+
+---
+
+## 10. Audit findings index (rationale)
+
+Urgent correctness (A): reverse-strand double-complement (`pileup_stream.rs:33-42`,
+`somatic/model.rs:325-327`); CIGAR-ignoring/read-dropping pileup (`pileup.rs`,
+`pileup_stream.rs:136`, `main.rs parse_cigar` bail); discarded-posterior "caller"
+(`statistics.rs:70`); hardcoded MAPQ (`bwt_aligner.rs:206`); non-conformant VCF (`vcf.rs:6`);
+empty-position recursion (`pileup_stream.rs:192`). Foundational (B): single-contig
+(`main.rs:881`); index rebuilt every run / zero SA samples persisted (`index/io.rs:140`);
+O(reference) build RAM. Moat (D): tautological space counter (`space/allocator.rs`),
+`rss_budget` caps 50 KB at 2 GB. Trust (E): vestigial theory layer; no clippy; Linux-only CI;
+empty bench; Python = RNA-seq demo only.

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -12,7 +12,9 @@ pub struct MemoryBudget {
 impl MemoryBudget {
     /// A budget expressed in mebibytes.
     pub fn from_mb(mb: u64) -> Self {
-        Self { bytes: mb.saturating_mul(1024 * 1024) }
+        Self {
+            bytes: mb.saturating_mul(1024 * 1024),
+        }
     }
 
     /// An effectively unbounded budget.
@@ -57,6 +59,9 @@ mod tests {
         assert!(MemoryBudget::unlimited().admits(u64::MAX));
         let ws = WorkingSet { bytes: 512 };
         assert!(ws.fits(MemoryBudget::from_mb(1)));
-        assert!(!WorkingSet { bytes: 5 * 1024 * 1024 }.fits(MemoryBudget::from_mb(1)));
+        assert!(!WorkingSet {
+            bytes: 5 * 1024 * 1024
+        }
+        .fits(MemoryBudget::from_mb(1)));
     }
 }

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -1,0 +1,61 @@
+//! Memory-as-a-contract primitives. Streaming stages report a `WorkingSet`
+//! bound so a run can be checked against a `MemoryBudget` *before* it starts
+//! (the foundation for `rosalind plan`).
+
+/// A declared cap on a streaming stage's working set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryBudget {
+    /// Maximum permitted working-set size, in bytes.
+    pub bytes: u64,
+}
+
+impl MemoryBudget {
+    /// A budget expressed in mebibytes.
+    pub fn from_mb(mb: u64) -> Self {
+        Self { bytes: mb.saturating_mul(1024 * 1024) }
+    }
+
+    /// An effectively unbounded budget.
+    pub fn unlimited() -> Self {
+        Self { bytes: u64::MAX }
+    }
+
+    /// Whether a working set of `working_set_bytes` is permitted.
+    pub fn admits(self, working_set_bytes: u64) -> bool {
+        working_set_bytes <= self.bytes
+    }
+}
+
+/// A reported working-set bound for a streaming stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkingSet {
+    /// Estimated peak working-set size, in bytes.
+    pub bytes: u64,
+}
+
+impl WorkingSet {
+    /// Whether this working set fits within `budget`.
+    pub fn fits(self, budget: MemoryBudget) -> bool {
+        budget.admits(self.bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_admits_within_and_rejects_beyond() {
+        let budget = MemoryBudget::from_mb(2);
+        assert!(budget.admits(1_000_000));
+        assert!(!budget.admits(3 * 1024 * 1024));
+    }
+
+    #[test]
+    fn unlimited_admits_everything_and_working_set_checks_fit() {
+        assert!(MemoryBudget::unlimited().admits(u64::MAX));
+        let ws = WorkingSet { bytes: 512 };
+        assert!(ws.fits(MemoryBudget::from_mb(1)));
+        assert!(!WorkingSet { bytes: 5 * 1024 * 1024 }.fits(MemoryBudget::from_mb(1)));
+    }
+}

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -49,6 +49,7 @@ mod tests {
         let budget = MemoryBudget::from_mb(2);
         assert!(budget.admits(1_000_000));
         assert!(!budget.admits(3 * 1024 * 1024));
+        assert!(budget.admits(2 * 1024 * 1024)); // boundary: working set == budget is admitted
     }
 
     #[test]

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -32,10 +32,19 @@ mod tests {
 
     #[test]
     fn budget_exceeded_displays_both_numbers() {
-        let e = CoreError::BudgetExceeded { needed: 4096, budget: 1024 };
+        let e = CoreError::BudgetExceeded {
+            needed: 4096,
+            budget: 1024,
+        };
         let msg = e.to_string();
-        assert!(msg.contains("4096"), "message should report needed bytes: {msg}");
-        assert!(msg.contains("1024"), "message should report budget bytes: {msg}");
+        assert!(
+            msg.contains("4096"),
+            "message should report needed bytes: {msg}"
+        );
+        assert!(
+            msg.contains("1024"),
+            "message should report budget bytes: {msg}"
+        );
     }
 
     #[test]

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,0 +1,40 @@
+//! Typed error taxonomy for the Rosalind core/library layer.
+//!
+//! The CLI boundary maps these into `anyhow`; library code returns `CoreError`.
+
+use thiserror::Error;
+
+/// Errors produced by the Rosalind core/library layer.
+#[derive(Debug, Error)]
+pub enum CoreError {
+    /// A streaming stage's working set would exceed the declared budget.
+    #[error("memory budget exceeded: working set {needed} bytes > budget {budget} bytes")]
+    BudgetExceeded {
+        /// Bytes the stage would require.
+        needed: u64,
+        /// Bytes the caller permitted.
+        budget: u64,
+    },
+    /// An input record could not be interpreted.
+    #[error("malformed record: {0}")]
+    MalformedRecord(String),
+    /// A contig id was not present in the active `ContigSet`.
+    #[error("invalid contig id {0}")]
+    InvalidContig(u32),
+    /// An underlying I/O failure.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_exceeded_displays_both_numbers() {
+        let e = CoreError::BudgetExceeded { needed: 4096, budget: 1024 };
+        let msg = e.to_string();
+        assert!(msg.contains("4096"), "message should report needed bytes: {msg}");
+        assert!(msg.contains("1024"), "message should report budget bytes: {msg}");
+    }
+}

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -37,4 +37,11 @@ mod tests {
         assert!(msg.contains("4096"), "message should report needed bytes: {msg}");
         assert!(msg.contains("1024"), "message should report budget bytes: {msg}");
     }
+
+    #[test]
+    fn io_error_converts_via_from() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let e: CoreError = io.into();
+        assert!(matches!(e, CoreError::Io(_)));
+    }
 }

--- a/src/core/locus.rs
+++ b/src/core/locus.rs
@@ -1,0 +1,116 @@
+//! Contig-aware genomic coordinates. Per-contig positions are `u32`; the
+//! concatenated-genome offset used by the multi-contig FM-index (Phase B) is
+//! 64-bit-safe, so no single coordinate space is capped at 4.29 Gbp.
+
+use std::sync::Arc;
+
+/// A reference contig (chromosome / sequence) with a stable id.
+#[derive(Debug, Clone)]
+pub struct Contig {
+    /// Dense 0-based id (index into the `ContigSet`).
+    pub id: u32,
+    /// Contig name as it appears in the reference / SAM `@SQ`.
+    pub name: Arc<str>,
+    /// Length in bases.
+    pub length: u32,
+    /// 0-based offset of this contig within the concatenated genome
+    /// (64-bit-safe; used by the multi-contig index in Phase B).
+    pub global_offset: u64,
+}
+
+/// A 0-based position within a single contig.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Position(pub u32);
+
+/// A canonical genomic coordinate: a contig id plus a position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Locus {
+    /// Contig id (index into the originating `ContigSet`).
+    pub contig: u32,
+    /// 0-based position within the contig.
+    pub pos: Position,
+}
+
+/// The ordered set of reference contigs: name<->id lookup and global offsets.
+#[derive(Debug, Clone, Default)]
+pub struct ContigSet {
+    contigs: Vec<Contig>,
+}
+
+impl ContigSet {
+    /// Create an empty contig set.
+    pub fn new() -> Self {
+        Self { contigs: Vec::new() }
+    }
+
+    /// Append a contig, assigning the next id and the running global offset.
+    /// Returns the new contig's id.
+    pub fn push(&mut self, name: impl Into<Arc<str>>, length: u32) -> u32 {
+        let id = self.contigs.len() as u32;
+        let global_offset = self
+            .contigs
+            .last()
+            .map_or(0, |c| c.global_offset + c.length as u64);
+        self.contigs.push(Contig { id, name: name.into(), length, global_offset });
+        id
+    }
+
+    /// Look up a contig by id.
+    pub fn by_id(&self, id: u32) -> Option<&Contig> {
+        self.contigs.get(id as usize)
+    }
+
+    /// Look up a contig by name.
+    pub fn by_name(&self, name: &str) -> Option<&Contig> {
+        self.contigs.iter().find(|c| c.name.as_ref() == name)
+    }
+
+    /// Number of contigs.
+    pub fn len(&self) -> usize {
+        self.contigs.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.contigs.is_empty()
+    }
+
+    /// Iterate contigs in id order.
+    pub fn iter(&self) -> impl Iterator<Item = &Contig> {
+        self.contigs.iter()
+    }
+
+    /// Total length of the concatenated genome (64-bit-safe).
+    pub fn total_length(&self) -> u64 {
+        self.contigs
+            .last()
+            .map_or(0, |c| c.global_offset + c.length as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contig_set_assigns_ids_and_global_offsets() {
+        let mut set = ContigSet::new();
+        let chr1 = set.push("chr1", 1_000);
+        let chr2 = set.push("chr2", 500);
+
+        assert_eq!(chr1, 0);
+        assert_eq!(chr2, 1);
+        assert_eq!(set.by_id(chr1).unwrap().global_offset, 0);
+        assert_eq!(set.by_id(chr2).unwrap().global_offset, 1_000);
+        assert_eq!(set.by_name("chr2").unwrap().id, 1);
+        assert_eq!(set.total_length(), 1_500);
+    }
+
+    #[test]
+    fn loci_order_by_contig_then_position() {
+        let a = Locus { contig: 0, pos: Position(100) };
+        let b = Locus { contig: 0, pos: Position(200) };
+        let c = Locus { contig: 1, pos: Position(0) };
+        assert!(a < b && b < c);
+    }
+}

--- a/src/core/locus.rs
+++ b/src/core/locus.rs
@@ -43,7 +43,9 @@ pub struct ContigSet {
 impl ContigSet {
     /// Create an empty contig set.
     pub fn new() -> Self {
-        Self { contigs: Vec::new() }
+        Self {
+            contigs: Vec::new(),
+        }
     }
 
     /// Append a contig, assigning the next id and the running global offset.
@@ -54,7 +56,12 @@ impl ContigSet {
             .contigs
             .last()
             .map_or(0, |c| c.global_offset + c.length as u64);
-        self.contigs.push(Contig { id, name: name.into(), length, global_offset });
+        self.contigs.push(Contig {
+            id,
+            name: name.into(),
+            length,
+            global_offset,
+        });
         id
     }
 
@@ -114,9 +121,18 @@ mod tests {
 
     #[test]
     fn loci_order_by_contig_then_position() {
-        let a = Locus { contig: 0, pos: Position(100) };
-        let b = Locus { contig: 0, pos: Position(200) };
-        let c = Locus { contig: 1, pos: Position(0) };
+        let a = Locus {
+            contig: 0,
+            pos: Position(100),
+        };
+        let b = Locus {
+            contig: 0,
+            pos: Position(200),
+        };
+        let c = Locus {
+            contig: 1,
+            pos: Position(0),
+        };
         assert!(a < b && b < c);
     }
 

--- a/src/core/locus.rs
+++ b/src/core/locus.rs
@@ -20,7 +20,10 @@ pub struct Contig {
 
 /// A 0-based position within a single contig.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Position(pub u32);
+pub struct Position(
+    /// 0-based offset within a contig.
+    pub u32,
+);
 
 /// A canonical genomic coordinate: a contig id plus a position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -46,7 +49,7 @@ impl ContigSet {
     /// Append a contig, assigning the next id and the running global offset.
     /// Returns the new contig's id.
     pub fn push(&mut self, name: impl Into<Arc<str>>, length: u32) -> u32 {
-        let id = self.contigs.len() as u32;
+        let id = u32::try_from(self.contigs.len()).expect("contig count exceeds u32::MAX");
         let global_offset = self
             .contigs
             .last()
@@ -61,6 +64,9 @@ impl ContigSet {
     }
 
     /// Look up a contig by name.
+    ///
+    /// O(n) in the number of contigs; for repeated lookups, build a name-indexed
+    /// map from [`ContigSet::iter`].
     pub fn by_name(&self, name: &str) -> Option<&Contig> {
         self.contigs.iter().find(|c| c.name.as_ref() == name)
     }
@@ -112,5 +118,20 @@ mod tests {
         let b = Locus { contig: 0, pos: Position(200) };
         let c = Locus { contig: 1, pos: Position(0) };
         assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn by_id_out_of_range_is_none() {
+        let mut set = ContigSet::new();
+        set.push("chr1", 1_000);
+        assert!(set.by_id(99).is_none());
+    }
+
+    #[test]
+    fn empty_contig_set_is_empty_with_zero_total_length() {
+        let set = ContigSet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.total_length(), 0);
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,8 @@
+//! Core types — the lingua franca shared by every Rosalind layer.
+//!
+//! Note: this module is named `core`; inside the crate always reference it as
+//! `crate::core::…`. Reach the std `core` crate (rarely needed) as `::core::…`.
+
+pub mod error;
+
+pub use error::CoreError;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,5 +4,7 @@
 //! `crate::core::…`. Reach the std `core` crate (rarely needed) as `::core::…`.
 
 pub mod error;
+pub mod locus;
 
 pub use error::CoreError;
+pub use locus::{Contig, ContigSet, Locus, Position};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,9 +6,11 @@
 pub mod budget;
 pub mod error;
 pub mod locus;
+pub mod record;
 pub mod sequence;
 pub use sequence::{allele_index, BaseCode};
 
 pub use budget::{MemoryBudget, WorkingSet};
 pub use error::CoreError;
 pub use locus::{Contig, ContigSet, Locus, Position};
+pub use record::{AlignedRead, CigarOp, CigarOpKind, RefBase, SamFlags};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,8 @@
 pub mod budget;
 pub mod error;
 pub mod locus;
+pub mod sequence;
+pub use sequence::{allele_index, BaseCode};
 
 pub use budget::{MemoryBudget, WorkingSet};
 pub use error::CoreError;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,8 +3,10 @@
 //! Note: this module is named `core`; inside the crate always reference it as
 //! `crate::core::…`. Reach the std `core` crate (rarely needed) as `::core::…`.
 
+pub mod budget;
 pub mod error;
 pub mod locus;
 
+pub use budget::{MemoryBudget, WorkingSet};
 pub use error::CoreError;
 pub use locus::{Contig, ContigSet, Locus, Position};

--- a/src/core/record.rs
+++ b/src/core/record.rs
@@ -31,12 +31,18 @@ pub enum CigarOpKind {
 impl CigarOpKind {
     /// Whether this op consumes reference bases.
     pub fn consumes_ref(self) -> bool {
-        matches!(self, CigarOpKind::Match | CigarOpKind::Deletion | CigarOpKind::RefSkip)
+        matches!(
+            self,
+            CigarOpKind::Match | CigarOpKind::Deletion | CigarOpKind::RefSkip
+        )
     }
 
     /// Whether this op consumes read/query bases.
     pub fn consumes_read(self) -> bool {
-        matches!(self, CigarOpKind::Match | CigarOpKind::Insertion | CigarOpKind::SoftClip)
+        matches!(
+            self,
+            CigarOpKind::Match | CigarOpKind::Insertion | CigarOpKind::SoftClip
+        )
     }
 }
 
@@ -141,7 +147,11 @@ pub struct AlignedRead {
 impl AlignedRead {
     /// Reference bases spanned by the alignment (sum of ref-consuming ops).
     pub fn ref_span(&self) -> u32 {
-        self.cigar.iter().filter(|o| o.kind.consumes_ref()).map(|o| o.len).sum()
+        self.cigar
+            .iter()
+            .filter(|o| o.kind.consumes_ref())
+            .map(|o| o.len)
+            .sum()
     }
 
     /// Half-open reference end coordinate. CIGAR-derived — never `pos + seq_len`.
@@ -167,7 +177,10 @@ impl AlignedRead {
             match op.kind {
                 CigarOpKind::Match => {
                     for _ in 0..op.len {
-                        out.push(RefBase { ref_pos, read_offset: read_off });
+                        out.push(RefBase {
+                            ref_pos,
+                            read_offset: read_off,
+                        });
                         ref_pos += 1;
                         read_off += 1;
                     }
@@ -208,7 +221,15 @@ mod tests {
     #[test]
     fn ref_span_and_end_are_cigar_derived_not_seq_len() {
         // 3M1D2M consumes 6 reference bases from 5 read bases.
-        let r = read(100, vec![op(CigarOpKind::Match, 3), op(CigarOpKind::Deletion, 1), op(CigarOpKind::Match, 2)], b"ACGTT");
+        let r = read(
+            100,
+            vec![
+                op(CigarOpKind::Match, 3),
+                op(CigarOpKind::Deletion, 1),
+                op(CigarOpKind::Match, 2),
+            ],
+            b"ACGTT",
+        );
         assert_eq!(r.ref_span(), 6);
         assert_eq!(r.end(), 106);
     }
@@ -234,19 +255,33 @@ mod tests {
         assert_eq!(
             pairs,
             vec![
-                (50, 2), (51, 3), (52, 4), // first 3M
-                (53, 6), (54, 7),          // 2M after the 1I (read offset skips 5)
-                (56, 8), (57, 9),          // 2M after the 1D (ref skips 55)
+                (50, 2),
+                (51, 3),
+                (52, 4), // first 3M
+                (53, 6),
+                (54, 7), // 2M after the 1I (read offset skips 5)
+                (56, 8),
+                (57, 9), // 2M after the 1D (ref skips 55)
             ]
         );
         // Soft-clipped and inserted read bases never appear in the projection.
-        assert!(!pairs.iter().any(|(_, off)| *off == 0 || *off == 1 || *off == 5));
+        assert!(!pairs
+            .iter()
+            .any(|(_, off)| *off == 0 || *off == 1 || *off == 5));
     }
 
     #[test]
     fn refskip_consumes_reference_only_like_a_long_intron() {
         // 2M 100N 2M (spliced long read): ref advances over the skip, no bases there.
-        let r = read(0, vec![op(CigarOpKind::Match, 2), op(CigarOpKind::RefSkip, 100), op(CigarOpKind::Match, 2)], b"ACGT");
+        let r = read(
+            0,
+            vec![
+                op(CigarOpKind::Match, 2),
+                op(CigarOpKind::RefSkip, 100),
+                op(CigarOpKind::Match, 2),
+            ],
+            b"ACGT",
+        );
         let proj = r.projected_bases();
         assert_eq!(proj.first().unwrap().ref_pos, 0);
         assert_eq!(proj.last().unwrap().ref_pos, 103);
@@ -261,8 +296,20 @@ mod tests {
         let r = read(1000, vec![op(CigarOpKind::Match, 5000)], &seq);
         let proj = r.projected_bases();
         assert_eq!(proj.len(), 5000);
-        assert_eq!(proj[0], RefBase { ref_pos: 1000, read_offset: 0 });
-        assert_eq!(proj[4999], RefBase { ref_pos: 5999, read_offset: 4999 });
+        assert_eq!(
+            proj[0],
+            RefBase {
+                ref_pos: 1000,
+                read_offset: 0
+            }
+        );
+        assert_eq!(
+            proj[4999],
+            RefBase {
+                ref_pos: 5999,
+                read_offset: 4999
+            }
+        );
     }
 
     #[test]
@@ -285,8 +332,20 @@ mod tests {
     #[test]
     fn pad_consumes_neither_ref_nor_read() {
         // 2M 1P 2M — padding advances neither cursor.
-        let r = read(0, vec![op(CigarOpKind::Match, 2), op(CigarOpKind::Pad, 1), op(CigarOpKind::Match, 2)], b"ACGT");
-        let pairs: Vec<(u32, usize)> = r.projected_bases().iter().map(|p| (p.ref_pos, p.read_offset)).collect();
+        let r = read(
+            0,
+            vec![
+                op(CigarOpKind::Match, 2),
+                op(CigarOpKind::Pad, 1),
+                op(CigarOpKind::Match, 2),
+            ],
+            b"ACGT",
+        );
+        let pairs: Vec<(u32, usize)> = r
+            .projected_bases()
+            .iter()
+            .map(|p| (p.ref_pos, p.read_offset))
+            .collect();
         assert_eq!(pairs, vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
         assert_eq!(r.ref_span(), 4);
         assert!(!CigarOpKind::Pad.consumes_ref());

--- a/src/core/record.rs
+++ b/src/core/record.rs
@@ -24,6 +24,8 @@ pub enum CigarOpKind {
     SoftClip,
     /// Hard clip (`H`): trimmed bases absent from the read; consumes neither.
     HardClip,
+    /// Padding (`P`): silent deletion from a padded/MSA reference; consumes neither.
+    Pad,
 }
 
 impl CigarOpKind {
@@ -151,6 +153,12 @@ impl AlignedRead {
     /// Insertions/soft-clips consume read only; deletions/ref-skips consume ref
     /// only; hard-clips consume neither. This is the single CIGAR projection the
     /// pileup kernel consumes.
+    ///
+    /// `Match` here is SAM `M`/`=`/`X`. `read_offset` is derived from the CIGAR
+    /// only and is NOT bounds-checked against `seq.len()`; the caller (e.g. the
+    /// Phase-A2 BAM source adapter) must ensure the read-consuming CIGAR length
+    /// equals `seq.len()`. Coordinate arithmetic is unchecked `u32` and assumes a
+    /// well-formed CIGAR — validation is the read-source's responsibility.
     pub fn projected_bases(&self) -> Vec<RefBase> {
         let mut out = Vec::new();
         let mut ref_pos = self.pos.0;
@@ -170,7 +178,7 @@ impl AlignedRead {
                 CigarOpKind::Deletion | CigarOpKind::RefSkip => {
                     ref_pos += op.len;
                 }
-                CigarOpKind::HardClip => {}
+                CigarOpKind::HardClip | CigarOpKind::Pad => {}
             }
         }
         out
@@ -264,5 +272,34 @@ mod tests {
         assert!(f.is_duplicate());
         assert!(!f.is_secondary());
         assert!(!f.is_unmapped());
+    }
+
+    #[test]
+    fn empty_cigar_projects_nothing() {
+        let r = read(100, vec![], b"");
+        assert!(r.projected_bases().is_empty());
+        assert_eq!(r.ref_span(), 0);
+        assert_eq!(r.end(), 100);
+    }
+
+    #[test]
+    fn pad_consumes_neither_ref_nor_read() {
+        // 2M 1P 2M — padding advances neither cursor.
+        let r = read(0, vec![op(CigarOpKind::Match, 2), op(CigarOpKind::Pad, 1), op(CigarOpKind::Match, 2)], b"ACGT");
+        let pairs: Vec<(u32, usize)> = r.projected_bases().iter().map(|p| (p.ref_pos, p.read_offset)).collect();
+        assert_eq!(pairs, vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
+        assert_eq!(r.ref_span(), 4);
+        assert!(!CigarOpKind::Pad.consumes_ref());
+        assert!(!CigarOpKind::Pad.consumes_read());
+    }
+
+    #[test]
+    fn projection_offsets_follow_cigar_not_seq_len() {
+        // Contract: read_offset comes from the CIGAR, NOT from seq.len().
+        // Here the read-consuming CIGAR length (3) exceeds seq.len() (2);
+        // projection still emits CIGAR-derived offsets 0,1,2 (caller owns bounds-checking).
+        let r = read(10, vec![op(CigarOpKind::Match, 3)], b"AC");
+        let offsets: Vec<usize> = r.projected_bases().iter().map(|p| p.read_offset).collect();
+        assert_eq!(offsets, vec![0, 1, 2]);
     }
 }

--- a/src/core/record.rs
+++ b/src/core/record.rs
@@ -1,0 +1,268 @@
+//! The canonical aligned-read record and CIGAR projection.
+//!
+//! SEQ is stored forward-reference-oriented (as in SAM/BAM); strand is
+//! metadata and is never applied to the bytes. Records are read-length-
+//! agnostic — short Illumina reads and long Nanopore/PacBio reads are handled
+//! identically.
+
+use std::sync::Arc;
+
+use crate::core::locus::Position;
+
+/// CIGAR operation kind (SAM). Consuming semantics follow the SAM spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CigarOpKind {
+    /// Alignment match or mismatch (`M`/`=`/`X`): consumes ref and read.
+    Match,
+    /// Insertion to the reference (`I`): consumes read only.
+    Insertion,
+    /// Deletion from the reference (`D`): consumes ref only.
+    Deletion,
+    /// Skipped reference region (`N`, e.g. an intron): consumes ref only.
+    RefSkip,
+    /// Soft clip (`S`): read bases present but unaligned; consumes read only.
+    SoftClip,
+    /// Hard clip (`H`): trimmed bases absent from the read; consumes neither.
+    HardClip,
+}
+
+impl CigarOpKind {
+    /// Whether this op consumes reference bases.
+    pub fn consumes_ref(self) -> bool {
+        matches!(self, CigarOpKind::Match | CigarOpKind::Deletion | CigarOpKind::RefSkip)
+    }
+
+    /// Whether this op consumes read/query bases.
+    pub fn consumes_read(self) -> bool {
+        matches!(self, CigarOpKind::Match | CigarOpKind::Insertion | CigarOpKind::SoftClip)
+    }
+}
+
+/// A single CIGAR operation with its run length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CigarOp {
+    /// The operation kind.
+    pub kind: CigarOpKind,
+    /// Number of bases the operation spans.
+    pub len: u32,
+}
+
+impl CigarOp {
+    /// Construct a CIGAR operation.
+    pub fn new(kind: CigarOpKind, len: u32) -> Self {
+        Self { kind, len }
+    }
+}
+
+/// SAM flag bitset (the subset Rosalind uses).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SamFlags(pub u16);
+
+impl SamFlags {
+    /// Template has multiple segments (paired).
+    pub const PAIRED: u16 = 0x1;
+    /// Each segment properly aligned (proper pair).
+    pub const PROPER_PAIR: u16 = 0x2;
+    /// Segment unmapped.
+    pub const UNMAPPED: u16 = 0x4;
+    /// Segment reverse-strand.
+    pub const REVERSE: u16 = 0x10;
+    /// Secondary alignment.
+    pub const SECONDARY: u16 = 0x100;
+    /// PCR or optical duplicate.
+    pub const DUPLICATE: u16 = 0x400;
+    /// Supplementary alignment.
+    pub const SUPPLEMENTARY: u16 = 0x800;
+
+    /// Whether the given flag bit is set.
+    pub fn contains(self, bit: u16) -> bool {
+        self.0 & bit != 0
+    }
+
+    /// Segment is unmapped.
+    pub fn is_unmapped(self) -> bool {
+        self.contains(Self::UNMAPPED)
+    }
+
+    /// Segment maps to the reverse strand (metadata only — SEQ stays forward).
+    pub fn is_reverse(self) -> bool {
+        self.contains(Self::REVERSE)
+    }
+
+    /// Alignment is secondary.
+    pub fn is_secondary(self) -> bool {
+        self.contains(Self::SECONDARY)
+    }
+
+    /// Alignment is supplementary.
+    pub fn is_supplementary(self) -> bool {
+        self.contains(Self::SUPPLEMENTARY)
+    }
+
+    /// Read is a PCR/optical duplicate.
+    pub fn is_duplicate(self) -> bool {
+        self.contains(Self::DUPLICATE)
+    }
+}
+
+/// One projected base: a read base aligned to a specific reference position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefBase {
+    /// 0-based reference position.
+    pub ref_pos: u32,
+    /// Offset of the base within the read's `seq`/`qual`.
+    pub read_offset: usize,
+}
+
+/// A read aligned to a single contig.
+///
+/// `seq` is uppercase ASCII in forward-reference orientation; `pos` is the
+/// 0-based leftmost reference coordinate. Read-length-agnostic.
+#[derive(Debug, Clone)]
+pub struct AlignedRead {
+    /// Contig id (index into the originating `ContigSet`).
+    pub contig: u32,
+    /// 0-based leftmost reference coordinate.
+    pub pos: Position,
+    /// Mapping quality (Phred-scaled).
+    pub mapq: u8,
+    /// SAM flags.
+    pub flags: SamFlags,
+    /// CIGAR describing the alignment.
+    pub cigar: Vec<CigarOp>,
+    /// Read sequence, uppercase ASCII, forward orientation.
+    pub seq: Arc<[u8]>,
+    /// Per-base Phred qualities (parallel to `seq`).
+    pub qual: Arc<[u8]>,
+}
+
+impl AlignedRead {
+    /// Reference bases spanned by the alignment (sum of ref-consuming ops).
+    pub fn ref_span(&self) -> u32 {
+        self.cigar.iter().filter(|o| o.kind.consumes_ref()).map(|o| o.len).sum()
+    }
+
+    /// Half-open reference end coordinate. CIGAR-derived — never `pos + seq_len`.
+    pub fn end(&self) -> u32 {
+        self.pos.0 + self.ref_span()
+    }
+
+    /// Project each `Match` base to its reference position by walking the CIGAR.
+    /// Insertions/soft-clips consume read only; deletions/ref-skips consume ref
+    /// only; hard-clips consume neither. This is the single CIGAR projection the
+    /// pileup kernel consumes.
+    pub fn projected_bases(&self) -> Vec<RefBase> {
+        let mut out = Vec::new();
+        let mut ref_pos = self.pos.0;
+        let mut read_off: usize = 0;
+        for op in &self.cigar {
+            match op.kind {
+                CigarOpKind::Match => {
+                    for _ in 0..op.len {
+                        out.push(RefBase { ref_pos, read_offset: read_off });
+                        ref_pos += 1;
+                        read_off += 1;
+                    }
+                }
+                CigarOpKind::Insertion | CigarOpKind::SoftClip => {
+                    read_off += op.len as usize;
+                }
+                CigarOpKind::Deletion | CigarOpKind::RefSkip => {
+                    ref_pos += op.len;
+                }
+                CigarOpKind::HardClip => {}
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(kind: CigarOpKind, len: u32) -> CigarOp {
+        CigarOp::new(kind, len)
+    }
+
+    fn read(pos: u32, cigar: Vec<CigarOp>, seq: &[u8]) -> AlignedRead {
+        AlignedRead {
+            contig: 0,
+            pos: Position(pos),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar,
+            seq: Arc::from(seq.to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; seq.len()].into_boxed_slice()),
+        }
+    }
+
+    #[test]
+    fn ref_span_and_end_are_cigar_derived_not_seq_len() {
+        // 3M1D2M consumes 6 reference bases from 5 read bases.
+        let r = read(100, vec![op(CigarOpKind::Match, 3), op(CigarOpKind::Deletion, 1), op(CigarOpKind::Match, 2)], b"ACGTT");
+        assert_eq!(r.ref_span(), 6);
+        assert_eq!(r.end(), 106);
+    }
+
+    #[test]
+    fn projection_handles_softclip_insertion_deletion_refskip() {
+        // 2S 3M 1I 2M 1D 2M; ref starts at 50.
+        // read offsets [0,1]=softclip, [2,3,4]=M, [5]=I, [6,7]=M, (1D no read), [8,9]=M
+        let r = read(
+            50,
+            vec![
+                op(CigarOpKind::SoftClip, 2),
+                op(CigarOpKind::Match, 3),
+                op(CigarOpKind::Insertion, 1),
+                op(CigarOpKind::Match, 2),
+                op(CigarOpKind::Deletion, 1),
+                op(CigarOpKind::Match, 2),
+            ],
+            b"NNACGTTGAA", // 10 bases: 2 clipped + 3 + 1 ins + 2 + 2
+        );
+        let proj = r.projected_bases();
+        let pairs: Vec<(u32, usize)> = proj.iter().map(|p| (p.ref_pos, p.read_offset)).collect();
+        assert_eq!(
+            pairs,
+            vec![
+                (50, 2), (51, 3), (52, 4), // first 3M
+                (53, 6), (54, 7),          // 2M after the 1I (read offset skips 5)
+                (56, 8), (57, 9),          // 2M after the 1D (ref skips 55)
+            ]
+        );
+        // Soft-clipped and inserted read bases never appear in the projection.
+        assert!(!pairs.iter().any(|(_, off)| *off == 0 || *off == 1 || *off == 5));
+    }
+
+    #[test]
+    fn refskip_consumes_reference_only_like_a_long_intron() {
+        // 2M 100N 2M (spliced long read): ref advances over the skip, no bases there.
+        let r = read(0, vec![op(CigarOpKind::Match, 2), op(CigarOpKind::RefSkip, 100), op(CigarOpKind::Match, 2)], b"ACGT");
+        let proj = r.projected_bases();
+        assert_eq!(proj.first().unwrap().ref_pos, 0);
+        assert_eq!(proj.last().unwrap().ref_pos, 103);
+        assert_eq!(proj.len(), 4);
+        assert_eq!(r.ref_span(), 104);
+    }
+
+    #[test]
+    fn long_read_projects_every_match_base() {
+        // Read-length-agnostic: a 5000-base full-match "long read".
+        let seq = vec![b'A'; 5000];
+        let r = read(1000, vec![op(CigarOpKind::Match, 5000)], &seq);
+        let proj = r.projected_bases();
+        assert_eq!(proj.len(), 5000);
+        assert_eq!(proj[0], RefBase { ref_pos: 1000, read_offset: 0 });
+        assert_eq!(proj[4999], RefBase { ref_pos: 5999, read_offset: 4999 });
+    }
+
+    #[test]
+    fn sam_flags_decode_common_bits() {
+        let f = SamFlags(SamFlags::REVERSE | SamFlags::DUPLICATE);
+        assert!(f.is_reverse());
+        assert!(f.is_duplicate());
+        assert!(!f.is_secondary());
+        assert!(!f.is_unmapped());
+    }
+}

--- a/src/core/sequence.rs
+++ b/src/core/sequence.rs
@@ -1,0 +1,94 @@
+//! Canonical DNA base model. Exact bases are A/C/G/T (U folds to T); every
+//! other byte — including IUPAC ambiguity codes — folds to `N` (lossy but
+//! explicit). `N` is not a callable allele.
+
+/// A canonical DNA base. `N` represents any non-ACGT / ambiguous base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaseCode {
+    /// Adenine.
+    A,
+    /// Cytosine.
+    C,
+    /// Guanine.
+    G,
+    /// Thymine (also the fold target for uracil `U`).
+    T,
+    /// Any non-ACGT / ambiguous base.
+    N,
+}
+
+impl BaseCode {
+    /// Allele index 0..=3 for A/C/G/T; `None` for `N` (not a callable allele).
+    pub fn allele_index(self) -> Option<usize> {
+        match self {
+            BaseCode::A => Some(0),
+            BaseCode::C => Some(1),
+            BaseCode::G => Some(2),
+            BaseCode::T => Some(3),
+            BaseCode::N => None,
+        }
+    }
+
+    /// Canonical uppercase ASCII byte for this base.
+    pub fn to_ascii(self) -> u8 {
+        match self {
+            BaseCode::A => b'A',
+            BaseCode::C => b'C',
+            BaseCode::G => b'G',
+            BaseCode::T => b'T',
+            BaseCode::N => b'N',
+        }
+    }
+
+    /// Map an ASCII byte to a `BaseCode`. A/C/G/T (any case) map directly,
+    /// `U`/`u` fold to `T`, and every other byte folds to `N`.
+    pub fn from_ascii_lossy(b: u8) -> BaseCode {
+        match b.to_ascii_uppercase() {
+            b'A' => BaseCode::A,
+            b'C' => BaseCode::C,
+            b'G' => BaseCode::G,
+            b'T' | b'U' => BaseCode::T,
+            _ => BaseCode::N,
+        }
+    }
+
+    /// Whether `b` is a recognized exact base (A/C/G/T/U). Bytes that fold to
+    /// `N` return `false`; callers use this to count ambiguity warnings.
+    pub fn is_exact(b: u8) -> bool {
+        matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'U')
+    }
+}
+
+/// Convenience: allele index 0..=3 for an ASCII base, or `None` for N/other.
+pub fn allele_index(base: u8) -> Option<usize> {
+    BaseCode::from_ascii_lossy(base).allele_index()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_bases_map_directly_and_u_folds_to_t() {
+        assert_eq!(BaseCode::from_ascii_lossy(b'a'), BaseCode::A);
+        assert_eq!(BaseCode::from_ascii_lossy(b'C'), BaseCode::C);
+        assert_eq!(BaseCode::from_ascii_lossy(b'u'), BaseCode::T);
+        assert_eq!(BaseCode::from_ascii_lossy(b'T'), BaseCode::T);
+    }
+
+    #[test]
+    fn ambiguous_and_unknown_fold_to_n_and_are_not_exact() {
+        assert_eq!(BaseCode::from_ascii_lossy(b'R'), BaseCode::N); // IUPAC purine
+        assert_eq!(BaseCode::from_ascii_lossy(b'.'), BaseCode::N);
+        assert!(!BaseCode::is_exact(b'R'));
+        assert!(BaseCode::is_exact(b'g'));
+    }
+
+    #[test]
+    fn allele_index_is_some_for_acgt_and_none_for_n() {
+        assert_eq!(allele_index(b'A'), Some(0));
+        assert_eq!(allele_index(b'T'), Some(3));
+        assert_eq!(allele_index(b'N'), None);
+        assert_eq!(allele_index(b'R'), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub mod algebra; // Algebraic replay engine
 pub mod blocking; // Block-respecting simulation
 /// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
 pub mod core;
+/// The streaming pileup kernel: one CIGAR-aware, filtered, bounded-memory engine.
+pub mod pileup;
 pub mod framework; // Generic compressed evaluation
 pub mod genomics; // Genomics primitives and algorithms
 pub mod ledger; // Streaming progress tracking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 #![allow(clippy::new_without_default)]
 
 // Core modules - each implements a key component of the algorithm
-/// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
-pub mod core;
 pub mod algebra; // Algebraic replay engine
 pub mod blocking; // Block-respecting simulation
+/// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
+pub mod core;
 pub mod framework; // Generic compressed evaluation
 pub mod genomics; // Genomics primitives and algorithms
 pub mod ledger; // Streaming progress tracking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,12 @@ pub mod algebra; // Algebraic replay engine
 pub mod blocking; // Block-respecting simulation
 /// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
 pub mod core;
-/// The streaming pileup kernel: one CIGAR-aware, filtered, bounded-memory engine.
-pub mod pileup;
 pub mod framework; // Generic compressed evaluation
 pub mod genomics; // Genomics primitives and algorithms
 pub mod ledger; // Streaming progress tracking
 pub mod machine; // Turing machine representation
+/// The streaming pileup kernel: one CIGAR-aware, filtered, bounded-memory engine.
+pub mod pileup;
 pub mod plugin; // Plugin system
 /// Python bindings for exposing Rosalind components to external runtimes.
 #[cfg(feature = "python-bindings")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 #![allow(clippy::new_without_default)]
 
 // Core modules - each implements a key component of the algorithm
+/// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
+pub mod core;
 pub mod algebra; // Algebraic replay engine
 pub mod blocking; // Block-respecting simulation
 pub mod framework; // Generic compressed evaluation

--- a/src/pileup/column.rs
+++ b/src/pileup/column.rs
@@ -59,13 +59,21 @@ mod tests {
     use crate::core::Position;
 
     fn obs(allele: u8, reverse: bool) -> Obs {
-        Obs { allele, base_qual: 30, mapq: 60, reverse }
+        Obs {
+            allele,
+            base_qual: 30,
+            mapq: 60,
+            reverse,
+        }
     }
 
     #[test]
     fn depth_allele_and_strand_counts() {
         let col = PileupColumn {
-            locus: Locus { contig: 0, pos: Position(100) },
+            locus: Locus {
+                contig: 0,
+                pos: Position(100),
+            },
             ref_base: b'A',
             obs: vec![obs(0, false), obs(0, true), obs(1, false)],
         };

--- a/src/pileup/column.rs
+++ b/src/pileup/column.rs
@@ -1,0 +1,79 @@
+//! The per-position pileup column and its observations — the public substrate
+//! type produced by `PileupEngine` and consumed by callers and plugins.
+
+use crate::core::Locus;
+
+/// One base observation at a pileup position. Only callable (A/C/G/T) bases are
+/// recorded; `allele` is the 0..=3 index (A=0, C=1, G=2, T=3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Obs {
+    /// Allele index 0..=3 (A/C/G/T).
+    pub allele: u8,
+    /// Base quality (Phred) of the observed base.
+    pub base_qual: u8,
+    /// Mapping quality of the read this observation came from.
+    pub mapq: u8,
+    /// Whether the read maps to the reverse strand (for strand-bias use).
+    pub reverse: bool,
+}
+
+/// All callable observations stacked at a single reference position.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PileupColumn {
+    /// The reference coordinate of this column.
+    pub locus: Locus,
+    /// The reference base at this locus (uppercase ASCII; `b'N'` if unknown).
+    pub ref_base: u8,
+    /// Callable observations, in deterministic (active-read insertion) order.
+    pub obs: Vec<Obs>,
+}
+
+impl PileupColumn {
+    /// Number of callable observations.
+    pub fn depth(&self) -> u32 {
+        self.obs.len() as u32
+    }
+
+    /// Per-allele observation counts, indexed `[A, C, G, T]`.
+    pub fn allele_counts(&self) -> [u32; 4] {
+        let mut counts = [0u32; 4];
+        for o in &self.obs {
+            counts[o.allele as usize] += 1;
+        }
+        counts
+    }
+
+    /// Per-allele, per-strand counts: `[allele][0 = forward, 1 = reverse]`.
+    pub fn strand_counts(&self) -> [[u32; 2]; 4] {
+        let mut counts = [[0u32; 2]; 4];
+        for o in &self.obs {
+            counts[o.allele as usize][o.reverse as usize] += 1;
+        }
+        counts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Position;
+
+    fn obs(allele: u8, reverse: bool) -> Obs {
+        Obs { allele, base_qual: 30, mapq: 60, reverse }
+    }
+
+    #[test]
+    fn depth_allele_and_strand_counts() {
+        let col = PileupColumn {
+            locus: Locus { contig: 0, pos: Position(100) },
+            ref_base: b'A',
+            obs: vec![obs(0, false), obs(0, true), obs(1, false)],
+        };
+        assert_eq!(col.depth(), 3);
+        assert_eq!(col.allele_counts(), [2, 1, 0, 0]);
+        // [allele][0=fwd,1=rev]: A has 1 fwd + 1 rev, C has 1 fwd.
+        let sc = col.strand_counts();
+        assert_eq!(sc[0], [1, 1]);
+        assert_eq!(sc[1], [1, 0]);
+    }
+}

--- a/src/pileup/column.rs
+++ b/src/pileup/column.rs
@@ -24,6 +24,10 @@ pub struct PileupColumn {
     pub locus: Locus,
     /// The reference base at this locus (uppercase ASCII; `b'N'` if unknown).
     pub ref_base: u8,
+    /// Total reads covering this position, including reads whose base is non-ACGT
+    /// or below the base-quality floor (so `raw_depth >= depth()`). Use for DP
+    /// annotation and N-fraction QC; `depth()` reports the callable depth.
+    pub raw_depth: u32,
     /// Callable observations, in deterministic (active-read insertion) order.
     pub obs: Vec<Obs>,
 }
@@ -75,9 +79,11 @@ mod tests {
                 pos: Position(100),
             },
             ref_base: b'A',
+            raw_depth: 4,
             obs: vec![obs(0, false), obs(0, true), obs(1, false)],
         };
         assert_eq!(col.depth(), 3);
+        assert_eq!(col.raw_depth, 4);
         assert_eq!(col.allele_counts(), [2, 1, 0, 0]);
         // [allele][0=fwd,1=rev]: A has 1 fwd + 1 rev, C has 1 fwd.
         let sc = col.strand_counts();

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -142,7 +142,9 @@ impl<S: ReadSource> PileupEngine<S> {
             .iter()
             .map(|r| (r.ref_to_read.len() as u64) * 16 + 64)
             .sum();
-        WorkingSet { bytes: active_bytes + 256 }
+        WorkingSet {
+            bytes: active_bytes + 256,
+        }
     }
 
     /// Whether the read passes flag/MAPQ filters. (Contig routing and the
@@ -256,7 +258,10 @@ impl<S: ReadSource> PileupEngine<S> {
             }
         }
         PileupColumn {
-            locus: Locus { contig: self.contig, pos: Position(self.pos) },
+            locus: Locus {
+                contig: self.contig,
+                pos: Position(self.pos),
+            },
             ref_base,
             obs,
         }
@@ -333,7 +338,10 @@ mod tests {
         let fwd = mread(0, b"AAGAA", false);
         let rev = mread(0, b"AAGAA", true);
         let cols = columns(engine(vec![fwd, rev], reference));
-        let at2 = cols.iter().find(|c| c.locus.pos.0 == 2).expect("column at pos 2");
+        let at2 = cols
+            .iter()
+            .find(|c| c.locus.pos.0 == 2)
+            .expect("column at pos 2");
         // Both observe G (allele 2); none observe C (allele 1, the complement of G).
         assert_eq!(at2.allele_counts(), [0, 0, 2, 0]);
     }
@@ -403,12 +411,16 @@ mod tests {
             qual: Arc::from(vec![30u8; 5].into_boxed_slice()),
         };
         let cols = columns(engine(vec![read], reference));
-        let get = |p: u32| cols.iter().find(|c| c.locus.pos.0 == p).map(|c| c.allele_counts());
+        let get = |p: u32| {
+            cols.iter()
+                .find(|c| c.locus.pos.0 == p)
+                .map(|c| c.allele_counts())
+        };
         assert_eq!(get(10), Some([0, 1, 0, 0])); // C (offset 0)
         assert_eq!(get(11), Some([0, 1, 0, 0])); // C (offset 1)
         assert_eq!(get(12), Some([0, 0, 1, 0])); // G (offset 3 — NOT the inserted 'A')
         assert_eq!(get(13), Some([0, 0, 0, 1])); // T (offset 4)
-        // The inserted 'A' (offset 2) appears at no reference position.
+                                                 // The inserted 'A' (offset 2) appears at no reference position.
         assert!(cols.iter().all(|c| c.allele_counts()[0] == 0));
     }
 
@@ -510,7 +522,10 @@ mod tests {
         let mut low = mread(0, b"GGGGG", false);
         low.mapq = 3;
         let reads = vec![mread(0, b"CCCCC", false), low];
-        let params = PileupParams { min_mapq: 10, ..PileupParams::default() };
+        let params = PileupParams {
+            min_mapq: 10,
+            ..PileupParams::default()
+        };
         let mut e = PileupEngine::new(
             SliceSource::new(reads),
             Arc::from(reference.to_vec().into_boxed_slice()),
@@ -531,7 +546,10 @@ mod tests {
         let reference = b"AAAAA";
         let mut r = mread(0, b"GGGGG", false);
         r.qual = Arc::from(vec![2u8; 5].into_boxed_slice()); // below the floor
-        let params = PileupParams { min_base_qual: 20, ..PileupParams::default() };
+        let params = PileupParams {
+            min_base_qual: 20,
+            ..PileupParams::default()
+        };
         let mut e = PileupEngine::new(
             SliceSource::new(vec![r]),
             Arc::from(reference.to_vec().into_boxed_slice()),
@@ -567,6 +585,43 @@ mod tests {
             assert!(ws.fits(budget), "working set {} exceeded 1 MiB", ws.bytes);
         }
         // Sanity: peak working set is far below holding all reads would cost.
-        assert!(max_ws < 64 * 1024, "peak working set unexpectedly large: {max_ws}");
+        assert!(
+            max_ws < 64 * 1024,
+            "peak working set unexpectedly large: {max_ws}"
+        );
+    }
+
+    #[test]
+    fn shuffled_source_yields_identical_columns() {
+        // SliceSource sorts on construction, so a shuffled input must produce the
+        // exact same column sequence (deterministic output).
+        let reference = b"ACGTACGTACGT";
+        let make = |order: Vec<(u32, &'static [u8])>| {
+            let reads: Vec<AlignedRead> =
+                order.into_iter().map(|(p, s)| mread(p, s, false)).collect();
+            columns(engine(reads, reference))
+        };
+        let a = make(vec![(0, b"AAAA"), (4, b"CCCC"), (8, b"GGGG")]);
+        let b = make(vec![(8, b"GGGG"), (0, b"AAAA"), (4, b"CCCC")]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn engine_is_an_open_substrate_for_arbitrary_per_locus_analysis() {
+        // A non-caller consumer: compute per-position coverage directly from the
+        // PileupColumn stream — no variant calling involved.
+        let reference = b"AAAAAAAA";
+        let reads = vec![mread(0, b"CCCC", false), mread(2, b"CCCC", false)];
+        let mut coverage = Vec::new();
+        let mut e = engine(reads, reference);
+        while let Some(c) = e.next() {
+            let col = c.unwrap();
+            coverage.push((col.locus.pos.0, col.depth()));
+        }
+        // pos 0,1 depth 1; pos 2,3 depth 2; pos 4,5 depth 1.
+        assert_eq!(
+            coverage,
+            vec![(0, 1), (1, 1), (2, 2), (3, 2), (4, 1), (5, 1)]
+        );
     }
 }

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -1,7 +1,5 @@
 //! The streaming pileup engine: CIGAR-aware, read-filtered, strand-aware,
 //! bounded-memory. Yields one `PileupColumn` per covered reference position.
-//!
-//! (The engine's imports are added in Task 4, alongside the engine itself.)
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -235,13 +233,18 @@ impl<S: ReadSource> PileupEngine<S> {
 
     /// Build the column at the current cursor from the active set.
     fn build_column(&self) -> PileupColumn {
+        // The cursor starts at region.start and only increments, so this
+        // subtraction cannot underflow.
+        debug_assert!(self.pos >= self.region.start);
         let ref_idx = (self.pos - self.region.start) as usize;
         let ref_base = self.reference.get(ref_idx).copied().unwrap_or(b'N');
         let mut obs = Vec::new();
         for r in &self.active {
             if let Some(&off) = r.ref_to_read.get(&self.pos) {
                 // Forward orientation — read the stored SEQ byte directly. No
-                // complement (this is the reverse-strand fix).
+                // complement (this is the reverse-strand fix). `off` is CIGAR-
+                // derived and not bounds-checked against seq.len() (per the
+                // RefBase contract), so a malformed read folds to N, not a panic.
                 let base = r.seq.get(off).copied().unwrap_or(b'N');
                 let bq = r.qual.get(off).copied().unwrap_or(0);
                 if bq < self.params.min_base_qual {

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -3,6 +3,14 @@
 //!
 //! (The engine's imports are added in Task 4, alongside the engine itself.)
 
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+
+use crate::core::{allele_index, AlignedRead, CoreError, Locus, Position};
+use crate::pileup::column::{Obs, PileupColumn};
+use crate::pileup::source::ReadSource;
+
 /// Read-level filters applied as reads enter the pileup.
 #[derive(Debug, Clone)]
 pub struct PileupParams {
@@ -59,9 +67,271 @@ impl SkipCounts {
     }
 }
 
+/// A read currently overlapping the cursor, with its CIGAR projection precomputed.
+#[derive(Debug)]
+struct ActiveRead {
+    /// Half-open reference end (CIGAR-derived) — used to expire the read.
+    end: u32,
+    /// Map from reference position to read offset for this read's Match bases.
+    ref_to_read: HashMap<u32, usize>,
+    /// Read sequence (forward-reference orientation).
+    seq: Arc<[u8]>,
+    /// Per-base qualities (parallel to `seq`).
+    qual: Arc<[u8]>,
+    /// Mapping quality.
+    mapq: u8,
+    /// Reverse-strand flag (metadata only — never applied to `seq`).
+    reverse: bool,
+}
+
+/// Streaming, CIGAR-aware, bounded-memory pileup over one contig region.
+///
+/// Yields one [`PileupColumn`] per covered reference position. The working set
+/// is bounded by local read coverage, not by input size.
+#[derive(Debug)]
+pub struct PileupEngine<S: ReadSource> {
+    source: S,
+    reference: Arc<[u8]>,
+    contig: u32,
+    region: Range<u32>,
+    params: PileupParams,
+    active: Vec<ActiveRead>,
+    next_read: Option<AlignedRead>,
+    pos: u32,
+    skips: SkipCounts,
+    source_done: bool,
+}
+
+impl<S: ReadSource> PileupEngine<S> {
+    /// Create an engine over `reference` bytes for `contig`, covering `region`
+    /// (0-based half-open; `reference[0]` is the base at `region.start`).
+    pub fn new(
+        source: S,
+        reference: Arc<[u8]>,
+        contig: u32,
+        region: Range<u32>,
+        params: PileupParams,
+    ) -> Self {
+        let pos = region.start;
+        Self {
+            source,
+            reference,
+            contig,
+            region,
+            params,
+            active: Vec::new(),
+            next_read: None,
+            pos,
+            skips: SkipCounts::default(),
+            source_done: false,
+        }
+    }
+
+    /// Reads skipped so far, by reason. Final after iteration completes.
+    pub fn skip_counts(&self) -> SkipCounts {
+        self.skips
+    }
+
+    /// Whether the read passes flag/MAPQ filters (contig + unmapped handled in
+    /// `advance_to`). Filtering is implemented in Task 6; here it accepts every read.
+    fn passes_filters(&mut self, _read: &AlignedRead) -> bool {
+        true
+    }
+
+    /// Precompute a read's reference→read-offset map and add it to the active set.
+    fn ingest(&mut self, read: AlignedRead) {
+        let end = read.end();
+        let mut ref_to_read = HashMap::new();
+        for rb in read.projected_bases() {
+            ref_to_read.insert(rb.ref_pos, rb.read_offset);
+        }
+        self.active.push(ActiveRead {
+            end,
+            ref_to_read,
+            seq: Arc::clone(&read.seq),
+            qual: Arc::clone(&read.qual),
+            mapq: read.mapq,
+            reverse: read.flags.is_reverse(),
+        });
+    }
+
+    /// Expire reads that no longer cover `pos`, then pull in reads starting at or
+    /// before `pos`. Reads are coordinate-sorted, so we stop at the first read
+    /// that starts after `pos` on the target contig.
+    fn advance_to(&mut self, pos: u32) -> Result<(), CoreError> {
+        self.active.retain(|r| r.end > pos);
+        loop {
+            if self.next_read.is_none() && !self.source_done {
+                match self.source.next_read()? {
+                    Some(r) => self.next_read = Some(r),
+                    None => self.source_done = true,
+                }
+            }
+            // Peek the routing fields without holding a borrow across `take`.
+            let (rc, rp, unmapped) = match self.next_read.as_ref() {
+                Some(r) => (r.contig, r.pos.0, r.flags.is_unmapped()),
+                None => break,
+            };
+            if unmapped {
+                self.next_read.take();
+                self.skips.unmapped += 1;
+                continue;
+            }
+            match rc.cmp(&self.contig) {
+                std::cmp::Ordering::Greater => break, // sorted: no more target-contig reads
+                std::cmp::Ordering::Less => {
+                    self.next_read.take();
+                    self.skips.wrong_contig += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if rp > pos {
+                        break; // future read on our contig
+                    }
+                    let read = self.next_read.take().unwrap();
+                    if !self.passes_filters(&read) {
+                        continue;
+                    }
+                    if read.end() <= pos {
+                        continue; // does not reach the cursor
+                    }
+                    self.ingest(read);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the column at the current cursor from the active set.
+    fn build_column(&self) -> PileupColumn {
+        let ref_idx = (self.pos - self.region.start) as usize;
+        let ref_base = self.reference.get(ref_idx).copied().unwrap_or(b'N');
+        let mut obs = Vec::new();
+        for r in &self.active {
+            if let Some(&off) = r.ref_to_read.get(&self.pos) {
+                // Forward orientation — read the stored SEQ byte directly. No
+                // complement (this is the reverse-strand fix).
+                let base = r.seq.get(off).copied().unwrap_or(b'N');
+                let bq = r.qual.get(off).copied().unwrap_or(0);
+                if bq < self.params.min_base_qual {
+                    continue;
+                }
+                if let Some(allele) = allele_index(base) {
+                    obs.push(Obs {
+                        allele: allele as u8,
+                        base_qual: bq,
+                        mapq: r.mapq,
+                        reverse: r.reverse,
+                    });
+                }
+            }
+        }
+        PileupColumn {
+            locus: Locus { contig: self.contig, pos: Position(self.pos) },
+            ref_base,
+            obs,
+        }
+    }
+}
+
+impl<S: ReadSource> Iterator for PileupEngine<S> {
+    type Item = Result<PileupColumn, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Loop over empty positions (no recursion → bounded stack, any gap size).
+        while self.pos < self.region.end {
+            let pos = self.pos;
+            if let Err(e) = self.advance_to(pos) {
+                self.pos = self.region.end;
+                return Some(Err(e));
+            }
+            let column = self.build_column();
+            self.pos += 1;
+            if !column.obs.is_empty() {
+                return Some(Ok(column));
+            }
+        }
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{CigarOp, CigarOpKind, SamFlags};
+    use crate::pileup::source::SliceSource;
+
+    // A fully-matched read at `pos` on contig 0 carrying `seq` (forward orientation).
+    fn mread(pos: u32, seq: &[u8], reverse: bool) -> AlignedRead {
+        let mut flags = SamFlags::default();
+        if reverse {
+            flags = SamFlags(SamFlags::REVERSE);
+        }
+        AlignedRead {
+            contig: 0,
+            pos: Position(pos),
+            mapq: 60,
+            flags,
+            cigar: vec![CigarOp::new(CigarOpKind::Match, seq.len() as u32)],
+            seq: Arc::from(seq.to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; seq.len()].into_boxed_slice()),
+        }
+    }
+
+    fn engine(reads: Vec<AlignedRead>, reference: &[u8]) -> PileupEngine<SliceSource> {
+        PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..reference.len() as u32,
+            PileupParams::default(),
+        )
+    }
+
+    fn columns(mut e: PileupEngine<SliceSource>) -> Vec<PileupColumn> {
+        let mut out = Vec::new();
+        while let Some(c) = e.next() {
+            out.push(c.expect("pileup column"));
+        }
+        out
+    }
+
+    #[test]
+    fn reverse_strand_reads_are_not_complemented() {
+        // Regression: forward and reverse-strand reads carrying the SAME forward
+        // SEQ must contribute the SAME allele (legacy code complemented reverse reads).
+        let reference = b"AAAAA";
+        let fwd = mread(0, b"AAGAA", false);
+        let rev = mread(0, b"AAGAA", true);
+        let cols = columns(engine(vec![fwd, rev], reference));
+        let at2 = cols.iter().find(|c| c.locus.pos.0 == 2).expect("column at pos 2");
+        // Both observe G (allele 2); none observe C (allele 1, the complement of G).
+        assert_eq!(at2.allele_counts(), [0, 0, 2, 0]);
+    }
+
+    #[test]
+    fn basic_ungapped_pileup_counts() {
+        let reference = b"ACGTACGT";
+        let reads = vec![mread(0, b"ACGT", false), mread(2, b"GTAC", false)];
+        let cols = columns(engine(reads, reference));
+        let at2 = cols.iter().find(|c| c.locus.pos.0 == 2).unwrap();
+        assert_eq!(at2.depth(), 2);
+        assert_eq!(at2.ref_base, b'G');
+        assert_eq!(at2.allele_counts(), [0, 0, 2, 0]);
+        assert!(cols.iter().all(|c| c.depth() > 0));
+    }
+
+    #[test]
+    fn sparse_coverage_skips_empty_positions_without_recursion() {
+        // A huge gap between two reads must not overflow the stack (loop, not recursion).
+        let mut reference = vec![b'A'; 100_000];
+        reference[0] = b'C';
+        reference[99_999] = b'C';
+        let reads = vec![mread(0, b"C", false), mread(99_999, b"C", false)];
+        let cols = columns(engine(reads, &reference));
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].locus.pos.0, 0);
+        assert_eq!(cols[1].locus.pos.0, 99_999);
+    }
 
     #[test]
     fn default_params_skip_noise_and_keep_quality_open() {

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -353,4 +353,98 @@ mod tests {
         };
         assert_eq!(s.total(), 21);
     }
+
+    #[test]
+    fn insertion_bases_do_not_shift_downstream_reference_positions() {
+        // 2M 1I 2M at ref 10: offsets 0,1 -> ref 10,11; offset 2 = inserted (no ref);
+        // offsets 3,4 -> ref 12,13.  seq "CCAGT": the inserted base is 'A' (offset 2).
+        let reference = b"AAAAAAAAAAAAAAAA"; // 16 'A'
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(10),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Insertion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"CCAGT".to_vec().into_boxed_slice()), // off: C C A(ins) G T
+            qual: Arc::from(vec![30u8; 5].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        let get = |p: u32| cols.iter().find(|c| c.locus.pos.0 == p).map(|c| c.allele_counts());
+        assert_eq!(get(10), Some([0, 1, 0, 0])); // C (offset 0)
+        assert_eq!(get(11), Some([0, 1, 0, 0])); // C (offset 1)
+        assert_eq!(get(12), Some([0, 0, 1, 0])); // G (offset 3 — NOT the inserted 'A')
+        assert_eq!(get(13), Some([0, 0, 0, 1])); // T (offset 4)
+        // The inserted 'A' (offset 2) appears at no reference position.
+        assert!(cols.iter().all(|c| c.allele_counts()[0] == 0));
+    }
+
+    #[test]
+    fn deletion_leaves_a_reference_gap_with_no_observation() {
+        // 2M 1D 2M at ref 0: ref 0,1 observed; ref 2 deleted (no obs); ref 3,4 observed.
+        let reference = b"AAAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(0),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Deletion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"GGGG".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![0, 1, 3, 4]); // ref 2 (deleted) emits no column
+    }
+
+    #[test]
+    fn soft_clipped_bases_are_excluded() {
+        // 2S 3M at ref 1: first 2 read bases clipped; only the 3 matched bases pile up.
+        let reference = b"AAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(1),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::SoftClip, 2),
+                CigarOp::new(CigarOpKind::Match, 3),
+            ],
+            seq: Arc::from(b"TTCGA".to_vec().into_boxed_slice()), // TT clipped; CGA -> ref 1,2,3
+            qual: Arc::from(vec![30u8; 5].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![1, 2, 3]);
+        let at1 = cols.iter().find(|c| c.locus.pos.0 == 1).unwrap();
+        assert_eq!(at1.allele_counts(), [0, 1, 0, 0]); // 'C' (offset 2), not the clipped 'T'
+    }
+
+    #[test]
+    fn long_read_piles_up_every_matched_base() {
+        // Read-length-agnostic: a 5000-base full-match read covers 5000 positions.
+        let reference = vec![b'A'; 6000];
+        let seq = vec![b'C'; 5000];
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(1000),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![CigarOp::new(CigarOpKind::Match, 5000)],
+            seq: Arc::from(seq.into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 5000].into_boxed_slice()),
+        };
+        let cols = columns(engine(vec![read], &reference));
+        assert_eq!(cols.len(), 5000);
+        assert_eq!(cols.first().unwrap().locus.pos.0, 1000);
+        assert_eq!(cols.last().unwrap().locus.pos.0, 5999);
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+    }
 }

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -239,8 +239,10 @@ impl<S: ReadSource> PileupEngine<S> {
         let ref_idx = (self.pos - self.region.start) as usize;
         let ref_base = self.reference.get(ref_idx).copied().unwrap_or(b'N');
         let mut obs = Vec::new();
+        let mut raw_depth: u32 = 0;
         for r in &self.active {
             if let Some(&off) = r.ref_to_read.get(&self.pos) {
+                raw_depth += 1;
                 // Forward orientation — read the stored SEQ byte directly. No
                 // complement (this is the reverse-strand fix). `off` is CIGAR-
                 // derived and not bounds-checked against seq.len() (per the
@@ -266,6 +268,7 @@ impl<S: ReadSource> PileupEngine<S> {
                 pos: Position(self.pos),
             },
             ref_base,
+            raw_depth,
             obs,
         }
     }
@@ -626,5 +629,18 @@ mod tests {
             coverage,
             vec![(0, 1), (1, 1), (2, 2), (3, 2), (4, 1), (5, 1)]
         );
+    }
+
+    #[test]
+    fn raw_depth_counts_covering_reads_even_when_base_is_dropped() {
+        // Two reads cover ref 0; one carries 'N' (not a callable allele), so it is
+        // excluded from obs/depth() but still counted in raw_depth.
+        let reference = b"AA";
+        let reads = vec![mread(0, b"C", false), mread(0, b"N", false)];
+        let cols = columns(engine(reads, reference));
+        let at0 = cols.iter().find(|c| c.locus.pos.0 == 0).unwrap();
+        assert_eq!(at0.depth(), 1); // only the callable 'C'
+        assert_eq!(at0.allele_counts(), [0, 1, 0, 0]);
+        assert_eq!(at0.raw_depth, 2); // both reads cover the position
     }
 }

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -1,0 +1,86 @@
+//! The streaming pileup engine: CIGAR-aware, read-filtered, strand-aware,
+//! bounded-memory. Yields one `PileupColumn` per covered reference position.
+//!
+//! (The engine's imports are added in Task 4, alongside the engine itself.)
+
+/// Read-level filters applied as reads enter the pileup.
+#[derive(Debug, Clone)]
+pub struct PileupParams {
+    /// Minimum mapping quality; reads below this are skipped.
+    pub min_mapq: u8,
+    /// Minimum base quality; observations below this are dropped.
+    pub min_base_qual: u8,
+    /// Skip secondary alignments (SAM flag 0x100).
+    pub skip_secondary: bool,
+    /// Skip supplementary alignments (SAM flag 0x800).
+    pub skip_supplementary: bool,
+    /// Skip PCR/optical duplicates (SAM flag 0x400).
+    pub skip_duplicate: bool,
+}
+
+impl Default for PileupParams {
+    fn default() -> Self {
+        Self {
+            min_mapq: 0,
+            min_base_qual: 0,
+            skip_secondary: true,
+            skip_supplementary: true,
+            skip_duplicate: true,
+        }
+    }
+}
+
+/// Counts of reads skipped during pileup, by reason (surfaced to callers/CLI).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SkipCounts {
+    /// Reads with the unmapped flag set.
+    pub unmapped: u64,
+    /// Reads on a contig other than the target.
+    pub wrong_contig: u64,
+    /// Secondary alignments skipped.
+    pub secondary: u64,
+    /// Supplementary alignments skipped.
+    pub supplementary: u64,
+    /// Duplicate reads skipped.
+    pub duplicate: u64,
+    /// Reads below the MAPQ threshold.
+    pub low_mapq: u64,
+}
+
+impl SkipCounts {
+    /// Total reads skipped across all reasons.
+    pub fn total(&self) -> u64 {
+        self.unmapped
+            + self.wrong_contig
+            + self.secondary
+            + self.supplementary
+            + self.duplicate
+            + self.low_mapq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_params_skip_noise_and_keep_quality_open() {
+        let p = PileupParams::default();
+        assert!(p.skip_secondary && p.skip_supplementary && p.skip_duplicate);
+        assert_eq!(p.min_mapq, 0);
+        assert_eq!(p.min_base_qual, 0);
+    }
+
+    #[test]
+    fn skip_counts_total_sums_all_reasons() {
+        let s = SkipCounts {
+            unmapped: 1,
+            wrong_contig: 2,
+            secondary: 3,
+            supplementary: 4,
+            duplicate: 5,
+            low_mapq: 6,
+        };
+        assert_eq!(s.total(), 21);
+    }
+}

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -132,9 +132,26 @@ impl<S: ReadSource> PileupEngine<S> {
         self.skips
     }
 
-    /// Whether the read passes flag/MAPQ filters (contig + unmapped handled in
-    /// `advance_to`). Filtering is implemented in Task 6; here it accepts every read.
-    fn passes_filters(&mut self, _read: &AlignedRead) -> bool {
+    /// Whether the read passes flag/MAPQ filters. (Contig routing and the
+    /// unmapped flag are handled in `advance_to`.)
+    fn passes_filters(&mut self, read: &AlignedRead) -> bool {
+        let f = read.flags;
+        if self.params.skip_secondary && f.is_secondary() {
+            self.skips.secondary += 1;
+            return false;
+        }
+        if self.params.skip_supplementary && f.is_supplementary() {
+            self.skips.supplementary += 1;
+            return false;
+        }
+        if self.params.skip_duplicate && f.is_duplicate() {
+            self.skips.duplicate += 1;
+            return false;
+        }
+        if read.mapq < self.params.min_mapq {
+            self.skips.low_mapq += 1;
+            return false;
+        }
         true
     }
 
@@ -446,5 +463,70 @@ mod tests {
         assert_eq!(cols.first().unwrap().locus.pos.0, 1000);
         assert_eq!(cols.last().unwrap().locus.pos.0, 5999);
         assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+    }
+
+    fn flagged_read(pos: u32, seq: &[u8], flag_bits: u16) -> AlignedRead {
+        let mut r = mread(pos, seq, false);
+        r.flags = SamFlags(flag_bits);
+        r
+    }
+
+    #[test]
+    fn filters_skip_secondary_supplementary_and_duplicate_reads() {
+        let reference = b"AAAAA";
+        let reads = vec![
+            mread(0, b"CCCCC", false),                          // kept
+            flagged_read(0, b"GGGGG", SamFlags::SECONDARY),     // skipped
+            flagged_read(0, b"GGGGG", SamFlags::SUPPLEMENTARY), // skipped
+            flagged_read(0, b"GGGGG", SamFlags::DUPLICATE),     // skipped
+        ];
+        let mut e = engine(reads, reference);
+        let mut cols = Vec::new();
+        while let Some(c) = e.next() {
+            cols.push(c.unwrap());
+        }
+        // Only the kept read's 'C' (allele 1) appears at every position.
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+        let s = e.skip_counts();
+        assert_eq!((s.secondary, s.supplementary, s.duplicate), (1, 1, 1));
+    }
+
+    #[test]
+    fn filters_skip_low_mapq_reads() {
+        let reference = b"AAAAA";
+        let mut low = mread(0, b"GGGGG", false);
+        low.mapq = 3;
+        let reads = vec![mread(0, b"CCCCC", false), low];
+        let params = PileupParams { min_mapq: 10, ..PileupParams::default() };
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..5,
+            params,
+        );
+        let mut cols = Vec::new();
+        while let Some(c) = e.next() {
+            cols.push(c.unwrap());
+        }
+        assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
+        assert_eq!(e.skip_counts().low_mapq, 1);
+    }
+
+    #[test]
+    fn low_base_quality_observations_are_dropped() {
+        let reference = b"AAAAA";
+        let mut r = mread(0, b"GGGGG", false);
+        r.qual = Arc::from(vec![2u8; 5].into_boxed_slice()); // below the floor
+        let params = PileupParams { min_base_qual: 20, ..PileupParams::default() };
+        let mut e = PileupEngine::new(
+            SliceSource::new(vec![r]),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..5,
+            params,
+        );
+        // All observations dropped → no columns emitted.
+        assert!(e.next().is_none());
     }
 }

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
-use crate::core::{allele_index, AlignedRead, CoreError, Locus, Position};
+use crate::core::{allele_index, AlignedRead, CoreError, Locus, Position, WorkingSet};
 use crate::pileup::column::{Obs, PileupColumn};
 use crate::pileup::source::ReadSource;
 
@@ -130,6 +130,19 @@ impl<S: ReadSource> PileupEngine<S> {
     /// Reads skipped so far, by reason. Final after iteration completes.
     pub fn skip_counts(&self) -> SkipCounts {
         self.skips
+    }
+
+    /// Current working-set estimate: bounded by the active read set (local
+    /// coverage), independent of total input size. Foundation for `rosalind plan`.
+    pub fn current_working_set(&self) -> WorkingSet {
+        // Each active read costs roughly its projection map (16 B/entry) plus a
+        // small constant for handles; plus a fixed engine overhead.
+        let active_bytes: u64 = self
+            .active
+            .iter()
+            .map(|r| (r.ref_to_read.len() as u64) * 16 + 64)
+            .sum();
+        WorkingSet { bytes: active_bytes + 256 }
     }
 
     /// Whether the read passes flag/MAPQ filters. (Contig routing and the
@@ -528,5 +541,32 @@ mod tests {
         );
         // All observations dropped → no columns emitted.
         assert!(e.next().is_none());
+    }
+
+    use crate::core::MemoryBudget;
+
+    #[test]
+    fn working_set_is_bounded_by_coverage_not_input_size() {
+        // 50,000 single-base reads tiled across the reference at depth ~1: the
+        // active set (and thus the working set) stays tiny throughout iteration.
+        let reference = vec![b'A'; 50_000];
+        let reads: Vec<AlignedRead> = (0..50_000u32).map(|p| mread(p, b"C", false)).collect();
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.into_boxed_slice()),
+            0,
+            0..50_000,
+            PileupParams::default(),
+        );
+        let budget = MemoryBudget::from_mb(1);
+        let mut max_ws = 0u64;
+        while let Some(c) = e.next() {
+            let _ = c.unwrap();
+            let ws = e.current_working_set();
+            max_ws = max_ws.max(ws.bytes);
+            assert!(ws.fits(budget), "working set {} exceeded 1 MiB", ws.bytes);
+        }
+        // Sanity: peak working set is far below holding all reads would cost.
+        assert!(max_ws < 64 * 1024, "peak working set unexpectedly large: {max_ws}");
     }
 }

--- a/src/pileup/mod.rs
+++ b/src/pileup/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod column;
 pub mod source;
+pub mod engine;
 
 pub use column::{Obs, PileupColumn};
 pub use source::{ReadSource, SliceSource};
+pub use engine::{PileupParams, SkipCounts};

--- a/src/pileup/mod.rs
+++ b/src/pileup/mod.rs
@@ -10,4 +10,4 @@ pub mod engine;
 
 pub use column::{Obs, PileupColumn};
 pub use source::{ReadSource, SliceSource};
-pub use engine::{PileupParams, SkipCounts};
+pub use engine::{PileupEngine, PileupParams, SkipCounts};

--- a/src/pileup/mod.rs
+++ b/src/pileup/mod.rs
@@ -5,5 +5,7 @@
 //! callers and plugins build on. Reference as `crate::pileup::…`.
 
 pub mod column;
+pub mod source;
 
 pub use column::{Obs, PileupColumn};
+pub use source::{ReadSource, SliceSource};

--- a/src/pileup/mod.rs
+++ b/src/pileup/mod.rs
@@ -1,0 +1,9 @@
+//! The streaming pileup kernel.
+//!
+//! `PileupEngine` consumes coordinate-sorted reads and yields one `PileupColumn`
+//! per covered reference position. It is the single substrate that variant
+//! callers and plugins build on. Reference as `crate::pileup::…`.
+
+pub mod column;
+
+pub use column::{Obs, PileupColumn};

--- a/src/pileup/mod.rs
+++ b/src/pileup/mod.rs
@@ -5,9 +5,9 @@
 //! callers and plugins build on. Reference as `crate::pileup::…`.
 
 pub mod column;
-pub mod source;
 pub mod engine;
+pub mod source;
 
 pub use column::{Obs, PileupColumn};
-pub use source::{ReadSource, SliceSource};
 pub use engine::{PileupEngine, PileupParams, SkipCounts};
+pub use source::{ReadSource, SliceSource};

--- a/src/pileup/source.rs
+++ b/src/pileup/source.rs
@@ -1,0 +1,63 @@
+//! Read sources feed coordinate-sorted reads into the pileup engine. `SliceSource`
+//! is an in-memory source (used by the Rust API and tests); a BAM-backed source
+//! lands when the calling path is migrated.
+
+use crate::core::{AlignedRead, CoreError};
+
+/// A source of coordinate-sorted aligned reads for the pileup engine.
+///
+/// Implementations MUST yield reads sorted ascending by `(contig, pos)`.
+pub trait ReadSource {
+    /// Return the next read, or `None` when exhausted.
+    fn next_read(&mut self) -> Result<Option<AlignedRead>, CoreError>;
+}
+
+/// An in-memory read source. Sorts the provided reads by `(contig, pos)` on
+/// construction so callers need not pre-sort.
+#[derive(Debug)]
+pub struct SliceSource {
+    reads: std::vec::IntoIter<AlignedRead>,
+}
+
+impl SliceSource {
+    /// Build a source from reads (sorted by `(contig, pos)` here).
+    pub fn new(mut reads: Vec<AlignedRead>) -> Self {
+        reads.sort_by(|a, b| a.contig.cmp(&b.contig).then(a.pos.0.cmp(&b.pos.0)));
+        Self { reads: reads.into_iter() }
+    }
+}
+
+impl ReadSource for SliceSource {
+    fn next_read(&mut self) -> Result<Option<AlignedRead>, CoreError> {
+        Ok(self.reads.next())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{CigarOp, CigarOpKind, Position, SamFlags};
+    use std::sync::Arc;
+
+    fn read(contig: u32, pos: u32) -> AlignedRead {
+        AlignedRead {
+            contig,
+            pos: Position(pos),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![CigarOp::new(CigarOpKind::Match, 4)],
+            seq: Arc::from(b"ACGT".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        }
+    }
+
+    #[test]
+    fn slice_source_yields_reads_sorted_by_contig_then_pos() {
+        let mut src = SliceSource::new(vec![read(1, 50), read(0, 200), read(0, 100)]);
+        let mut order = Vec::new();
+        while let Some(r) = src.next_read().unwrap() {
+            order.push((r.contig, r.pos.0));
+        }
+        assert_eq!(order, vec![(0, 100), (0, 200), (1, 50)]);
+    }
+}

--- a/src/pileup/source.rs
+++ b/src/pileup/source.rs
@@ -23,7 +23,9 @@ impl SliceSource {
     /// Build a source from reads (sorted by `(contig, pos)` here).
     pub fn new(mut reads: Vec<AlignedRead>) -> Self {
         reads.sort_by(|a, b| a.contig.cmp(&b.contig).then(a.pos.0.cmp(&b.pos.0)));
-        Self { reads: reads.into_iter() }
+        Self {
+            reads: reads.into_iter(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The first two phases of the first-principles rebuild — a clean, tested foundation for the unified genomics engine. Both are **additive**: nothing on the existing `variants`/`somatic` calling path imports them yet, so this carries zero risk to the current engine while making the corrected kernel available to library consumers.

**A1 — `core/` canonical types.** `Contig`/`Position`/`Locus` (per-contig u32 with a 64-bit-safe global offset), `BaseCode` (2-bit + IUPAC→N), `MemoryBudget`/`WorkingSet`, and a canonical `AlignedRead` carrying full CIGAR/flags/MAPQ/strand with a **CIGAR-derived `end()`** — fixing the `pos + seq_len` indel bug baked into the legacy `genomics::AlignedRead`.

**A2 — `pileup/` streaming kernel.** One CIGAR-aware, read-filtered, strand-aware, bounded-memory `PileupEngine` over `core::AlignedRead`, yielding a `PileupColumn` stream that is a public substrate for arbitrary per-locus analysis. Fixes two silently-wrong-output bugs from the legacy path:
- **Reverse-strand double-complement** — reads the forward SEQ byte directly, no complement (legacy both re-reversed *and* complemented reverse-strand reads, corrupting ~half of all bases).
- **CIGAR-ignoring projection** — projects each read via `core::projected_bases()` (indel/softclip/long-read correct), replacing the raw `pos - start` offset that mis-placed every base after an indel.

Also: read-level filtering (secondary/supplementary/duplicate/MAPQ) with `SkipCounts` accounting; a `current_working_set()` reporter bounded by local coverage rather than input size; no-recursion empty-position handling (legacy could stack-overflow across long reference gaps); `raw_depth` (total covering) alongside callable `depth()`; deterministic, shuffle-invariant output.

Built subagent-driven with per-task TDD and two-stage (spec compliance, then code quality) review; final holistic review verdict READY.

## Test plan
- [x] `cargo test` — full suite green (71 lib + 6 main + 31 integration, 0 failures)
- [x] `cargo build` — 0 warnings
- [x] `cargo clippy` — clean across the new `core` + `pileup` modules
- [x] `cargo fmt --all -- --check` — clean
- [x] Headline regressions covered: reverse-strand non-complement; indel/softclip/long-read projection; empty-position no-recursion; working-set-bounded-by-coverage; determinism (shuffle-invariance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)