### PR TITLE
Phase B foundations: genome-scale design spec + B1 streaming FASTA/FASTQ readers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ ff = "0.13"
 ark-poly = "0.4"
 # Fast hashing for advisory fingerprints
 blake3 = "1.5"
+# Transparent gzip/bgzf-sequential decompression for FASTA/FASTQ ingestion
+flate2 = "1.0"
 # Bit manipulation - for compact ledger representation
 bitvec = "1.0"
 # Error handling

--- a/docs/superpowers/plans/2026-05-27-phase-b1-streaming-readers.md
+++ b/docs/superpowers/plans/2026-05-27-phase-b1-streaming-readers.md
@@ -1,0 +1,846 @@
+# Phase B1 — Streaming FASTA/FASTQ readers + transparent decompression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move FASTA/FASTQ parsing out of `main.rs` into a library-first `io/` layer of streaming,
+multi-record readers that transparently read plain **or gzip/bgzf** input and accept `-` (stdin),
+returning `core`-friendly owned records and typed `CoreError`s.
+
+**Architecture:** Three new modules under `src/io/`: `decompress` (a magic-sniffing `BufRead` wrapper +
+`open_input`/`open_output` that handle `-`), `fasta` (a multi-record streaming `FastaReader` iterator),
+and `fastq` (a streaming `FastqReader` iterator). `main.rs` keeps thin adapter functions (`read_fasta`
+single-record CLI policy, `read_fastq` collect, plus the existing pairing logic) that call the new
+library readers — so the binary gains gzip + stdin support and the multi-record capability lives in the
+library, while CLI behavior stays single-contig (multi-contig consumption is Phase B4).
+
+**Tech Stack:** Rust 2021; `flate2` (new dep, default `miniz_oxide` pure-Rust backend) for gzip/bgzf
+sequential decompression; `std::io::BufRead`; `thiserror` via the existing `core::CoreError`.
+
+This is stage **B1** of the Phase B design spec
+(`docs/superpowers/specs/2026-05-27-phase-b-genome-scale-design.md`, §9). It lands green and
+independently; it does **not** make alignment/calling multi-contig (that is B2/B4).
+
+---
+
+## File structure
+
+- `Cargo.toml` — add `flate2 = "1.0"`.
+- `src/io/decompress.rs` — **Create.** `maybe_decompress<R: BufRead + 'static>(R) -> io::Result<Box<dyn BufRead>>`, `open_input<P: AsRef<Path>>(P)`, `open_output<P: AsRef<Path>>(P)`. No genomics types; pure plumbing.
+- `src/io/fasta.rs` — **Create.** `FastaRecord { name, sequence }`, `FastaReader<R: BufRead>: Iterator<Item = Result<FastaRecord, CoreError>>`.
+- `src/io/fastq.rs` — **Create.** `FastqRecord { name, sequence, qualities }`, `FastqReader<R: BufRead>: Iterator<Item = Result<FastqRecord, CoreError>>`.
+- `src/io/mod.rs` — **Modify.** Add `pub mod decompress; pub mod fasta; pub mod fastq;`.
+- `src/main.rs` — **Modify.** Delete the private `struct FastaRecord` / `struct FastqRecord`; import the `io::` ones; replace the bodies of `read_fasta` / `read_fastq` with adapters over the new readers; keep `read_fastq_pairs` / `normalize_read_name` / `FastqPair` / `ResolvedReads`.
+- `tests/io_readers.rs` — **Create.** Public-API integration test: a gzipped multi-record FASTA read through `open_input` + `FastaReader` builds a 3-contig `ContigSet`.
+
+---
+
+## Task 1: `flate2` dependency + `io/decompress.rs`
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `src/io/decompress.rs`
+- Modify: `src/io/mod.rs`
+
+- [ ] **Step 1: Add the dependency.** In `Cargo.toml`, under `[dependencies]`, add this line immediately after the `blake3` line (keep the existing comment style):
+
+```toml
+# Transparent gzip/bgzf-sequential decompression for FASTA/FASTQ ingestion
+flate2 = "1.0"
+```
+
+- [ ] **Step 2: Create the module with signatures + tests (bodies unimplemented).** Create `src/io/decompress.rs`:
+
+```rust
+//! Transparent decompression + stream plumbing for pipe-native IO.
+//!
+//! Input may be plain text or gzip-compressed; bgzf (the BAM/“block gzip”
+//! format) is a series of concatenated gzip members, so a multi-member gzip
+//! decoder reads it transparently for sequential access. Random-access bgzf
+//! (virtual offsets, `.gzi`/`.csi`) is Phase D and is not handled here.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::Path;
+
+use flate2::bufread::MultiGzDecoder;
+
+/// The two-byte gzip magic prefix (`1f 8b`), shared by plain gzip and bgzf.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// Wrap a buffered reader, transparently decompressing if its first two bytes
+/// are the gzip magic. Plain input passes through unchanged.
+pub fn maybe_decompress<R: BufRead + 'static>(reader: R) -> io::Result<Box<dyn BufRead>> {
+    unimplemented!()
+}
+
+/// Open `path` (or `-` for stdin) as a transparently-decompressed buffered reader.
+pub fn open_input<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn BufRead>> {
+    unimplemented!()
+}
+
+/// Open `path` (or `-` for stdout) as a writer.
+pub fn open_output<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn Write>> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::{Cursor, Read, Write as _};
+
+    fn gzip(bytes: &[u8]) -> Vec<u8> {
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(bytes).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn plain_input_passes_through() {
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(b"plain text".to_vec()))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "plain text");
+    }
+
+    #[test]
+    fn gzip_input_is_transparently_decompressed() {
+        let gz = gzip(b"hello world");
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(gz))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn empty_input_is_treated_as_plain_and_yields_nothing() {
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(Vec::<u8>::new()))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "");
+    }
+}
+```
+
+- [ ] **Step 3: Register the module.** In `src/io/mod.rs`, add above `pub mod bam;`:
+
+```rust
+pub mod decompress;
+```
+
+- [ ] **Step 4: Run the tests to verify they fail.**
+
+Run: `cargo test --lib io::decompress 2>&1 | tail -20`
+Expected: tests run and FAIL — panics with `not implemented` from `unimplemented!()`.
+
+- [ ] **Step 5: Implement the three functions.** Replace the three `unimplemented!()` bodies in `src/io/decompress.rs`:
+
+```rust
+pub fn maybe_decompress<R: BufRead + 'static>(reader: R) -> io::Result<Box<dyn BufRead>> {
+    let mut reader = reader;
+    let is_gzip = {
+        let head = reader.fill_buf()?;
+        head.len() >= 2 && head[0] == GZIP_MAGIC[0] && head[1] == GZIP_MAGIC[1]
+    };
+    if is_gzip {
+        Ok(Box::new(BufReader::new(MultiGzDecoder::new(reader))))
+    } else {
+        Ok(Box::new(reader))
+    }
+}
+
+pub fn open_input<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn BufRead>> {
+    let path = path.as_ref();
+    if path.as_os_str() == "-" {
+        maybe_decompress(BufReader::new(io::stdin()))
+    } else {
+        maybe_decompress(BufReader::new(File::open(path)?))
+    }
+}
+
+pub fn open_output<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn Write>> {
+    let path = path.as_ref();
+    if path.as_os_str() == "-" {
+        Ok(Box::new(io::stdout()))
+    } else {
+        Ok(Box::new(File::create(path)?))
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass.**
+
+Run: `cargo test --lib io::decompress 2>&1 | tail -20`
+Expected: `test result: ok. 3 passed`.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add Cargo.toml Cargo.lock src/io/decompress.rs src/io/mod.rs
+git commit -m "feat(io/decompress): transparent gzip/bgzf + stdin/stdout plumbing (open_input/open_output)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `io/fasta.rs` — streaming, multi-record FASTA reader
+
+**Files:**
+- Create: `src/io/fasta.rs`
+- Modify: `src/io/mod.rs`
+
+- [ ] **Step 1: Create the module with the type, signature, and tests (body unimplemented).** Create `src/io/fasta.rs`:
+
+```rust
+//! Streaming, multi-record FASTA reader. Library-first: owned records, typed
+//! `CoreError`, no CLI (`anyhow`) or htslib types. One record per `>` header;
+//! sequence bytes are uppercased and newline-stripped. Read-length/contig-count
+//! agnostic — the multi-contig *consumer* is Phase B4; this reader already
+//! yields every record.
+
+use std::io::BufRead;
+
+use crate::core::CoreError;
+
+/// One FASTA record: a contig name and its uppercased sequence bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FastaRecord {
+    /// First whitespace-delimited token of the `>` header line.
+    pub name: String,
+    /// Sequence bytes, ASCII-uppercased, with line breaks removed.
+    pub sequence: Vec<u8>,
+}
+
+/// A streaming reader over a FASTA source, yielding one [`FastaRecord`] per header.
+#[derive(Debug)]
+pub struct FastaReader<R: BufRead> {
+    reader: R,
+    /// The header (without `>`) of the record that the previous `next()` peeked.
+    pending_header: Option<String>,
+    line: String,
+}
+
+impl<R: BufRead> FastaReader<R> {
+    /// Construct a reader over any buffered source.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            pending_header: None,
+            line: String::new(),
+        }
+    }
+}
+
+impl<R: BufRead> Iterator for FastaReader<R> {
+    type Item = Result<FastaRecord, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ContigSet;
+    use std::io::Cursor;
+
+    fn read_all(input: &str) -> Vec<FastaRecord> {
+        FastaReader::new(Cursor::new(input.as_bytes().to_vec()))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("FASTA should parse")
+    }
+
+    #[test]
+    fn reads_single_record_uppercased() {
+        let recs = read_all(">chr1 some description\nacgt\nACGT\n");
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].name, "chr1");
+        assert_eq!(recs[0].sequence, b"ACGTACGT");
+    }
+
+    #[test]
+    fn reads_three_records_and_builds_a_three_contig_set() {
+        let recs = read_all(">chr1\nACGT\n>chr2\nAACCGGTT\n>chr3\nGG\n");
+        assert_eq!(recs.len(), 3);
+
+        let mut contigs = ContigSet::new();
+        for r in &recs {
+            contigs.push(r.name.clone(), r.sequence.len() as u32);
+        }
+        assert_eq!(contigs.len(), 3);
+        assert_eq!(contigs.by_name("chr2").unwrap().id, 1);
+        // chr1(4) + chr2(8) → chr3 starts at global offset 12.
+        assert_eq!(contigs.by_name("chr3").unwrap().global_offset, 12);
+    }
+
+    #[test]
+    fn skips_blank_lines_between_records() {
+        let recs = read_all("\n>chr1\nAC\n\nGT\n\n>chr2\nTT\n");
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].sequence, b"ACGT");
+        assert_eq!(recs[1].sequence, b"TT");
+    }
+
+    #[test]
+    fn missing_header_is_a_malformed_record_error() {
+        let err = FastaReader::new(Cursor::new(b"ACGT\n".to_vec()))
+            .next()
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn header_without_sequence_is_a_malformed_record_error() {
+        let err = FastaReader::new(Cursor::new(b">chr1\n".to_vec()))
+            .next()
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn empty_input_yields_no_records() {
+        assert!(read_all("").is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module.** In `src/io/mod.rs`, add (after `pub mod decompress;`):
+
+```rust
+pub mod fasta;
+```
+
+- [ ] **Step 3: Run the tests to verify they fail.**
+
+Run: `cargo test --lib io::fasta 2>&1 | tail -20`
+Expected: tests run and FAIL — `not implemented` from the `unimplemented!()` `next()`.
+
+- [ ] **Step 4: Implement `next()`.** Replace the `unimplemented!()` in `impl Iterator for FastaReader`:
+
+```rust
+    fn next(&mut self) -> Option<Self::Item> {
+        // Establish this record's header (from the peeked one, or by scanning).
+        let header = match self.pending_header.take() {
+            Some(h) => h,
+            None => loop {
+                self.line.clear();
+                match self.reader.read_line(&mut self.line) {
+                    Ok(0) => return None, // clean EOF: no more records
+                    Ok(_) => {}
+                    Err(e) => return Some(Err(CoreError::Io(e))),
+                }
+                let trimmed = self.line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match trimmed.strip_prefix('>') {
+                    Some(rest) => break rest.to_string(),
+                    None => {
+                        return Some(Err(CoreError::MalformedRecord(format!(
+                            "expected FASTA header starting with '>', found '{trimmed}'"
+                        ))))
+                    }
+                }
+            },
+        };
+
+        let name = match header.split_whitespace().next() {
+            Some(n) => n.to_string(),
+            None => {
+                return Some(Err(CoreError::MalformedRecord(
+                    "FASTA header has no name".to_string(),
+                )))
+            }
+        };
+
+        // Accumulate sequence lines until the next header or EOF.
+        let mut sequence = Vec::new();
+        loop {
+            self.line.clear();
+            match self.reader.read_line(&mut self.line) {
+                Ok(0) => break, // EOF terminates the final record
+                Ok(_) => {}
+                Err(e) => return Some(Err(CoreError::Io(e))),
+            }
+            let trimmed = self.line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix('>') {
+                self.pending_header = Some(rest.to_string());
+                break;
+            }
+            sequence.extend(trimmed.bytes().map(|b| b.to_ascii_uppercase()));
+        }
+
+        if sequence.is_empty() {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "FASTA record '{name}' has no sequence data"
+            ))));
+        }
+
+        Some(Ok(FastaRecord { name, sequence }))
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass.**
+
+Run: `cargo test --lib io::fasta 2>&1 | tail -20`
+Expected: `test result: ok. 6 passed`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/io/fasta.rs src/io/mod.rs
+git commit -m "feat(io/fasta): streaming multi-record FASTA reader (library-first, typed errors)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `io/fastq.rs` — streaming FASTQ reader
+
+**Files:**
+- Create: `src/io/fastq.rs`
+- Modify: `src/io/mod.rs`
+
+- [ ] **Step 1: Create the module with the type, signatures, and tests (bodies unimplemented).** Create `src/io/fastq.rs`:
+
+```rust
+//! Streaming FASTQ reader. Library-first: owned records, typed `CoreError`, no
+//! CLI/htslib types. Four lines per record (`@name`, sequence, `+`, qualities);
+//! sequence is uppercased; qualities are kept as raw ASCII (Phred+33) bytes.
+
+use std::io::BufRead;
+
+use crate::core::CoreError;
+
+/// One FASTQ record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FastqRecord {
+    /// First whitespace-delimited token of the `@` header line.
+    pub name: String,
+    /// Sequence bytes, ASCII-uppercased.
+    pub sequence: Vec<u8>,
+    /// Quality bytes as raw ASCII (Phred+33), same length as `sequence`.
+    pub qualities: Vec<u8>,
+}
+
+/// A streaming reader over a FASTQ source, yielding one [`FastqRecord`] per 4 lines.
+#[derive(Debug)]
+pub struct FastqReader<R: BufRead> {
+    reader: R,
+    line: String,
+}
+
+impl<R: BufRead> FastqReader<R> {
+    /// Construct a reader over any buffered source.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            line: String::new(),
+        }
+    }
+
+    /// Read the next non-blank line, or `None` at clean EOF.
+    fn next_nonblank(&mut self) -> Result<Option<String>, CoreError> {
+        unimplemented!()
+    }
+
+    /// Read the next line; a clean EOF here is a malformed (truncated) record.
+    fn next_required(&mut self, ctx: &str) -> Result<String, CoreError> {
+        unimplemented!()
+    }
+}
+
+impl<R: BufRead> Iterator for FastqReader<R> {
+    type Item = Result<FastqRecord, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn read_all(input: &str) -> Result<Vec<FastqRecord>, CoreError> {
+        FastqReader::new(Cursor::new(input.as_bytes().to_vec())).collect()
+    }
+
+    #[test]
+    fn reads_two_records_and_trims_name_after_space() {
+        let recs = read_all("@read1 1:N:0:CG\nacgt\n+\nIIII\n@read2\nTT\n+\n##\n").unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].name, "read1");
+        assert_eq!(recs[0].sequence, b"ACGT");
+        assert_eq!(recs[0].qualities, b"IIII");
+        assert_eq!(recs[1].name, "read2");
+    }
+
+    #[test]
+    fn missing_at_prefix_is_malformed() {
+        let err = read_all("read1\nACGT\n+\nIIII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn missing_plus_separator_is_malformed() {
+        let err = read_all("@read1\nACGT\n-\nIIII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn seq_qual_length_mismatch_is_malformed() {
+        let err = read_all("@read1\nACGT\n+\nII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn truncated_record_at_eof_is_malformed() {
+        let err = read_all("@read1\nACGT\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn empty_input_yields_no_records() {
+        assert!(read_all("").unwrap().is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module.** In `src/io/mod.rs`, add (after `pub mod fasta;`):
+
+```rust
+pub mod fastq;
+```
+
+- [ ] **Step 3: Run the tests to verify they fail.**
+
+Run: `cargo test --lib io::fastq 2>&1 | tail -20`
+Expected: tests run and FAIL — `not implemented`.
+
+- [ ] **Step 4: Implement the helpers and `next()`.** Replace the three `unimplemented!()` bodies:
+
+```rust
+    fn next_nonblank(&mut self) -> Result<Option<String>, CoreError> {
+        loop {
+            self.line.clear();
+            let n = self.reader.read_line(&mut self.line)?;
+            if n == 0 {
+                return Ok(None);
+            }
+            let trimmed = self.line.trim();
+            if !trimmed.is_empty() {
+                return Ok(Some(trimmed.to_string()));
+            }
+        }
+    }
+
+    fn next_required(&mut self, ctx: &str) -> Result<String, CoreError> {
+        self.line.clear();
+        let n = self.reader.read_line(&mut self.line)?;
+        if n == 0 {
+            return Err(CoreError::MalformedRecord(format!(
+                "unexpected end of FASTQ while reading {ctx}"
+            )));
+        }
+        Ok(self.line.trim().to_string())
+    }
+```
+
+```rust
+    fn next(&mut self) -> Option<Self::Item> {
+        let header = match self.next_nonblank() {
+            Ok(Some(h)) => h,
+            Ok(None) => return None, // clean EOF between records
+            Err(e) => return Some(Err(e)),
+        };
+        let name = match header.strip_prefix('@') {
+            Some(rest) => match rest.split_whitespace().next() {
+                Some(n) => n.to_string(),
+                None => {
+                    return Some(Err(CoreError::MalformedRecord(
+                        "FASTQ header has no read name".to_string(),
+                    )))
+                }
+            },
+            None => {
+                return Some(Err(CoreError::MalformedRecord(format!(
+                    "expected FASTQ header starting with '@', found '{header}'"
+                ))))
+            }
+        };
+
+        let sequence = match self.next_required("sequence") {
+            Ok(s) => s.to_ascii_uppercase().into_bytes(),
+            Err(e) => return Some(Err(e)),
+        };
+        let plus = match self.next_required("'+' separator") {
+            Ok(s) => s,
+            Err(e) => return Some(Err(e)),
+        };
+        if !plus.starts_with('+') {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "expected '+' separator for read '{name}', found '{plus}'"
+            ))));
+        }
+        let qualities = match self.next_required("qualities") {
+            Ok(s) => s.into_bytes(),
+            Err(e) => return Some(Err(e)),
+        };
+        if sequence.len() != qualities.len() {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "sequence/quality length mismatch for read '{name}' ({} vs {})",
+                sequence.len(),
+                qualities.len()
+            ))));
+        }
+
+        Some(Ok(FastqRecord {
+            name,
+            sequence,
+            qualities,
+        }))
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass.**
+
+Run: `cargo test --lib io::fastq 2>&1 | tail -20`
+Expected: `test result: ok. 6 passed`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/io/fastq.rs src/io/mod.rs
+git commit -m "feat(io/fastq): streaming FASTQ reader (library-first, typed errors)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Rewire `main.rs` onto the library readers (parsing leaves `main.rs`)
+
+**Files:**
+- Modify: `src/main.rs`
+
+The goal: delete the private record structs and the hand-rolled parsing; route `read_fasta`/`read_fastq`
+through the new library readers (gaining gzip + `-` support); keep CLI behavior single-contig and keep
+the pairing logic. The existing `main.rs` tests must still pass unchanged.
+
+- [ ] **Step 1: Import the library record types; delete the private structs.** At the top of
+`src/main.rs`, with the other `use rosalind::...` imports, add:
+
+```rust
+use rosalind::io::decompress::open_input;
+use rosalind::io::fasta::{FastaReader, FastaRecord};
+use rosalind::io::fastq::{FastqReader, FastqRecord};
+```
+
+Then delete the two private struct definitions (currently around lines 152–162):
+
+```rust
+struct FastaRecord {
+    name: String,
+    sequence: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct FastqRecord {
+    name: String,
+    sequence: Vec<u8>,
+    qualities: Vec<u8>,
+}
+```
+
+(Leave `struct FastqPair`, `enum ResolvedReads`, and everything else in place — they now refer to the
+imported `FastqRecord`, which has identical fields.)
+
+- [ ] **Step 2: Replace the body of `read_fasta`.** Replace the entire `fn read_fasta(...) { ... }`
+(currently lines ~850–892) with this adapter:
+
+```rust
+/// Read a reference FASTA (plain or gzip; `-` = stdin). Phase B1 keeps the
+/// single-contig CLI policy: only the first record is used; additional records
+/// are warned about (multi-contig consumption is Phase B4). The streaming
+/// parser itself lives in `io::fasta`.
+fn read_fasta(path: &PathBuf) -> Result<FastaRecord> {
+    let reader =
+        open_input(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut records = FastaReader::new(reader);
+    let first = records
+        .next()
+        .ok_or_else(|| anyhow!("FASTA file {} is missing a record", path.display()))?
+        .with_context(|| format!("failed to parse FASTA {}", path.display()))?;
+    if records.next().is_some() {
+        eprintln!(
+            "warning: only the first FASTA record is currently used; ignoring the rest \
+             (multi-contig lands in Phase B4)"
+        );
+    }
+    Ok(first)
+}
+```
+
+- [ ] **Step 3: Replace the body of `read_fastq`.** Replace the entire `fn read_fastq(...) { ... }`
+(currently lines ~894–956) with this adapter:
+
+```rust
+/// Read a FASTQ file (plain or gzip; `-` = stdin) into a vector of records.
+/// The streaming parser lives in `io::fastq`.
+fn read_fastq(path: &PathBuf) -> Result<Vec<FastqRecord>> {
+    let reader = open_input(path)
+        .with_context(|| format!("failed to open FASTQ file {}", path.display()))?;
+    FastqReader::new(reader)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to parse FASTQ {}", path.display()))
+}
+```
+
+- [ ] **Step 4: Build and clear any newly-unused imports.**
+
+Run: `cargo build 2>&1 | grep -iE 'error|warning'`
+Expected: no errors. If the compiler warns that `std::io::BufReader` (or `File`, `bail`) is now unused
+*because it was only used by the deleted parsing*, remove just those names from their `use` lines until
+the build is warning-clean. Do **not** remove names still used elsewhere in `main.rs`.
+
+- [ ] **Step 5: Run the existing reader tests + full suite to confirm no behavior change.**
+
+Run: `cargo test 2>&1 | tail -30`
+Expected: full suite green, including the preserved `fasta_parser_extracts_primary_name`,
+`fastq_parser_trims_after_space`, and `align_reads_with_fm_index` (which now construct the imported
+`FastqRecord` — identical fields). Report the totals.
+
+- [ ] **Step 6: Smoke-test gzip transparency from the CLI.**
+
+```bash
+cargo build --release
+gzip -c examples/data/reads.fastq > /tmp/reads.fastq.gz 2>/dev/null || \
+  (python3 scripts/generate_toy_data.py /tmp/illumina_toy && gzip -c /tmp/illumina_toy/reads_R1.fastq > /tmp/reads.fastq.gz)
+# Align reading the GZIPPED reads; should behave identically to the uncompressed run.
+./target/release/rosalind align \
+  --reference examples/data/ref.fa \
+  --reads /tmp/reads.fastq.gz \
+  --format sam | head -5
+```
+Expected: SAM header + alignment lines (no decompression error). Report the output.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/main.rs
+git commit -m "refactor(main): route FASTA/FASTQ reading through io:: readers (adds gzip + stdin)" \
+  -m "Deletes the private FastaRecord/FastqRecord structs and the hand-rolled parsers; read_fasta/read_fastq are now thin CLI adapters over io::fasta/io::fastq via io::decompress::open_input. CLI stays single-contig (multi-contig is Phase B4); existing reader tests are preserved." \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Public-API integration test (gz multi-record → `ContigSet`)
+
+**Files:**
+- Create: `tests/io_readers.rs`
+
+This is the B1 definition-of-done check, run by `cargo test` in CI: a gzipped, multi-record FASTA, read
+through the public `open_input` + `FastaReader` API, builds the expected multi-contig `ContigSet`.
+
+- [ ] **Step 1: Write the integration test.** Create `tests/io_readers.rs`:
+
+```rust
+//! Phase B1 DoD: the public reader API reads gzipped, multi-record FASTA and
+//! produces a multi-contig ContigSet.
+
+use std::io::{Cursor, Write};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use rosalind::core::ContigSet;
+use rosalind::io::decompress::maybe_decompress;
+use rosalind::io::fasta::FastaReader;
+
+fn gzip(bytes: &[u8]) -> Vec<u8> {
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(bytes).unwrap();
+    enc.finish().unwrap()
+}
+
+#[test]
+fn gzipped_multi_record_fasta_builds_a_contig_set() {
+    let fasta = b">chr1 first\nACGTACGT\n>chr2\nAACC\n>chr3\nGGGGTTTT\n";
+    let gz = gzip(fasta);
+
+    let reader = maybe_decompress(Cursor::new(gz)).unwrap();
+    let records: Vec<_> = FastaReader::new(reader)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("gz FASTA should parse");
+
+    assert_eq!(records.len(), 3);
+
+    let mut contigs = ContigSet::new();
+    for r in &records {
+        contigs.push(r.name.clone(), r.sequence.len() as u32);
+    }
+    assert_eq!(contigs.len(), 3);
+    assert_eq!(contigs.by_name("chr1").unwrap().global_offset, 0);
+    assert_eq!(contigs.by_name("chr2").unwrap().global_offset, 8);
+    assert_eq!(contigs.by_name("chr3").unwrap().global_offset, 12);
+    assert_eq!(contigs.total_length(), 20);
+}
+```
+
+- [ ] **Step 2: Run the integration test.**
+
+Run: `cargo test --test io_readers 2>&1 | tail -20`
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 3: Confirm the whole suite is still green.**
+
+Run: `cargo test 2>&1 | tail -15` then `cargo fmt --all -- --check`
+Expected: full suite green; formatting clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/io_readers.rs
+git commit -m "test(io): gzipped multi-record FASTA → multi-contig ContigSet (B1 DoD)" \
+  -m "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (before opening the B1 PR)
+
+- `cargo test` — full suite green (report totals).
+- `cargo build 2>&1 | grep -iE 'error|warning'` — clean.
+- `cargo fmt --all -- --check` — clean.
+- `grep -n "fn read_to_string\|\.lines()\|starts_with('>')\|starts_with('@')" src/main.rs` — should be
+  empty (no FASTA/FASTQ *parsing* remains in `main.rs`; only the thin adapters that call `io::`).
+- CLI smoke: `align` reads a `.gz` reads file identically to the uncompressed file (Task 4 Step 6).
+
+## Self-Review
+
+- **Spec coverage (B1 row of §9):** streaming multi-record readers in `io/` ✔ (Tasks 2, 3); gz/bgzf
+  transparent ✔ (Task 1, `MultiGzDecoder` handles concatenated members); `-`/stdin ✔ (`open_input`);
+  library-first / no htslib/anyhow in `io/` signatures ✔ (readers return `CoreError`); parsing leaves
+  `main.rs` ✔ (Task 4 + the grep gate); 3-record FASTA → 3-contig `ContigSet` ✔ (Task 2 + Task 5);
+  malformed-input typed errors ✔ (Tasks 2, 3).
+- **Out of scope confirmed:** alignment/calling stay single-contig (Task 4 keeps the first-record
+  policy + warning); no FM-index, persistence, or `@SQ`/`##contig` changes here.
+- **Type consistency:** `FastaRecord { name, sequence }` and `FastqRecord { name, sequence, qualities }`
+  match the field names `main.rs` already uses (`.name`, `.sequence`, `.qualities`), so `FastqPair`,
+  `ResolvedReads`, `read_fastq_pairs`, `normalize_read_name`, and `align_reads_with_fm_index` compile
+  unchanged. `open_input`/`maybe_decompress`/`open_output` names are used consistently across tasks.
+- **No placeholders:** every step ships complete code or an exact command + expected output.

--- a/docs/superpowers/specs/2026-05-27-phase-b-genome-scale-design.md
+++ b/docs/superpowers/specs/2026-05-27-phase-b-genome-scale-design.md
@@ -1,0 +1,362 @@
+# Phase B — Make it real on a genome (multi-contig + persisted index + streaming ingestion)
+
+**Status:** Spec for review — 2026-05-27. Second vertical of the target architecture
+(`2026-05-26-rosalind-target-architecture.md`, §9.2). Builds directly on the Phase A kernel
+(`core/`, `pileup/`, `call/`, `io/vcf`, `provenance/`).
+
+**One-line goal.** Take the Phase A calling vertical from a single-contig, rebuild-the-index-every-run,
+uncompressed-input toy to a tool that runs on a **real, multi-contig genome from a build-once,
+memory-mapped index**, reads **gzipped** FASTA/FASTQ as a streaming library, and **composes over
+pipes** — without surrendering any of the five promises (deterministic, memory-as-contract,
+standards-compliant, verifiable, embeddable).
+
+**Why this phase, and why this shape.** A builder forking Rosalind today is hard-blocked: `align`
+indexes only the first FASTA record, the FM-index is rebuilt in RAM on every run, and only
+uncompressed input is accepted. The Phase A `PileupColumn` substrate is clean but starved — it can
+only ever see one contig of one toy. Phase B raises the ceiling on *all* downstream builder value by
+making the engine work on a real genome. We deliberately do the roadmap-literal infrastructure (not a
+builder-experience detour) because the substrate is worthless on data it cannot ingest.
+
+---
+
+## 1. Success criteria (definition of done)
+
+Phase B is done when, on a multi-contig reference with gzipped reads, all of the following hold:
+
+- **Multi-contig:** `align` indexes and maps reads across *every* contig; emitted `core::AlignedRead`s
+  carry the correct `(contig, pos)`; the "first FASTA record only" warning path is gone. Reads whose
+  alignment would straddle a contig boundary are rejected, not mis-mapped.
+- **Build-once, mmap-load:** `rosalind index ref.fa[.gz]` produces a single index artifact; `align` /
+  `variants` / `somatic` load it via mmap and **never rebuild the FM-index** (no SA-IS on the read
+  path). Querying the loaded index returns **byte-identical** results to the in-RAM index it was built
+  from.
+- **Streaming ingestion:** FASTA and FASTQ readers live in `io/`, stream multi-record input, and read
+  plain or gzip/bgzf transparently (auto-detected); a `.gz` reference/reads produce identical results
+  to their decompressed equivalents.
+- **Self-contained index:** the index stores the 2-bit reference, so `variants`/`somatic` need only
+  `--index` (not also `--reference`). A stale index (reference BLAKE3 mismatch) is rejected with a
+  clear error.
+- **Deterministic:** the index file is byte-identical across repeated builds (no timestamps, fixed
+  section order, fixed-width LE encoding); VCF + receipt remain byte-identical across runs and across
+  the file-based vs piped paths.
+- **Memory honest:** loading the index does not make it resident (near-zero declared RSS; OS-paged).
+  The `MemoryBudget` contract continues to govern the streaming working set; the index's
+  page-cache residency is documented as OS-managed and separate.
+- **Pipe-native:** `align --reads - | rosalind sort - | rosalind variants --alignments -` produces the
+  same VCF as the file-based path; the receipt records the index artifact's hash.
+- **Embeddable:** the readers, the index reader/writer, and `FmIndexView` are library-first — no
+  `rust_htslib` or `anyhow` types in public signatures; the on-disk format is documented as a
+  public, forkable artifact (`docs/index-format.md`).
+- **Standards:** multi-contig VCF carries a `##contig` line per contig and a multi-contig BAM carries an
+  `@SQ` line per contig, both from the `ContigSet`; `bcftools`/`samtools` validate them in CI when
+  available.
+
+---
+
+## 2. Scope
+
+**In:**
+1. `io/fasta` + `io/fastq` — streaming, multi-record, gzip/bgzf-transparent readers; ingestion leaves
+   `main.rs`.
+2. Multi-contig FM-index build over the concatenated genome + global↔local `Locus` mapping.
+3. Index persistence — a zero-copy on-disk layout, a serializer, an mmap-backed `FmIndexView`, and a
+   `rosalind index` subcommand. Self-contained (stores the 2-bit reference).
+4. Consumer wiring — `align`/`variants`/`somatic` load the persisted multi-contig index; the pileup
+   walks the whole genome contig-by-contig; `@SQ`/`##contig` from the `ContigSet`.
+5. Pipe-native `-`/stdin/stdout composition; receipt extended to cover the index artifact.
+6. Minimal per-pillar CI for the surface B introduces + a docs-truth pass (README scope +
+   `docs/index-format.md`).
+
+**Out (deferred, by design — do not let these creep in):**
+- **Alignment *algorithm* rewrite** (real MAPQ calibration, soft-clip scoring, better chaining). Phase B
+  keeps the existing seed→chain→extend math and only makes it multi-contig + index-backed. Algorithm
+  quality is a later `align/` phase.
+- **rayon / real RSS gate / `rosalind plan` / `rosalind verify`** → Phase D. (B exposes the honest
+  memory story and a basic load-residency check; the *enforced* RSS gate is D.)
+- **`.csi` / bgzf random-access region `fetch`** → Phase D. B reads bgzf by sequential full
+  decompression only.
+- **Germline indels** → Phase C. **Somatic indels** remain Phase C (already deferred in Phase A).
+- **Python binding** → Phase P. (The readers/view/index API are shaped to be bindable, but no PyO3
+  surface is added here.)
+- **Theory-layer feature-gating, clippy `-D warnings` across the legacy tree, `lib.rs` crate-doc
+  honesty pass** → Phase E. (Noted as a known builder-legibility wart; intentionally untouched here.)
+
+---
+
+## 3. Locked decisions (2026-05-27)
+
+These were settled in the brainstorming dialogue and are not re-opened during implementation:
+
+1. **Phase B mission = genome-scale infrastructure, roadmap-literal.** The four roadmap pillars, not a
+   builder-experience reprioritization.
+2. **Index memory model = mmap read-only, OS-paged.** The `MemoryBudget` contract governs the
+   *streaming working set* (pileup/sort, coverage-bounded). The index is mmap'd: near-zero declared
+   RSS, demand-paged, evictable, shareable across processes. Index *build* is O(reference) and
+   documented separately. No `--load-index`/pin option now (YAGNI; revisit in D with the RSS gate).
+3. **Index load = zero-copy, via a build-side/read-side split.** The existing `BlockedFMIndex` stays the
+   *build-side* type (builds in RAM, then serializes). A new *read-side* `FmIndexView<'a>` borrows
+   `&'a [u8]` slices from the mmap and runs the FM algorithm directly over them. **On-disk layout =
+   query layout.** One source of truth for the FM algorithm via a `BwtBacking` trait implemented by
+   both; an equivalence property test asserts the view returns identical results to the in-RAM index.
+   No throwaway owned-deserialization path.
+4. **`sa_samples` stays `u32`** → a documented ≤4.29 Gbp concatenated-genome ceiling (covers human and
+   the overwhelming majority of edge targets; keeps SA-sample memory lean). `build_multi` errors
+   clearly if the concatenated length reaches 2³². The `u64` coordinate API in `ContigSet` is
+   preserved.
+5. **Self-contained index** — the index stores the 2-bit forward reference, so `variants`/`somatic`
+   require only `--index`. A stale index is rejected via the header's reference BLAKE3.
+6. **SA samples are stored compactly (sparse), not as a dense full-length array.** The current
+   `BlockedFMIndex` holds `sa_samples: Vec<u32>` of length `bwt_len` with `u32::MAX` holes
+   (`fm_index.rs:469`) — so the sample *rate* only changes density, never storage size (~12 GB for a
+   human genome; a persisted index would be ~13 GB). The on-disk `SaSamples` section and the read-side
+   `sa_at` use a compact representation — a sampled-position **bitvector** (reusing `rank_select`) plus a
+   **packed array of the sampled values** — making SA-sample storage sub-linear (`O(bwt_len / rate)`).
+   The build-side is moved to the same compact form, eliminating the dense array. This is a prerequisite
+   for honestly persisting a bounded-memory index, not an optimization.
+
+---
+
+## 4. Module map (changes)
+
+```
+io/
+  fasta        NEW  streaming, multi-record, gz/bgzf-transparent FASTA reader → core types
+  fastq        NEW  streaming, gz/bgzf-transparent FASTQ reader → core types
+  decompress   NEW  magic-sniffing Read wrapper (plain / gzip / bgzf-sequential) + open_input/open_output (- = std)
+  bam, vcf     KEEP (vcf: emit @SQ/##contig for all contigs from ContigSet)
+genomics/
+  fm_index     EXTEND  build_multi over the concatenated genome; factor FM ops over a `BwtBacking` trait
+  index/
+    format     EXTEND  add section kinds (BwtBlocks, RankCheckpoints, Boundaries, CTable, Reference2bit, real SaSamples); contig global_offset
+    io         REWRITE  serialize the queryable FM-index; FmIndexView<'a> over the mmap; stale-index guard
+  bwt_aligner  REWRITE  generic over `B: BwtBacking` (owned index for build/tests; FmIndexView for production); contig-aware locate → Locus; reject boundary-straddling hits
+  suffix_array, rank_select, compressed_dna  KEEP kernels (rank_select/compressed_dna gain borrowed-slice read accessors used by FmIndexView)
+core/
+  locus        KEEP  ContigSet already 64-bit-offset-ready; add global_offset→Locus resolve (binary search) + boundary-cross check helper
+provenance/
+  mod          EXTEND  RunManifest records the index artifact path + BLAKE3
+main.rs        REWRITE (slim)  `rosalind index` subcommand; align/variants/somatic take --index; - conventions; reading removed (now in io/)
+docs/
+  index-format.md  NEW  the on-disk format as a public, forkable artifact
+```
+
+**Public-API discipline (unchanged hard rule):** no `rust_htslib` types in public signatures; readers
+and the index API return/borrow `core` types; `anyhow` only at the CLI.
+
+**New dependency:** `flate2` (default `miniz_oxide` backend — pure Rust, portable/edge-friendly) for
+gzip/bgzf-sequential decompression. bgzf *random access* is not pulled in here (Phase D).
+
+---
+
+## 5. The on-disk index format (public, forkable artifact)
+
+A single little-endian file. The header (fixed size, already implemented) is readable without parsing
+the body and carries magic, version, endian marker, `contig_count`, `sa_sample_rate`, the section-table
+location, and the **reference BLAKE3**. The body is a set of length-delimited sections located by a
+section table; **section payloads are flat, naturally-aligned, fixed-width LE arrays so the read-side
+view can index into them directly from the mmap (zero-copy).**
+
+Sections (extending today's `Contigs` / `Reference` / `SaSamples`):
+
+| Section | Payload (v1) |
+|---|---|
+| `Contigs` | per contig: `name_len:u32, name:[u8], length:u64, global_offset:u64` (offset stored, not re-derived, so the view is self-describing) |
+| `Reference2bit` | the concatenated forward reference, 2-bit packed (A/C/G/T) + an N/ambiguity bitmask (lossless), for `ref_base` lookups without a separate `.fa` |
+| `BwtBlocks` | the 2-bit BWT, block-partitioned (`block_size` from the header), exactly the bytes `CompressedDNA` already produces |
+| `RankCheckpoints` | per-block `Occ`/rank-select payload (`RankSelectIndex` data as flat arrays) |
+| `Boundaries` | per-block `{start:u64, cumulative_counts:[u32;5], sentinel_count:u32}` (the `CompressedBoundaries` table) + `c_table:[u32;6]` + `sentinel_pos:u64` |
+| `SaSamples` | **compact/sparse** (decision §3.6): a sampled-position bitvector over BWT indices + its rank checkpoints + a packed array of the sampled `u32` SA values — *not* the dense `bwt_len × u32` array, and not the current scaffold's zero samples |
+
+**Determinism:** SA-IS is deterministic; sections are written in a fixed order with fixed-width LE
+encoding; no timestamps appear anywhere in the file. ⇒ byte-identical across builds of the same
+reference. **Integrity:** the header already stores the reference BLAKE3; `IndexReader::open` validates
+magic/version/endian/header-size/section-table and (cheaply) that section extents lie within the file.
+
+`docs/index-format.md` documents all of the above as a stable, forkable contract so a third party can
+write a compatible builder or reader.
+
+---
+
+## 6. Data flow after Phase B
+
+```
+# build once
+rosalind index ref.fa[.gz] [-o ref.fa.rosalind.idx]
+  io::fasta (stream, multi-record) -> ContigSet + concatenated text (err if len >= 2^32)
+  -> BlockedFMIndex::build_multi (SA-IS, single terminal sentinel, real SA samples)
+  -> genomics::index serializer (deterministic, flat LE sections, BLAKE3) -> ref.fa.rosalind.idx
+
+# align (streaming reads -> SAM/BAM)
+rosalind align --index ref.fa.rosalind.idx --reads R.fq[.gz] [--output - | out.bam]
+  IndexReader::open -> mmap -> FmIndexView (queryable; NO rebuild)
+  io::fastq (stream, gz) -> seed -> chain -> extend -> resolve Locus -> reject cross-contig
+  -> core::AlignedRead{contig,pos,..} -> SAM/BAM (@SQ per contig) -> stdout/-
+
+# call (whole-genome pileup -> VCF)
+rosalind variants --index ref.fa.rosalind.idx [--alignments - | sorted.bam]
+  BamSource -> for each contig in ContigSet: PileupEngine(region = 0..contig.len)
+            -> call::germline -> io::vcf (##contig per contig)
+  ref_base served from the index's Reference2bit (no separate --reference)
+  + RunManifest records index path + BLAKE3
+```
+
+---
+
+## 7. Multi-contig FM-index design
+
+- **Concatenation, single sentinel.** All contig sequences are concatenated (in `ContigSet` id order)
+  into one text; a single terminal `$` sentinel is appended (exactly as today); SA-IS runs once over
+  the whole text. **No per-contig separators** — keeping the kernel unchanged.
+- **Coordinate mapping.** A located global SA position `p` resolves to `Locus{contig, pos}` by binary
+  search over the contigs' `global_offset` (`pos = p - global_offset`). `ContigSet` already stores
+  `global_offset: u64`.
+- **Boundary rejection (the bwa "bns" model).** A hit of read length `L` at global `p` is **rejected**
+  if `[p, p+L)` crosses a contig boundary (i.e., spans into the next contig). This is the only thing
+  preventing phantom cross-contig matches; the SA itself may contain boundary-straddling suffixes,
+  which are simply never reported. Covered by a dedicated test (a read placed to straddle a boundary
+  yields no hit).
+- **u32 ceiling.** Concatenated length must be `< 2^32`; `build_multi` returns a typed error otherwise.
+  Documented in README + `index-format.md`.
+- **Reference bases.** The forward 2-bit reference (with N/ambiguity mask) is stored so the pileup can
+  read `ref_base` at any locus without a separate FASTA.
+
+---
+
+## 8. Zero-copy loading design
+
+- **`trait BwtBacking`** — the minimal surface the FM algorithm needs: BWT symbol/word access, per-block
+  rank checkpoint access, boundary/c_table access, and compact SA-sample access (the sampled-position
+  bitvector + its rank + the packed sampled values, per §3.6). The FM operations (`backward_search`,
+  `rank`, `lf_index`, `sa_at`, `locate_interval`) are written **once** against this trait; `sa_at` walks
+  LF until it lands on a sampled BWT position (rank over the sampled bitvector → index into the packed
+  values).
+- **Build-side backing** = the existing owned `BlockedFMIndex` data (Vecs in RAM). Used by `rosalind
+  index` and by unit/property tests.
+- **Read-side backing** = `FmIndexView<'a>`, holding `&'a [u8]` subslices of the mmap (BWT words, rank
+  checkpoints, boundaries, c_table, sa_samples) + the parsed `ContigSet`. `ReferenceIndex` owns the
+  `MmapReadOnly`; `ReferenceIndex::view(&self) -> FmIndexView<'_>` borrows from it. **No allocation of
+  the big arrays; the OS pages them.**
+- **`BWTAligner` becomes generic** over `B: BwtBacking`: production wires it to `FmIndexView`;
+  build/tests wire it to the owned index. Contig-aware locate returns `Locus`.
+- **Equivalence gate (the headline correctness test):** build an index in RAM, serialize it, mmap it as
+  an `FmIndexView`, and assert that `backward_search` / `rank` / `sa_at` / `locate_interval` return
+  **identical** results for a large, fixed battery of patterns. This simultaneously proves zero-copy
+  correctness *and* serialization round-trip fidelity.
+- **No-rebuild gate:** the read path must not call SA-IS. Enforced structurally (the loader constructs a
+  view, never a `BlockedFMIndex::build*`) and asserted in an e2e timing/behavioral check.
+
+---
+
+## 9. Decomposition — six stages, each lands green, dependency-ordered
+
+Each stage is independently compilable, testable, and green; later stages depend only on earlier ones.
+Each becomes its own implementation plan (writing-plans) and PR, mirroring the Phase A A1–A7 cadence.
+
+### B1 — Streaming readers (`io/fasta`, `io/fastq`, `io/decompress`)
+- Streaming, multi-record FASTA/FASTQ over any `Read`; magic-sniffing transparent gz/bgzf-sequential
+  decompression; `-` = stdin. Library-first (typed errors, `core` types, no htslib/anyhow). Ingestion
+  removed from `main.rs`.
+- **DoD:** a 3-record FASTA yields a 3-contig `ContigSet`; `.gz` and plain read identically (byte-for-
+  byte equal records); reading from `-` works; round-trip + malformed-input tests; CI reads a gz toy.
+- **Why first:** hard prerequisite for index build and for gz reads.
+
+### B2 — Multi-contig FM-index build + `Locus` mapping (in-RAM)
+- `BlockedFMIndex::build_multi(ContigSet, &concat)`; global→`Locus` resolve; cross-boundary rejection;
+  contig-aware locate. Still in-RAM (no persistence yet) to **isolate multi-contig correctness from
+  serialization.**
+- **DoD:** 2-contig reference — a read maps to the correct `(contig,pos)`; a boundary-straddling read is
+  rejected; exact-match correctness vs naive on both contigs; deterministic; `build_multi` errors at
+  `len >= 2^32`.
+
+### B3 — Zero-copy persistence: format + serializer + `FmIndexView` + `rosalind index`
+- Extend the section set (§5); serialize the queryable FM-index deterministically; implement
+  `BwtBacking` + `FmIndexView<'a>`; add the `rosalind index` subcommand.
+- **DoD (headline gates):** view == in-RAM index (equivalence battery); index file byte-identical across
+  builds; load performs no SA-IS; basic load-residency check (index not resident); **SA samples stored
+  compactly** (the index file scales as `O(reference + bwt_len/rate)`, not `O(bwt_len)` in the sample
+  array). Round-trip test over a multi-contig reference.
+
+### B4 — Wire consumers + whole-genome pileup walk
+- `align`/`variants`/`somatic` take `--index`; load `FmIndexView`; drop the single-contig blocker and
+  the per-run `BWTAligner::new(reference)` rebuild. Pileup iterates per contig across the genome.
+  `@SQ`/`##contig` for all contigs. Stale-index BLAKE3 guard. `variants`/`somatic` drop the
+  `--reference` requirement (served from the index).
+- **DoD:** multi-contig FASTA → index → align → sort → variants → VCF with calls on ≥2 contigs, correct
+  `##contig`, deterministic; stale index rejected with a clear message.
+
+### B5 — Pipe-native composition + receipt covers the index
+- `-` conventions for align reads/output and variants alignments; `open_input`/`open_output` helpers.
+  Sort stays spill-to-disk internally but reads/writes streams at its ends; `variants` documents that
+  stdin must be coordinate-sorted. `RunManifest` records the index path + BLAKE3.
+- **DoD:** `align - | sort - | variants -` equals the file-based VCF; receipt includes the index hash;
+  determinism holds across the pipe.
+
+### B6 — Minimal per-pillar CI + docs-truth (scoped to what B ships)
+- CI: index round-trip/determinism job; multi-contig gz e2e (index→align→sort→variants on a ≥2-contig
+  toy); `bcftools view`/`samtools quickcheck` when available. README "Current scope" updated
+  (multi-contig, persisted index, gzip); `docs/index-format.md` published.
+- **DoD:** new CI jobs green; README no longer claims single-contig/uncompressed-only; format
+  documented. (Clippy `-D` + theory gating remain Phase E.)
+
+---
+
+## 10. Testing strategy (TDD — failing test first per stage)
+
+- **Reader fidelity (B1):** multi-record FASTA/FASTQ parsing; gz vs plain byte-equality; `-`/stdin;
+  truncated/malformed records produce typed errors, not panics.
+- **Multi-contig correctness (B2):** map-to-correct-contig; boundary-straddle rejection; exact-match vs
+  naive over a 2-contig reference; `len >= 2^32` error path (small synthetic via a stubbed length
+  check).
+- **Zero-copy equivalence + determinism (B3):** the equivalence battery (view vs in-RAM, many
+  patterns); index file byte-identical across two builds; section-extent validation; corrupt/truncated
+  index rejected.
+- **End-to-end multi-contig (B4):** 2-contig gz reference + reads spanning both → align → sort →
+  variants → expected multi-`##contig` VCF; stale-index guard fires on reference mismatch.
+- **Pipe equivalence (B5):** piped path VCF == file-based path VCF; receipt determinism incl. the index
+  hash.
+- **Property/regression carried from A:** existing determinism/space-bounds/fm-index-props/golden-vcf
+  suites stay green; `golden_vcf` extended for multi-contig.
+
+---
+
+## 11. Risks & mitigations
+
+- **Zero-copy refactor is the largest piece.** *Mitigation:* the build-side/read-side split avoids a
+  risky in-place rewrite of `BlockedFMIndex`; the `BwtBacking` trait keeps one FM-algorithm source of
+  truth; the equivalence test makes any divergence loud. B2 proves multi-contig correctness *before* B3
+  touches serialization.
+- **Alignment-quality scope creep.** *Mitigation:* §2 hard boundary — keep the existing seed→chain→
+  extend math; only make it multi-contig + index-backed. MAPQ/soft-clip quality is explicitly a later
+  phase.
+- **bgzf vs gzip confusion.** *Mitigation:* B reads both *sequentially* via `flate2::MultiGzDecoder`
+  (bgzf is concatenated gzip members); random-access bgzf (virtual offsets, `.gzi`/`.csi`) is Phase D
+  and explicitly out.
+- **u32 SA ceiling surprising a user with a >4.29 Gbp target.** *Mitigation:* a typed build error +
+  documentation in README and `index-format.md`; the `u64` coordinate API is preserved so a future u64
+  SA is a format-version bump, not an API break.
+- **mmap memory story overclaiming.** *Mitigation:* document that the index is OS page-cache (not the
+  budgeted working set); the load-residency check guards against accidental full-read; the enforced RSS
+  gate lands in D.
+- **`--reference` removal is a CLI change.** *Mitigation:* note in CHANGELOG; `variants`/`somatic` read
+  the reference from the self-contained index; keep a clear error if neither an index nor a reference is
+  available.
+- **Index *build* is memory-heavy on large genomes** (SA-IS workspace + the SA itself are `O(reference)`;
+  the dense sample array is removed per §3.6, but SA-IS over a human genome is still a big-machine, not a
+  laptop, operation). *Mitigation:* this is the accepted "build is O(reference), documented separately"
+  caveat — the promise is that *using* (mmap-load + query) the index is bounded. Document the build
+  footprint in `index-format.md`; a streaming/low-memory SA construction is explicitly out of Phase B
+  scope.
+
+---
+
+## 12. CI additions (minimal, per-pillar — full hardening is Phase E)
+
+- **Index determinism job:** build the toy index twice; assert byte-identical files; assert
+  `IndexReader::open` round-trips.
+- **Multi-contig gz e2e:** generate a ≥2-contig gzipped toy; `index` → `align` (from `-`) → `sort` →
+  `variants`; assert calls on ≥2 contigs and a `##contig` per contig.
+- **Standards validation (best-effort):** `samtools quickcheck` the BAM and `bcftools view` the VCF when
+  the tools are present on the runner.
+
+Clippy `-D warnings` across the legacy tree, theory-layer feature-gating, and the `lib.rs` crate-doc
+honesty pass remain **Phase E**.

--- a/src/io/decompress.rs
+++ b/src/io/decompress.rs
@@ -1,0 +1,148 @@
+//! Transparent decompression + stream plumbing for pipe-native IO.
+//!
+//! Input may be plain text or gzip-compressed; bgzf (the BAM/"block gzip"
+//! format) is a series of concatenated gzip members, so a multi-member gzip
+//! decoder reads it transparently for sequential access. Random-access bgzf
+//! (virtual offsets, `.gzi`/`.csi`) is Phase D and is not handled here.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::Path;
+
+use flate2::bufread::MultiGzDecoder;
+
+/// The two-byte gzip magic prefix (`1f 8b`), shared by plain gzip and bgzf.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// Wrap a buffered reader, transparently decompressing if it begins with the
+/// gzip magic (`1f 8b`). Plain input passes through unchanged.
+///
+/// The two magic bytes are read out and then restored via [`Read::chain`], so
+/// the returned reader still yields the complete original stream. The probe
+/// loops because [`Read::read`] (like `fill_buf`) may return fewer bytes than
+/// asked for — this keeps detection correct even for sources that deliver one
+/// byte at a time (e.g. a trickling pipe).
+pub fn maybe_decompress<R: BufRead + 'static>(mut reader: R) -> io::Result<Box<dyn BufRead>> {
+    let mut magic = [0u8; 2];
+    let mut filled = 0;
+    while filled < magic.len() {
+        match reader.read(&mut magic[filled..]) {
+            Ok(0) => break, // EOF before two bytes: cannot be gzip
+            Ok(n) => filled += n,
+            Err(e) => return Err(e),
+        }
+    }
+    let restored = io::Cursor::new(magic[..filled].to_vec()).chain(reader);
+    if filled == 2 && magic == GZIP_MAGIC {
+        // `MultiGzDecoder` decodes concatenated members (covers bgzf) but is
+        // `Read`-only, so wrap it back into a `BufReader` for the `BufRead` return.
+        Ok(Box::new(BufReader::new(MultiGzDecoder::new(restored))))
+    } else {
+        Ok(Box::new(restored))
+    }
+}
+
+/// Open `path` (or `-` for stdin) as a transparently-decompressed buffered reader.
+pub fn open_input<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn BufRead>> {
+    let path = path.as_ref();
+    if path.as_os_str() == "-" {
+        maybe_decompress(BufReader::new(io::stdin()))
+    } else {
+        maybe_decompress(BufReader::new(File::open(path)?))
+    }
+}
+
+/// Open `path` (or `-` for stdout) as a buffered writer.
+pub fn open_output<P: AsRef<Path>>(path: P) -> io::Result<Box<dyn Write>> {
+    let path = path.as_ref();
+    if path.as_os_str() == "-" {
+        Ok(Box::new(io::BufWriter::new(io::stdout())))
+    } else {
+        Ok(Box::new(io::BufWriter::new(File::create(path)?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Cursor;
+
+    fn gzip(bytes: &[u8]) -> Vec<u8> {
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(bytes).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn plain_input_passes_through() {
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(b"plain text".to_vec()))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "plain text");
+    }
+
+    #[test]
+    fn gzip_input_is_transparently_decompressed() {
+        let gz = gzip(b"hello world");
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(gz))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn empty_input_is_treated_as_plain_and_yields_nothing() {
+        let mut out = String::new();
+        maybe_decompress(Cursor::new(Vec::<u8>::new()))
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "");
+    }
+
+    /// A `BufRead` that releases at most one byte per call, to prove magic
+    /// detection survives sources that don't deliver two bytes at once.
+    struct Trickle {
+        data: Vec<u8>,
+        pos: usize,
+    }
+
+    impl Read for Trickle {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.pos >= self.data.len() || buf.is_empty() {
+                return Ok(0);
+            }
+            buf[0] = self.data[self.pos];
+            self.pos += 1;
+            Ok(1)
+        }
+    }
+
+    impl BufRead for Trickle {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            let end = (self.pos + 1).min(self.data.len());
+            Ok(&self.data[self.pos..end])
+        }
+        fn consume(&mut self, amt: usize) {
+            self.pos += amt;
+        }
+    }
+
+    #[test]
+    fn gzip_detected_even_when_source_yields_one_byte_at_a_time() {
+        let gz = gzip(b"trickled gzip payload");
+        let reader = Trickle { data: gz, pos: 0 };
+        let mut out = String::new();
+        maybe_decompress(reader)
+            .unwrap()
+            .read_to_string(&mut out)
+            .unwrap();
+        assert_eq!(out, "trickled gzip payload");
+    }
+}

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1,0 +1,173 @@
+//! Streaming, multi-record FASTA reader. Library-first: owned records, typed
+//! `CoreError`, no CLI (`anyhow`) or htslib types. One record per `>` header;
+//! sequence bytes are uppercased and newline-stripped. Read-length/contig-count
+//! agnostic — the multi-contig *consumer* is Phase B4; this reader already
+//! yields every record.
+
+use std::io::BufRead;
+
+use crate::core::CoreError;
+
+/// One FASTA record: a contig name and its uppercased sequence bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FastaRecord {
+    /// First whitespace-delimited token of the `>` header line.
+    pub name: String,
+    /// Sequence bytes, ASCII-uppercased, with line breaks removed.
+    pub sequence: Vec<u8>,
+}
+
+/// A streaming reader over a FASTA source, yielding one [`FastaRecord`] per header.
+#[derive(Debug)]
+pub struct FastaReader<R: BufRead> {
+    reader: R,
+    /// The header (without `>`) of the record that the previous `next()` peeked.
+    pending_header: Option<String>,
+    line: String,
+}
+
+impl<R: BufRead> FastaReader<R> {
+    /// Construct a reader over any buffered source.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            pending_header: None,
+            line: String::new(),
+        }
+    }
+}
+
+impl<R: BufRead> Iterator for FastaReader<R> {
+    type Item = Result<FastaRecord, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Establish this record's header (from the peeked one, or by scanning).
+        let header = match self.pending_header.take() {
+            Some(h) => h,
+            None => loop {
+                self.line.clear();
+                match self.reader.read_line(&mut self.line) {
+                    Ok(0) => return None, // clean EOF: no more records
+                    Ok(_) => {}
+                    Err(e) => return Some(Err(CoreError::Io(e))),
+                }
+                let trimmed = self.line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match trimmed.strip_prefix('>') {
+                    Some(rest) => break rest.to_string(),
+                    None => {
+                        return Some(Err(CoreError::MalformedRecord(format!(
+                            "expected FASTA header starting with '>', found '{trimmed}'"
+                        ))))
+                    }
+                }
+            },
+        };
+
+        let name = match header.split_whitespace().next() {
+            Some(n) => n.to_string(),
+            None => {
+                return Some(Err(CoreError::MalformedRecord(
+                    "FASTA header has no name".to_string(),
+                )))
+            }
+        };
+
+        // Accumulate sequence lines until the next header or EOF.
+        let mut sequence = Vec::new();
+        loop {
+            self.line.clear();
+            match self.reader.read_line(&mut self.line) {
+                Ok(0) => break, // EOF terminates the final record
+                Ok(_) => {}
+                Err(e) => return Some(Err(CoreError::Io(e))),
+            }
+            let trimmed = self.line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix('>') {
+                self.pending_header = Some(rest.to_string());
+                break;
+            }
+            sequence.extend(trimmed.bytes().map(|b| b.to_ascii_uppercase()));
+        }
+
+        if sequence.is_empty() {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "FASTA record '{name}' has no sequence data"
+            ))));
+        }
+
+        Some(Ok(FastaRecord { name, sequence }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ContigSet;
+    use std::io::Cursor;
+
+    fn read_all(input: &str) -> Vec<FastaRecord> {
+        FastaReader::new(Cursor::new(input.as_bytes().to_vec()))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("FASTA should parse")
+    }
+
+    #[test]
+    fn reads_single_record_uppercased() {
+        let recs = read_all(">chr1 some description\nacgt\nACGT\n");
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].name, "chr1");
+        assert_eq!(recs[0].sequence, b"ACGTACGT");
+    }
+
+    #[test]
+    fn reads_three_records_and_builds_a_three_contig_set() {
+        let recs = read_all(">chr1\nACGT\n>chr2\nAACCGGTT\n>chr3\nGG\n");
+        assert_eq!(recs.len(), 3);
+
+        let mut contigs = ContigSet::new();
+        for r in &recs {
+            contigs.push(r.name.clone(), r.sequence.len() as u32);
+        }
+        assert_eq!(contigs.len(), 3);
+        assert_eq!(contigs.by_name("chr2").unwrap().id, 1);
+        // chr1(4) + chr2(8) → chr3 starts at global offset 12.
+        assert_eq!(contigs.by_name("chr3").unwrap().global_offset, 12);
+    }
+
+    #[test]
+    fn skips_blank_lines_between_records() {
+        let recs = read_all("\n>chr1\nAC\n\nGT\n\n>chr2\nTT\n");
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].sequence, b"ACGT");
+        assert_eq!(recs[1].sequence, b"TT");
+    }
+
+    #[test]
+    fn missing_header_is_a_malformed_record_error() {
+        let err = FastaReader::new(Cursor::new(b"ACGT\n".to_vec()))
+            .next()
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn header_without_sequence_is_a_malformed_record_error() {
+        let err = FastaReader::new(Cursor::new(b">chr1\n".to_vec()))
+            .next()
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn empty_input_yields_no_records() {
+        assert!(read_all("").is_empty());
+    }
+}

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -1,0 +1,179 @@
+//! Streaming FASTQ reader. Library-first: owned records, typed `CoreError`, no
+//! CLI/htslib types. Four lines per record (`@name`, sequence, `+`, qualities);
+//! sequence is uppercased; qualities are kept as raw ASCII (Phred+33) bytes.
+
+use std::io::BufRead;
+
+use crate::core::CoreError;
+
+/// One FASTQ record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FastqRecord {
+    /// First whitespace-delimited token of the `@` header line.
+    pub name: String,
+    /// Sequence bytes, ASCII-uppercased.
+    pub sequence: Vec<u8>,
+    /// Quality bytes as raw ASCII (Phred+33), same length as `sequence`.
+    pub qualities: Vec<u8>,
+}
+
+/// A streaming reader over a FASTQ source, yielding one [`FastqRecord`] per 4 lines.
+#[derive(Debug)]
+pub struct FastqReader<R: BufRead> {
+    reader: R,
+    line: String,
+}
+
+impl<R: BufRead> FastqReader<R> {
+    /// Construct a reader over any buffered source.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            line: String::new(),
+        }
+    }
+
+    /// Read the next non-blank line, or `None` at clean EOF.
+    fn next_nonblank(&mut self) -> Result<Option<String>, CoreError> {
+        loop {
+            self.line.clear();
+            let n = self.reader.read_line(&mut self.line)?;
+            if n == 0 {
+                return Ok(None);
+            }
+            let trimmed = self.line.trim();
+            if !trimmed.is_empty() {
+                return Ok(Some(trimmed.to_string()));
+            }
+        }
+    }
+
+    /// Read the next line; a clean EOF here is a malformed (truncated) record.
+    fn next_required(&mut self, ctx: &str) -> Result<String, CoreError> {
+        self.line.clear();
+        let n = self.reader.read_line(&mut self.line)?;
+        if n == 0 {
+            return Err(CoreError::MalformedRecord(format!(
+                "unexpected end of FASTQ while reading {ctx}"
+            )));
+        }
+        Ok(self.line.trim().to_string())
+    }
+}
+
+impl<R: BufRead> Iterator for FastqReader<R> {
+    type Item = Result<FastqRecord, CoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let header = match self.next_nonblank() {
+            Ok(Some(h)) => h,
+            Ok(None) => return None, // clean EOF between records
+            Err(e) => return Some(Err(e)),
+        };
+        let name = match header.strip_prefix('@') {
+            Some(rest) => match rest.split_whitespace().next() {
+                Some(n) => n.to_string(),
+                None => {
+                    return Some(Err(CoreError::MalformedRecord(
+                        "FASTQ header has no read name".to_string(),
+                    )))
+                }
+            },
+            None => {
+                return Some(Err(CoreError::MalformedRecord(format!(
+                    "expected FASTQ header starting with '@', found '{header}'"
+                ))))
+            }
+        };
+
+        let sequence = match self.next_required("sequence") {
+            Ok(s) => s.to_ascii_uppercase().into_bytes(),
+            Err(e) => return Some(Err(e)),
+        };
+        let plus = match self.next_required("'+' separator") {
+            Ok(s) => s,
+            Err(e) => return Some(Err(e)),
+        };
+        if !plus.starts_with('+') {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "expected '+' separator for read '{name}', found '{plus}'"
+            ))));
+        }
+        let qualities = match self.next_required("qualities") {
+            Ok(s) => s.into_bytes(),
+            Err(e) => return Some(Err(e)),
+        };
+        if sequence.len() != qualities.len() {
+            return Some(Err(CoreError::MalformedRecord(format!(
+                "sequence/quality length mismatch for read '{name}' ({} vs {})",
+                sequence.len(),
+                qualities.len()
+            ))));
+        }
+
+        Some(Ok(FastqRecord {
+            name,
+            sequence,
+            qualities,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn read_all(input: &str) -> Result<Vec<FastqRecord>, CoreError> {
+        FastqReader::new(Cursor::new(input.as_bytes().to_vec())).collect()
+    }
+
+    #[test]
+    fn reads_two_records_and_trims_name_after_space() {
+        let recs = read_all("@read1 1:N:0:CG\nacgt\n+\nIIII\n@read2\nTT\n+\n##\n").unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].name, "read1");
+        assert_eq!(recs[0].sequence, b"ACGT");
+        assert_eq!(recs[0].qualities, b"IIII");
+        assert_eq!(recs[1].name, "read2");
+    }
+
+    #[test]
+    fn missing_at_prefix_is_malformed() {
+        let err = read_all("read1\nACGT\n+\nIIII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn missing_plus_separator_is_malformed() {
+        let err = read_all("@read1\nACGT\n-\nIIII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn seq_qual_length_mismatch_is_malformed() {
+        let err = read_all("@read1\nACGT\n+\nII\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn truncated_record_at_eof_is_malformed() {
+        let err = read_all("@read1\nACGT\n").unwrap_err();
+        assert!(matches!(err, CoreError::MalformedRecord(_)));
+    }
+
+    #[test]
+    fn empty_input_yields_no_records() {
+        assert!(read_all("").unwrap().is_empty());
+    }
+
+    #[test]
+    fn quality_line_starting_with_at_is_not_a_header() {
+        // Classic FASTQ trap: a quality line may legitimately begin with '@'.
+        // The parser reads 4 lines per record positionally, so this must NOT be
+        // mistaken for the next record's header.
+        let recs = read_all("@r1\nACGT\n+\n@III\n").unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].qualities, b"@III");
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,4 +4,6 @@
 
 pub mod vcf;
 
+pub mod decompress;
+
 pub mod bam;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -8,4 +8,6 @@ pub mod decompress;
 
 pub mod fasta;
 
+pub mod fastq;
+
 pub mod bam;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,4 +6,6 @@ pub mod vcf;
 
 pub mod decompress;
 
+pub mod fasta;
+
 pub mod bam;

--- a/src/main.rs
+++ b/src/main.rs
@@ -843,8 +843,7 @@ fn run_variants(
 /// are warned about (multi-contig consumption is a later phase). The streaming
 /// parser itself lives in `io::fasta`.
 fn read_fasta(path: &PathBuf) -> Result<FastaRecord> {
-    let reader =
-        open_input(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let reader = open_input(path).with_context(|| format!("failed to open {}", path.display()))?;
     let mut records = FastaReader::new(reader);
     let first = records
         .next()

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ use rosalind::genomics::{
     compare_callsets, create_bam_writer, read_vcf_variants, sort_bam_deterministic, AlignedRead,
     BWTAligner, BedIndex, CigarOp, CigarOpKind,
 };
+use rosalind::io::decompress::open_input;
+use rosalind::io::fasta::{FastaReader, FastaRecord};
+use rosalind::io::fastq::{FastqReader, FastqRecord};
 use rosalind::util::rss::peak_rss_bytes;
 use rust_htslib::bam::Read as BamRead;
 use rust_htslib::bam::{
@@ -147,18 +150,6 @@ enum Commands {
 enum OutputFormat {
     Sam,
     Bam,
-}
-
-struct FastaRecord {
-    name: String,
-    sequence: Vec<u8>,
-}
-
-#[derive(Debug, Clone)]
-struct FastqRecord {
-    name: String,
-    sequence: Vec<u8>,
-    qualities: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -847,112 +838,36 @@ fn run_variants(
     Ok(())
 }
 
+/// Read a reference FASTA (plain or gzip; `-` = stdin). Phase B1 keeps the
+/// single-contig CLI policy: only the first record is used; additional records
+/// are warned about (multi-contig consumption is a later phase). The streaming
+/// parser itself lives in `io::fasta`.
 fn read_fasta(path: &PathBuf) -> Result<FastaRecord> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
-
-    let mut name = None;
-    let mut sequence = String::new();
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        if trimmed.starts_with('>') {
-            if name.is_some() {
-                eprintln!(
-                    "warning: only the first FASTA record is currently used; ignoring '{}'",
-                    trimmed
-                );
-                break;
-            }
-            let header = trimmed.trim_start_matches('>').trim();
-            let primary_name = header
-                .split_whitespace()
-                .next()
-                .ok_or_else(|| anyhow!("FASTA header '{}' has no name", header))?
-                .to_string();
-            name = Some(primary_name);
-        } else {
-            sequence.push_str(trimmed);
-        }
+    let reader =
+        open_input(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut records = FastaReader::new(reader);
+    let first = records
+        .next()
+        .ok_or_else(|| anyhow!("FASTA file {} is missing a record", path.display()))?
+        .with_context(|| format!("failed to parse FASTA {}", path.display()))?;
+    if records.next().is_some() {
+        eprintln!(
+            "warning: {}: only the first FASTA record is currently used; ignoring the rest \
+             (multi-contig lands in a later phase)",
+            path.display()
+        );
     }
-
-    let name = name.ok_or_else(|| anyhow!("FASTA file {} is missing a header", path.display()))?;
-    if sequence.is_empty() {
-        bail!("FASTA record {} has no sequence data", name);
-    }
-
-    Ok(FastaRecord {
-        name,
-        sequence: sequence.to_ascii_uppercase().into_bytes(),
-    })
+    Ok(first)
 }
 
+/// Read a FASTQ file (plain or gzip; `-` = stdin) into a vector of records.
+/// The streaming parser lives in `io::fastq`.
 fn read_fastq(path: &PathBuf) -> Result<Vec<FastqRecord>> {
-    let file = File::open(path)
+    let reader = open_input(path)
         .with_context(|| format!("failed to open FASTQ file {}", path.display()))?;
-    let mut reader = BufReader::new(file).lines();
-    let mut records = Vec::new();
-
-    while let Some(header) = reader.next() {
-        let header = header?;
-        if header.trim().is_empty() {
-            continue;
-        }
-        if !header.starts_with('@') {
-            bail!(
-                "expected FASTQ header starting with '@', got '{}' in {}",
-                header,
-                path.display()
-            );
-        }
-        let header_rest = header[1..].trim();
-        let name = header_rest
-            .split_whitespace()
-            .next()
-            .ok_or_else(|| anyhow!("FASTQ header '{}' has no read name", header))?
-            .to_string();
-
-        let seq_line = reader
-            .next()
-            .ok_or_else(|| anyhow!("unexpected end of FASTQ file while reading {}", name))??;
-        let plus_line = reader
-            .next()
-            .ok_or_else(|| anyhow!("unexpected end of FASTQ file after sequence {}", name))??;
-        if !plus_line.trim().starts_with('+') {
-            bail!(
-                "expected '+' separator after sequence for read {}, found '{}'",
-                name,
-                plus_line
-            );
-        }
-        let qual_line = reader
-            .next()
-            .ok_or_else(|| anyhow!("unexpected end of FASTQ file after '+' for {}", name))??;
-
-        let sequence = seq_line.trim().to_ascii_uppercase().into_bytes();
-        let qualities = qual_line.trim().as_bytes().to_vec();
-
-        if sequence.len() != qualities.len() {
-            bail!(
-                "sequence/quality length mismatch for read {} ({} vs {})",
-                name,
-                sequence.len(),
-                qualities.len()
-            );
-        }
-
-        records.push(FastqRecord {
-            name,
-            sequence,
-            qualities,
-        });
-    }
-
-    Ok(records)
+    FastqReader::new(reader)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to parse FASTQ {}", path.display()))
 }
 
 fn normalize_read_name(raw: &str) -> String {

--- a/tests/io_readers.rs
+++ b/tests/io_readers.rs
@@ -1,0 +1,39 @@
+//! Phase B1 DoD: the public reader API reads gzipped, multi-record FASTA and
+//! produces a multi-contig ContigSet.
+
+use std::io::{Cursor, Write};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use rosalind::core::ContigSet;
+use rosalind::io::decompress::maybe_decompress;
+use rosalind::io::fasta::FastaReader;
+
+fn gzip(bytes: &[u8]) -> Vec<u8> {
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(bytes).unwrap();
+    enc.finish().unwrap()
+}
+
+#[test]
+fn gzipped_multi_record_fasta_builds_a_contig_set() {
+    let fasta = b">chr1 first\nACGTACGT\n>chr2\nAACC\n>chr3\nGGGGTTTT\n";
+    let gz = gzip(fasta);
+
+    let reader = maybe_decompress(Cursor::new(gz)).unwrap();
+    let records: Vec<_> = FastaReader::new(reader)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("gz FASTA should parse");
+
+    assert_eq!(records.len(), 3);
+
+    let mut contigs = ContigSet::new();
+    for r in &records {
+        contigs.push(r.name.clone(), r.sequence.len() as u32);
+    }
+    assert_eq!(contigs.len(), 3);
+    assert_eq!(contigs.by_name("chr1").unwrap().global_offset, 0);
+    assert_eq!(contigs.by_name("chr2").unwrap().global_offset, 8);
+    assert_eq!(contigs.by_name("chr3").unwrap().global_offset, 12);
+    assert_eq!(contigs.total_length(), 20);
+}


### PR DESCRIPTION
## Summary

Lands the **Phase B** ("make it real on a genome") design spec and its first stage, **B1 — streaming ingestion**.

- **Design spec** (`docs/superpowers/specs/2026-05-27-phase-b-genome-scale-design.md`): multi-contig + build-once **mmap** FM-index + streaming/gzip ingestion + pipe-native, decomposed into six green-landing stages B1–B6. Locks the key decisions (mmap/OS-paged index, zero-copy load via a build-side/read-side split + `BwtBacking` trait + equivalence gate, `u32` SA with documented ceiling stored **compactly**, self-contained 2-bit-reference index).
- **B1** moves FASTA/FASTQ **parsing out of `main.rs`** into a library-first `io/` layer:
  - `io::fasta` — streaming, multi-record `FastaReader` (→ `ContigSet`-ready records).
  - `io::fastq` — streaming `FastqReader` (positional 4-line parsing; the `@`-quality-line trap is handled + tested).
  - `io::decompress` — transparent **gzip/bgzf-sequential** decompression (magic-sniffed, short-read-safe) + `open_input`/`open_output` that treat `-` as stdin/stdout.
  - `main.rs` now reads through these (gaining **gzip + stdin** support); CLI behavior unchanged — single-contig until B4 — and ~86 lines lighter.
- Library-first throughout: the `io/` readers return typed `core::CoreError`; no `anyhow`/`rust_htslib` types leak into public signatures.

Scope held: no changes to alignment, calling, sorting, the FM-index, or index persistence (those are later Phase B stages).

## Test plan

- [x] Full suite green — 22 test binaries, **0 failures** (114 lib + integration)
- [x] `cargo fmt --all -- --check` clean; `cargo build` **0 warnings**; no clippy lints in the new `io/` modules
- [x] Unit coverage: gzip-vs-plain transparency, one-byte-at-a-time (trickle) magic detection, multi-record + blank-line handling, `@`-as-quality regression, and all malformed/truncated error paths (typed `MalformedRecord`, no panics)
- [x] Public-API integration test: gzipped multi-record FASTA → 3-contig `ContigSet` with asserted offsets
- [x] CLI smoke: `align --reads reads.fastq.gz` and a gzipped reference both align **byte-identically** to plain input; stdin (`-`) works
- [x] Per-task spec + code-quality reviews on Tasks 1–4; final whole-branch review → ready to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)