### PR TITLE
Trust + correctness hardening keystone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,37 @@ jobs:
           test -s examples/data/illumina_toy/alignments.bam
           grep -q '^#CHROM' examples/data/illumina_toy/variants.vcf
           grep -q -v '^#' examples/data/illumina_toy/variants.vcf || echo \"warning: no variant lines emitted\"
+      - name: Build index for the bounded contract path
+        run: |
+          cargo run --release -- index \
+            --reference examples/data/illumina_toy/reference.fa \
+            --output examples/data/illumina_toy/reference.idx
+      - name: Sort the BAM for the contract path
+        run: |
+          cargo run --release -- sort \
+            --input examples/data/illumina_toy/alignments.bam \
+            --output examples/data/illumina_toy/sorted.bam
+      - name: Contract gate — fits / verify / refuse (bounded --index path)
+        run: |
+          set -e
+          # (1) Generous budget fits -> exit 0 + "contract: OK".
+          cargo run --release -- variants --index examples/data/illumina_toy/reference.idx \
+            --alignments examples/data/illumina_toy/sorted.bam \
+            --memory-budget-mb 4096 --enforce \
+            -o examples/data/illumina_toy/contract.vcf 2> ok.log
+          grep -q "contract: OK" ok.log
+          # (2) Verify the receipt without re-running -> exit 0.
+          cargo run --release -- verify \
+            --manifest examples/data/illumina_toy/contract.vcf.manifest.json | grep -q "verify: OK"
+          # (3) 1 MiB budget refuses up front -> exit 3, and writes no VCF.
+          rm -f examples/data/illumina_toy/refused.vcf
+          set +e
+          cargo run --release -- variants --index examples/data/illumina_toy/reference.idx \
+            --alignments examples/data/illumina_toy/sorted.bam \
+            --memory-budget-mb 1 --enforce \
+            -o examples/data/illumina_toy/refused.vcf 2> refuse.log
+          code=$?
+          set -e
+          test "$code" -eq 3
+          grep -q "REFUSE" refuse.log
+          test ! -f examples/data/illumina_toy/refused.vcf

--- a/docs/superpowers/plans/2026-06-02-trust-correctness-hardening-keystone.md
+++ b/docs/superpowers/plans/2026-06-02-trust-correctness-hardening-keystone.md
@@ -1,0 +1,864 @@
+# Trust + Correctness Hardening Keystone — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans (inline) to implement
+> this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the shipped memory contract's correctness + trust guarantees actually hold and be
+tested: stop the depth cap from silently dropping real variants, keep output byte-identical, surface
+when the cap engages, enforce `--max-read-len`, and regression-guard the exit-4 breach path + a CI
+memory gate.
+
+**Architecture:** All changes are on the call/contract path. The depth cap becomes a fixed-seed
+min-hash bounded reservoir (unbiased, deterministic, bounded). Obs are emitted in a canonical total
+order so the f64 likelihood sum is order-independent. `SkipCounts` is threaded out to the CLI +
+receipt. `--max-read-len` becomes an ingest precondition under `--enforce`. A post-run-only RSS test
+seam makes the exit-4 branch testable; CI exercises the bounded `--index` path.
+
+**Tech stack:** Rust (MSRV 1.72), `cargo test`/`fmt`, GitHub Actions. Spec:
+`docs/superpowers/specs/2026-06-02-trust-correctness-hardening-keystone-design.md`.
+
+**Conventions:** TDD (failing test first), per-task commit, 0 warnings (debug + release),
+`cargo fmt --all -- --check` clean, full `cargo test` green at each task boundary. Branch:
+`rosalind/trust-correctness-keystone`.
+
+---
+
+## File map
+
+- `src/pileup/engine.rs` — Item A (reservoir + `read_priority` + `ActiveRead.priority`), Item B
+  (canonical obs in `build_column`), Item D (`PileupParams.max_read_len` + ingest check).
+- `src/call/pipeline.rs`, `src/call/whole_genome.rs` — Item C (return `SkipCounts`).
+- `src/core/error.rs` — Item D (`ReadExceedsDeclaredLength` variant).
+- `src/main.rs` — Item C (stderr summary + receipt fields), Item D (pass `max_read_len` under
+  `--enforce`, help-text fixes), Item E (force-RSS seam at the realized-peak capture).
+- `src/call/plan.rs` — Item D (fix the contradictory comment).
+- `tests/plan_enforce.rs` — Items C/D/E integration tests.
+- `.github/workflows/ci.yml` — Item F (contract gate on `--index`).
+
+---
+
+## Task 1: Canonical obs order in `build_column` (Item B)
+
+**Files:** Modify `src/pileup/engine.rs` (`build_column`, ~262-302) + a unit test.
+
+Rationale: Item A reorders the active set; the germline f64 likelihood sum
+(`src/call/germline.rs:48-58`) is over `column.obs` in order and is non-associative. Emitting obs in
+a canonical total order makes downstream QUAL/PL byte-identical regardless of active-set order.
+
+- [ ] **Step 1: Write the failing test** (append to `engine.rs` `#[cfg(test)] mod tests`)
+
+```rust
+    #[test]
+    fn obs_are_emitted_in_canonical_order() {
+        // A column with mixed alleles/quals must emit obs sorted by
+        // (allele, base_qual, mapq, reverse) — independent of read arrival order,
+        // so the downstream f64 likelihood sum is order-stable.
+        let reference = b"AAAA";
+        // Three reads covering pos 0 with different alleles at offset 0:
+        //  C (allele 1), A (allele 0, ref), G (allele 2). Arrival order C,A,G.
+        let reads = vec![
+            mread(0, b"C", false),
+            mread(0, b"A", false),
+            mread(0, b"G", false),
+        ];
+        let cols = columns(engine(reads, reference));
+        let at0 = cols.iter().find(|c| c.locus.pos.0 == 0).unwrap();
+        let alleles: Vec<u8> = at0.obs.iter().map(|o| o.allele).collect();
+        // Canonical: sorted ascending by allele (0,1,2) regardless of C,A,G arrival.
+        assert_eq!(alleles, vec![0, 1, 2]);
+    }
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (current order is arrival order C,A,G → `[1,0,2]`)
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests::obs_are_emitted_in_canonical_order`
+Expected: assertion failure `[1, 0, 2]` vs `[0, 1, 2]`.
+
+- [ ] **Step 3: Implement — sort obs canonically in `build_column`**
+
+In `build_column`, after the `for r in &self.active { … obs.push(Obs { … }) … }` loop and before
+constructing `PileupColumn`, insert:
+
+```rust
+        // Emit observations in a canonical total order so the downstream diploid
+        // log-likelihood accumulation (germline.rs) is order-independent and the
+        // VCF stays byte-identical regardless of active-set internal order.
+        obs.sort_by(|a, b| {
+            (a.allele, a.base_qual, a.mapq, a.reverse as u8).cmp(&(
+                b.allele,
+                b.base_qual,
+                b.mapq,
+                b.reverse as u8,
+            ))
+        });
+```
+
+- [ ] **Step 4: Run the new test + the golden/determinism suite**
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests::obs_are_emitted_in_canonical_order`
+Expected: PASS.
+Run: `cargo test --test golden_vcf --test determinism`
+Expected: PASS (uniform-quality fixtures ⇒ reordering identical terms doesn't change QUAL/PL). If
+`golden_vcf` fails, inspect the diff — it must be at most a ±1 rounding artifact from reordered
+summation; regenerate with `ROSALIND_UPDATE_SNAPSHOTS=1 cargo test --test golden_vcf` and note it in
+the commit. Any larger/structural change is a bug — stop and investigate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pileup/engine.rs tests/snapshots 2>/dev/null; git add -A
+git commit -m "fix(pileup): emit obs in canonical order (order-stable QUAL/PL)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Unbiased hash-priority depth-cap reservoir (Item A)
+
+**Files:** Modify `src/pileup/engine.rs` (`ActiveRead`, `ingest`, `advance_to`, a new `read_priority`
+free fn) + tests.
+
+- [ ] **Step 1: Write the failing regression test** (append to `engine.rs` tests)
+
+```rust
+    #[test]
+    fn unbiased_cap_keeps_downstream_starting_reads() {
+        // The biased (leftmost-arrival) cap dropped reads that START at a deep
+        // variant, zeroing the alt allele. The min-hash reservoir keeps a
+        // start-position-independent sample, so a variant carried only by reads
+        // that begin AT the variant column survives. Reads must be DISTINCT
+        // (real reads are) — identical content shares one hash and degenerates.
+        let reference = vec![b'A'; 64];
+        let v = 32u32; // variant column
+        let cap = 30u32;
+        let mut reads = Vec::new();
+        // 30 ref reads starting upstream (pos 0), distinct lengths -> distinct
+        // hashes, all carrying A (ref) at v.
+        for i in 0..30u32 {
+            let len = 33 + i as usize; // covers v=32 (len>32); 33..62 < 64
+            reads.push(mread(0, &vec![b'A'; len], false));
+        }
+        // 30 alt reads starting AT v, distinct lengths, carrying C at v (offset 0).
+        for j in 0..30u32 {
+            let len = 1 + j as usize; // start v, covers v
+            let mut seq = vec![b'A'; len];
+            seq[0] = b'C';
+            reads.push(mread(v, &seq, false));
+        }
+        let params = PileupParams {
+            max_depth: Some(cap),
+            ..PileupParams::default()
+        };
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.into_boxed_slice()),
+            0,
+            0..64,
+            params,
+        );
+        let mut at_v = None;
+        while let Some(c) = e.next() {
+            let col = c.unwrap();
+            if col.locus.pos.0 == v {
+                at_v = Some(col);
+            }
+        }
+        let counts = at_v.expect("a column at v").allele_counts();
+        // Both alleles present: ref (A=0) AND alt (C=1) — the biased cap gave alt==0.
+        assert!(counts[1] > 0, "alt allele must survive the cap: {counts:?}");
+        assert!(counts[0] > 0, "ref allele must remain too: {counts:?}");
+        // Capped: total observed at v <= cap.
+        assert!(counts.iter().sum::<u32>() <= cap, "depth must be capped");
+    }
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (current biased cap: `counts[1] == 0`)
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests::unbiased_cap_keeps_downstream_starting_reads`
+Expected: assertion `alt allele must survive the cap` fails (alt == 0).
+
+- [ ] **Step 3: Implement the reservoir**
+
+(3a) Add a fixed-seed FNV-1a `read_priority` free fn near the top of `engine.rs` (after imports):
+
+```rust
+/// Fixed-seed FNV-1a-64 over a read's identity (position, end, flags, CIGAR, seq,
+/// qual). Deterministic across runs/processes (NOT `DefaultHasher`, whose seed is
+/// per-process). Uncorrelated with the allele at any single column — the basis of
+/// the unbiased depth-cap sample.
+fn read_priority(read: &AlignedRead) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    #[inline]
+    fn fold(mut h: u64, bytes: &[u8]) -> u64 {
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        h
+    }
+    let mut h = FNV_OFFSET;
+    h = fold(h, &read.pos.0.to_le_bytes());
+    h = fold(h, &read.end().to_le_bytes());
+    h = fold(h, &read.flags.0.to_le_bytes());
+    for op in &read.cigar {
+        h = fold(h, &[op.kind as u8]);
+        h = fold(h, &op.len.to_le_bytes());
+    }
+    h = fold(h, &read.seq);
+    h = fold(h, &read.qual);
+    h
+}
+```
+
+(3b) Add `priority: u64` to `ActiveRead` (after `reverse: bool`):
+
+```rust
+    /// Fixed-seed content hash — the reservoir admission/eviction key.
+    priority: u64,
+```
+
+(3c) Change `ingest` to take the precomputed priority:
+
+```rust
+    /// Precompute a read's reference→read-offset map and add it to the active set.
+    fn ingest(&mut self, read: AlignedRead, priority: u64) {
+        let end = read.end();
+        let mut ref_to_read = HashMap::new();
+        for rb in read.projected_bases() {
+            ref_to_read.insert(rb.ref_pos, rb.read_offset);
+        }
+        self.active.push(ActiveRead {
+            end,
+            ref_to_read,
+            seq: Arc::clone(&read.seq),
+            qual: Arc::clone(&read.qual),
+            mapq: read.mapq,
+            reverse: read.flags.is_reverse(),
+            priority,
+        });
+    }
+```
+
+(3d) In `advance_to`, replace the cap block (the `if let Some(max) = self.params.max_depth { if
+self.active.len() as u32 >= max { self.skips.over_max_depth += 1; continue; } }` and the following
+`self.ingest(read);`) with:
+
+```rust
+                    let prio = read_priority(&read);
+                    if let Some(max) = self.params.max_depth {
+                        if self.active.len() as u32 >= max {
+                            // Unbiased min-hash reservoir: keep the `max`
+                            // smallest-priority reads covering the cursor. Evict the
+                            // greatest-priority resident iff the newcomer ranks below
+                            // it; otherwise refuse. Either way the cap removed one
+                            // read (counted). Priority is a fixed-seed content hash,
+                            // so selection is independent of start position / allele.
+                            let mut worst = 0usize;
+                            for i in 1..self.active.len() {
+                                if self.active[i].priority > self.active[worst].priority {
+                                    worst = i;
+                                }
+                            }
+                            self.skips.over_max_depth += 1;
+                            if prio < self.active[worst].priority {
+                                self.active.swap_remove(worst);
+                                self.ingest(read, prio);
+                            }
+                            continue;
+                        }
+                    }
+                    self.ingest(read, prio);
+```
+
+- [ ] **Step 4: Run the new test + the existing cap/bounded tests**
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests`
+Expected: PASS, including `unbiased_cap_keeps_downstream_starting_reads`,
+`max_depth_caps_active_set_deterministically` (5 identical reads share a hash ⇒ ties ⇒ no eviction ⇒
+first-2 kept, over=3 — unchanged), and `working_set_is_bounded_by_coverage_not_input_size`.
+
+- [ ] **Step 5: Full suite + warnings + fmt**
+
+Run: `cargo test` ; `cargo build --release 2>&1 | grep -c warning: || true` (expect 0) ;
+`cargo fmt --all -- --check`
+Expected: all green, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix(pileup): unbiased min-hash depth-cap reservoir (no silent variant drops)
+
+Replaces leftmost-arrival truncation with a fixed-seed content-hash bounded
+reservoir + eviction. Keeps a start-position/allele-independent sample at the
+declared cap; a deep het variant carried by reads starting at the variant
+survives. Deterministic and bounded at max_depth. Regression test included.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Surface `SkipCounts` on the `--index` path + receipt (Item C)
+
+**Files:** Modify `src/pileup/engine.rs` (`SkipCounts::accumulate`), `src/call/pipeline.rs`,
+`src/call/whole_genome.rs`, `src/main.rs` + tests.
+
+- [ ] **Step 1: Add a `SkipCounts` accumulator + test** (engine.rs)
+
+In `impl SkipCounts` (after `total`):
+
+```rust
+    /// Field-wise sum (across per-contig engines on the whole-genome path).
+    pub fn accumulate(&mut self, other: &SkipCounts) {
+        self.unmapped += other.unmapped;
+        self.wrong_contig += other.wrong_contig;
+        self.secondary += other.secondary;
+        self.supplementary += other.supplementary;
+        self.duplicate += other.duplicate;
+        self.low_mapq += other.low_mapq;
+        self.over_max_depth += other.over_max_depth;
+    }
+```
+
+Test (engine.rs tests):
+
+```rust
+    #[test]
+    fn skip_counts_accumulate_sums_fieldwise() {
+        let mut a = SkipCounts {
+            over_max_depth: 2,
+            low_mapq: 1,
+            ..SkipCounts::default()
+        };
+        let b = SkipCounts {
+            over_max_depth: 3,
+            duplicate: 4,
+            ..SkipCounts::default()
+        };
+        a.accumulate(&b);
+        assert_eq!(a.over_max_depth, 5);
+        assert_eq!(a.low_mapq, 1);
+        assert_eq!(a.duplicate, 4);
+    }
+```
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests::skip_counts_accumulate_sums_fieldwise` →
+PASS (pure addition).
+
+- [ ] **Step 2: Change `call_germline_region_streaming` to return `(WorkingSet, SkipCounts)`**
+
+In `src/call/pipeline.rs`, change the signature + body:
+
+```rust
+pub fn call_germline_region_streaming<S: ReadSource>(
+    source: S,
+    reference: Arc<[u8]>,
+    contig: u32,
+    region: Range<u32>,
+    pileup_params: PileupParams,
+    germline_params: &GermlineParams,
+    on_row: &mut dyn FnMut((Locus, u8, GermlineCall)) -> Result<(), CoreError>,
+) -> Result<(WorkingSet, SkipCounts), CoreError> {
+    let mut engine = PileupEngine::new(source, reference, contig, region, pileup_params);
+    let mut max_ws = WorkingSet { bytes: 0 };
+    while let Some(column) = engine.next() {
+        let column = column?;
+        let ws = engine.current_working_set();
+        if ws.bytes > max_ws.bytes {
+            max_ws = ws;
+        }
+        if let Some(call) = call_germline(&column, germline_params) {
+            on_row((column.locus, column.ref_base, call))?;
+        }
+    }
+    Ok((max_ws, engine.skip_counts()))
+}
+```
+
+Add `SkipCounts` to the `use crate::pileup::{…}` import line. Update `call_germline_region_tracked`
+(it calls `_streaming`): destructure `(ws, _skips)` and keep returning `(Vec, WorkingSet)`:
+
+```rust
+    let (ws, _skips) = call_germline_region_streaming( … same args … )?;
+    Ok((out, ws))
+```
+
+(`call_germline_region` is unchanged — it calls `_tracked`.)
+
+- [ ] **Step 3: Change `call_germline_whole_genome` to return `(WorkingSet, SkipCounts)`**
+
+In `src/call/whole_genome.rs`: add `SkipCounts` to the `use crate::pileup::{…}` import; change the
+return type and accumulate per contig:
+
+```rust
+) -> Result<(WorkingSet, SkipCounts), CoreError> {
+    let mut max_ws = WorkingSet { bytes: 0 };
+    let mut skips = SkipCounts::default();
+    let mut peeked: Option<AlignedRead> = None;
+
+    for c in contigs.iter() {
+        // … decode reference, build `per`, region (unchanged) …
+        let (ws, contig_skips) = call_germline_region_streaming(
+            per,
+            reference,
+            c.id,
+            region,
+            pileup_params.clone(),
+            germline_params,
+            on_row,
+        )?;
+        if ws.bytes > max_ws.bytes {
+            max_ws = ws;
+        }
+        skips.accumulate(&contig_skips);
+    }
+
+    Ok((max_ws, skips))
+}
+```
+
+Update the in-file test `whole_genome_equals_per_contig_calls`: it binds `let ws =
+call_germline_whole_genome(…)` → change to `let (ws, _skips) = call_germline_whole_genome(…)`.
+Update `working_set_is_bounded_by_reference_and_capped_depth_not_read_count`: the `run` closure ends
+`.unwrap().bytes` → change to `.unwrap().0.bytes`.
+
+- [ ] **Step 4: Update `main.rs` call sites + stderr summary + receipt fields**
+
+In `run_variants_index` (`src/main.rs:1294-1350`), both match arms bind `let ws =
+call_germline_whole_genome(…)?;` and `ws` at the arm tail. Change the outer binding to capture both:
+make each arm return `(ws, skips)` and bind `let (max_ws, skips) = match &output { … };`.
+Concretely, in each arm replace `let ws = call_germline_whole_genome(…)…?; writer.flush()?; ws`
+with `let (ws, sk) = call_germline_whole_genome(…)…?; writer.flush()?; (ws, sk)` and change the
+outer `let max_ws = match &output {` to `let (max_ws, skips) = match &output {`.
+
+After the realized-peak line (`eprintln!("memory: peak RSS …")`, ~1430-1434), add the skip summary:
+
+```rust
+    if skips.over_max_depth > 0 {
+        eprintln!(
+            "pileup: dropped {} reads at --max-depth {} (deep-site downsampling — \
+             calls at those sites use a bounded unbiased sample)",
+            skips.over_max_depth, max_depth
+        );
+    }
+    let other_skipped = skips.total() - skips.over_max_depth;
+    if other_skipped > 0 {
+        eprintln!(
+            "pileup: skipped {other_skipped} reads by filter (unmapped/wrong-contig/\
+             secondary/supplementary/duplicate/low-mapq)"
+        );
+    }
+```
+
+In the receipt block (after `max_working_set_bytes`, ~1412), add:
+
+```rust
+        manifest
+            .params
+            .insert("over_max_depth".to_string(), skips.over_max_depth.to_string());
+        manifest
+            .params
+            .insert("reads_skipped_total".to_string(), skips.total().to_string());
+```
+
+- [ ] **Step 5: Add an integration test** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn receipt_records_skip_counts() {
+    // The standard fixture (5 reads, max depth way below default 1000) drops
+    // nothing → over_max_depth 0. A tight --max-depth 1 forces drops → > 0.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let manifest = dir.join("run.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--max-depth", "1", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    let json = std::fs::read_to_string(&manifest).unwrap();
+    assert!(
+        json.contains("\"over_max_depth\":") && json.contains("\"reads_skipped_total\":"),
+        "manifest missing skip fields: {json}"
+    );
+    // At pos 0 the fixture stacks >1 read; --max-depth 1 must drop at least one.
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&json).unwrap();
+    let over: u64 = m.params.get("over_max_depth").unwrap().parse().unwrap();
+    assert!(over > 0, "tight cap should drop reads, got {over}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 6: Run, verify, commit**
+
+Run: `cargo test` ; `cargo build --release 2>&1 | grep -c warning: || true` ;
+`cargo fmt --all -- --check`
+Expected: all green, 0 warnings. (Also confirm `stdout_run_persists_a_self_describing_receipt` and
+`estimator_upper_bounds_the_realized_working_set` still pass — they don't read the new fields.)
+
+```bash
+git add -A
+git commit -m "feat(variants): surface depth-cap + filter skip counts (stderr + receipt)
+
+Thread SkipCounts out of the streaming + whole-genome callers; print a summary
+when the cap engages; record over_max_depth + reads_skipped_total in the
+manifest so the receipt is honest about whether downsampling was load-bearing.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Enforce `--max-read-len` at ingest under `--enforce` (Item D)
+
+**Files:** `src/core/error.rs`, `src/pileup/engine.rs` (`PileupParams` + `advance_to`),
+`src/main.rs`, `src/call/plan.rs` (comment) + tests.
+
+- [ ] **Step 1: Add the error variant** (`src/core/error.rs`, inside `enum CoreError`)
+
+```rust
+    /// A read longer than the declared `--max-read-len` voids the predicted
+    /// memory envelope (raised only under `--enforce`).
+    #[error("read length {len} exceeds declared --max-read-len {declared}; raise --max-read-len or drop --enforce")]
+    ReadExceedsDeclaredLength {
+        /// The offending read's sequence length.
+        len: u32,
+        /// The declared cap.
+        declared: u32,
+    },
+```
+
+- [ ] **Step 2: Add `max_read_len` to `PileupParams` + failing test** (`src/pileup/engine.rs`)
+
+Add field (after `max_depth`):
+
+```rust
+    /// When `Some(m)` (set only under `--enforce`), a read whose `seq.len()`
+    /// exceeds `m` aborts the run (the predicted envelope assumes `<= m`).
+    /// `None` = no check (default).
+    pub max_read_len: Option<u32>,
+```
+
+Add `max_read_len: None` to the `Default` impl.
+
+Failing test (engine.rs tests):
+
+```rust
+    #[test]
+    fn read_exceeding_declared_max_read_len_errors() {
+        let reference = b"AAAAAAAA";
+        let params = PileupParams {
+            max_read_len: Some(4),
+            ..PileupParams::default()
+        };
+        let mut e = PileupEngine::new(
+            SliceSource::new(vec![mread(0, b"CCCCCC", false)]), // len 6 > 4
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..8,
+            params,
+        );
+        let err = loop {
+            match e.next() {
+                Some(Ok(_)) => continue,
+                Some(Err(err)) => break err,
+                None => panic!("expected an error, got clean end"),
+            }
+        };
+        assert!(matches!(
+            err,
+            crate::core::CoreError::ReadExceedsDeclaredLength { len: 6, declared: 4 }
+        ));
+    }
+```
+
+Run: `cargo test -p rosalind --lib pileup::engine::tests::read_exceeding_declared_max_read_len_errors`
+→ FAIL (no check yet; `CoreError` variant must compile first — add Step 1 before running).
+
+- [ ] **Step 3: Implement the ingest check** (`advance_to`, just before `let prio = read_priority`)
+
+```rust
+                    if let Some(maxlen) = self.params.max_read_len {
+                        if read.seq.len() as u32 > maxlen {
+                            return Err(CoreError::ReadExceedsDeclaredLength {
+                                len: read.seq.len() as u32,
+                                declared: maxlen,
+                            });
+                        }
+                    }
+```
+
+Run the test → PASS. Confirm `long_read_piles_up_every_matched_base` (max_read_len `None`) still
+passes.
+
+- [ ] **Step 4: Wire it under `--enforce` in `main.rs` + fix help/comment text**
+
+(4a) `run_variants_index` builds `pileup_params`. Find where `PileupParams { … max_depth … }` is
+constructed (the `max_depth == 0 → None` logic) and set `max_read_len`:
+
+```rust
+        max_read_len: if enforce { Some(max_read_len) } else { None },
+```
+
+(4b) Fix the stale `--memory-budget-mb` help (`src/main.rs:96-97`):
+
+```rust
+        /// Declared memory budget (MiB) for the run — records a plan/peak line.
+        /// With `--enforce`, it is honored (exit 3 refuse / exit 4 breach). (`--index` path.)
+```
+
+(4c) Update the `--max-read-len` help (`src/main.rs:104-106`):
+
+```rust
+        /// Max read length assumed by the pre-run `--enforce` estimate AND
+        /// enforced at ingest under `--enforce` (a longer read aborts the run).
+```
+
+(4d) Fix the contradictory comment in `src/call/plan.rs:19-20` (it claims `max_read_len` is
+"enforced at runtime"): reword to state the estimate assumes `<= --max-read-len`, which `--enforce`
+now checks at ingest (engine.rs).
+
+- [ ] **Step 5: Integration test** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn enforce_aborts_on_a_read_longer_than_declared_max_read_len() {
+    // Standard fixture has 16 bp reads. Declare --max-read-len 8 under --enforce
+    // (with a generous budget so we hit the ingest check, not the exit-3 gate).
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args([
+            "--memory-budget-mb", "4096",
+            "--max-read-len", "8",
+            "--max-depth", "1000",
+            "--enforce",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "over-long read must abort: {out:?}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("exceeds declared --max-read-len"),
+        "missing clear message: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+Note: confirm the budget passes the exit-3 gate at `--max-read-len 8` (predicted uses 8 → smaller →
+fits 4096), so the run proceeds to ingest and hits the abort. If exit-3 intervenes, raise the budget.
+
+- [ ] **Step 6: Run, verify, commit**
+
+Run: `cargo test` ; `cargo build --release 2>&1 | grep -c warning: || true` ;
+`cargo fmt --all -- --check` → all green, 0 warnings.
+
+```bash
+git add -A
+git commit -m "feat(enforce): check --max-read-len at ingest (close the silent-OOM path)
+
+Under --enforce, a read whose seq.len() exceeds the declared --max-read-len
+aborts loudly (CoreError::ReadExceedsDeclaredLength) instead of silently voiding
+the predicted envelope. Non-enforced runs are unaffected. Fixes the contradictory
+plan.rs comment and the stale --memory-budget-mb / --max-read-len help text.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Test the exit-4 realized-breach path (Item E)
+
+**Files:** `src/main.rs` (force-RSS seam at the realized-peak capture), `tests/plan_enforce.rs`.
+
+- [ ] **Step 1: Add the post-run-only force seam** (`src/main.rs`, the realized-peak capture ~1352)
+
+Replace `let peak_rss = peak_rss_bytes();` with:
+
+```rust
+    // Realized peak (monotonic high-water mark) captured after the calling pass.
+    // Test-only seam: ROSALIND_FORCE_PEAK_RSS_BYTES overrides ONLY the post-run
+    // realized peak (never the pre-run baseline at the --enforce gate), so the
+    // exit-4 breach branch can be exercised deterministically without allocating.
+    let peak_rss = std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or_else(peak_rss_bytes);
+```
+
+- [ ] **Step 2: Write the exit-4 test** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn enforce_breach_exits_4_after_writing_output_and_receipt() {
+    // Budget 4096 MiB passes the pre-run exit-3 gate (tiny fixture), but a forced
+    // realized peak of 8 GiB trips the post-run breach -> exit 4, with the VCF +
+    // receipt still written (the documented "output + receipt written" semantics).
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .env("ROSALIND_FORCE_PEAK_RSS_BYTES", "8589934592") // 8 GiB
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(4), "expected breach exit 4: {out:?}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("VIOLATED"), "missing VIOLATED line: {stderr}");
+    // Output + receipt were still written before the breach exit.
+    assert!(vcf.exists(), "VCF must be written before exit 4");
+    let json = std::fs::read_to_string(&manifest).expect("receipt written");
+    assert!(
+        json.contains("\"contract_verdict\":\"over\""),
+        "verdict should be over: {json}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test --test plan_enforce` (incl. the new breach test) ; then `cargo test` full ;
+`cargo build --release 2>&1 | grep -c warning: || true` ; `cargo fmt --all -- --check`
+Expected: all green, 0 warnings.
+
+```bash
+git add -A
+git commit -m "test(enforce): cover the exit-4 realized-breach backstop
+
+Adds a post-run-only ROSALIND_FORCE_PEAK_RSS_BYTES seam to deterministically
+force predicted-fits-yet-realized-overruns, and asserts exit 4 + VIOLATED +
+VCF/receipt still written. The contract's most safety-critical branch was
+previously untested.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: CI memory-envelope gate on the bounded `--index` path (Item F)
+
+**Files:** `.github/workflows/ci.yml`.
+
+- [ ] **Step 1: Add a contract-gate step to the `cli-e2e` job**
+
+After the existing "Call variants" step (which uses the legacy `--reference` path), append steps that
+exercise the bounded `--index` contract on the toy data. (The toy `alignments.bam` is produced by the
+existing "Align to BAM" step; build an index from `reference.fa`, sort the BAM, then enforce.)
+
+```yaml
+      - name: Build index for the contract path
+        run: |
+          cargo run --release -- index \
+            --reference examples/data/illumina_toy/reference.fa \
+            --output examples/data/illumina_toy/reference.idx
+      - name: Sort the BAM
+        run: |
+          cargo run --release -- sort \
+            --input examples/data/illumina_toy/alignments.bam \
+            --output examples/data/illumina_toy/sorted.bam
+      - name: Contract gate — fits, breaches, refuses
+        run: |
+          set -e
+          # (1) Generous budget fits -> exit 0 + "contract: OK".
+          cargo run --release -- variants --index examples/data/illumina_toy/reference.idx \
+            --alignments examples/data/illumina_toy/sorted.bam \
+            --memory-budget-mb 4096 --enforce \
+            -o examples/data/illumina_toy/contract.vcf 2> ok.log
+          grep -q "contract: OK" ok.log
+          # (2) verify the receipt without re-running -> exit 0.
+          cargo run --release -- verify \
+            --manifest examples/data/illumina_toy/contract.vcf.manifest.json | grep -q "verify: OK"
+          # (3) 1 MiB budget refuses up front -> exit 3, no VCF.
+          rm -f examples/data/illumina_toy/refused.vcf
+          set +e
+          cargo run --release -- variants --index examples/data/illumina_toy/reference.idx \
+            --alignments examples/data/illumina_toy/sorted.bam \
+            --memory-budget-mb 1 --enforce \
+            -o examples/data/illumina_toy/refused.vcf 2> refuse.log
+          code=$?
+          set -e
+          test "$code" -eq 3
+          grep -q "REFUSE" refuse.log
+          test ! -f examples/data/illumina_toy/refused.vcf
+```
+
+- [ ] **Step 2: Validate the YAML locally (best-effort) + commit**
+
+Run (best-effort lint; skip if `yamllint` absent):
+`yamllint .github/workflows/ci.yml || echo "yamllint not installed — skipping"`
+Manually re-read the indentation against the existing steps in the file.
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: exercise the bounded variants --index contract (fits / refuse / verify)
+
+Adds a contract gate to cli-e2e: build index -> sort -> variants --index
+--enforce at a generous budget (exit 0 + contract: OK), verify the receipt,
+and a 1 MiB budget (exit 3 refuse, no VCF). Makes 'the bounded contract is
+exercised in CI' literally true, via deterministic exit codes (no RSS-noise
+flakiness; exit-4 is covered deterministically by the force-seam unit test).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Finish — verify, push, PR (no merge)
+
+**Files:** none (release hygiene).
+
+- [ ] **Step 1: Full green gate**
+
+Run: `cargo fmt --all -- --check` ; `cargo test` ;
+`cargo build 2>&1 | grep -c warning: || true` ; `cargo build --release 2>&1 | grep -c warning: || true`
+Expected: fmt clean, full suite green, 0 warnings (debug + release).
+
+- [ ] **Step 2: Skim the diff for honesty + scope**
+
+Run: `git log --oneline main..HEAD` and `git diff --stat main..HEAD`. Confirm only the 6 keystone
+items changed; no cross-cutting (sort.rs, bam.rs @SQ, rss.rs unit fix) leaked in.
+
+- [ ] **Step 3: Push the branch + open the PR (DO NOT MERGE)**
+
+```bash
+git push -u origin rosalind/trust-correctness-keystone
+gh pr create --title "Trust + correctness hardening keystone" --body "$(cat <<'EOF'
+## Summary
+The 6 call/contract-path items from the 2026-06-02 reflection audit:
+- **Unbiased depth cap** — replace leftmost-arrival truncation with a fixed-seed min-hash bounded reservoir (no more silent het drops at deep sites); deterministic + bounded at `max_depth`.
+- **Canonical obs order** — `build_column` emits obs sorted by `(allele, base_qual, mapq, reverse)` so the f64 QUAL/PL sum is order-independent (byte-identical VCF).
+- **Surface skip counts** — thread `SkipCounts` out to a stderr summary + `over_max_depth`/`reads_skipped_total` in the receipt.
+- **`--max-read-len` enforcement** — under `--enforce`, an over-long read aborts loudly instead of voiding the predicted envelope; fixes stale help/comment text.
+- **Exit-4 breach test** — a post-run-only `ROSALIND_FORCE_PEAK_RSS_BYTES` seam makes the "never a silent overrun" backstop testable; asserts exit 4 + `VIOLATED` + output/receipt written.
+- **CI memory gate** — `cli-e2e` now exercises the bounded `variants --index` contract (fits / refuse / verify).
+
+Deferred to a fast-follow (out of scope here): sort tie-break, `@SQ` length check, BSD `ru_maxrss` unit fix + cgroup-awareness, front-door honesty pass, merging PR #23.
+
+## Test plan
+- [ ] `cargo test` green (incl. new unbiased-cap, obs-order, skip-count, max-read-len, and exit-4 tests)
+- [ ] `cargo fmt --all -- --check` clean; 0 warnings (debug + release)
+- [ ] CI contract gate passes (fits exit 0 / refuse exit 3 / verify OK)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Report the PR URL to the user; await merge authorization.** Do NOT merge to `main`.

--- a/docs/superpowers/specs/2026-06-02-trust-correctness-hardening-keystone-design.md
+++ b/docs/superpowers/specs/2026-06-02-trust-correctness-hardening-keystone-design.md
@@ -1,0 +1,255 @@
+# Trust + Correctness Hardening — Keystone (design)
+
+**Status:** DESIGN SPEC — 2026-06-02. Approved decisions captured below; ready for the
+implementation plan after user review. **Branch:** `rosalind/trust-correctness-keystone` (off `main`
+`b6fdfda`). **Source:** the 2026-06-02 reflection audit (16-agent workflow) — see the conversation
+record; the audit's `strongest_gap` (depth-cap silent variant drops) and `strongest_next_step`
+(exit-4 + CI gate untested) are the two anchors of this increment.
+
+## 1. Goal
+
+Make the shipped memory contract's **correctness** and **trust** guarantees actually hold and be
+tested, before we deepen or grow the system. Concretely: stop the variant caller from silently
+dropping real variants, and regression-guard the two claims most central to the pitch
+("honor-or-breach / never a silent overrun" and "CI-enforced bound"), which the audit found are the
+two **least** covered.
+
+This is the **keystone** increment. It is scoped to the call/contract path so it is one coherent,
+reviewable PR. Cross-cutting hardening (sort tie-break, `@SQ` length check, BSD `ru_maxrss` unit
+fix + cgroup-awareness, manifest provenance, front-door honesty pass, merging PR #23) is sequenced
+to a **fast-follow** increment (§7) and is explicitly out of scope here.
+
+## 2. Approved decisions (locked)
+
+1. **Depth-cap algorithm:** unbiased **hash-priority bounded reservoir** (min-hash with eviction).
+2. **Default `--max-depth`:** keep **1000** (now unbiased), plus a stderr warning + a receipt field
+   when the cap engages.
+3. **First-PR scope:** the **6 keystone items** (§4). Guards + cross-cutting → fast-follow.
+
+## 3. Background: the two verified problems
+
+- **Silent variant drops (correctness blocker).** `PileupEngine::advance_to`
+  (`src/pileup/engine.rs:249-254`) refuses *new arrivals* once `self.active.len() >= max`, retaining
+  reads that started upstream. A read's start position correlates with which allele it carries near
+  that start, so the cap is **allele-biased**: an agent reproduced a true 30:30 het SNV becoming
+  **zero variant calls** at `--max-depth 30` (the alt reads, which start at the variant, are all
+  dropped → the site reads as hom-ref → abstain). The default cap is 1000, so this bites at any site
+  deeper than 1000× (panels/amplicon/deep-tumor). The `over_max_depth` skip count is computed
+  (`engine.rs:251`) but **never surfaced** on the `--index` path or in the receipt.
+- **f64 order-sensitivity (propagation).** `site_likelihoods` (`src/call/germline.rs:48-58`)
+  accumulates `log_l[0/1/2] += …` by summing over `column.obs` **in active-set order**. f64 addition
+  is non-associative, so any fix that reorders the active set would change QUAL/PL bytes. `build_column`
+  (`engine.rs:271-292`) emits `obs` in `self.active` Vec order. **The cap fix and an obs-order
+  canonicalization must land together** to preserve byte-identical output.
+
+## 4. The six keystone items
+
+### Item A — unbiased hash-priority depth-cap reservoir
+
+**Files:** `src/pileup/engine.rs` (modify).
+
+Replace leftmost-arrival truncation with a **min-hash bounded reservoir**:
+
+- Add a fixed-seed content hash to each active read. `priority(read) = fnv1a64(pos.0, end, flags.0,
+  cigar bytes, &seq, &qual)`. **Fixed seed** (a hand-rolled FNV-1a, *not* `std::collections`'
+  `RandomState`/`DefaultHasher`, whose per-process seed would break determinism). The hash is
+  independent of arrival order and uncorrelated with the allele at any single column — this is what
+  removes the bias.
+- `ActiveRead` gains a `priority: u64` field (computed once in `ingest`).
+- In `advance_to`, when a read passes filters and reaches the cursor:
+  - if `self.active.len() < max` → ingest (admit);
+  - else find the resident with the **maximum** priority; if `new.priority < worst.priority` →
+    evict that resident (`self.skips.over_max_depth += 1`) and ingest the newcomer; else refuse the
+    newcomer (`self.skips.over_max_depth += 1`).
+  - `over_max_depth` counts **every read removed by the cap** (refused arrival OR evicted resident);
+    documented as such.
+- Tie semantics: equal priorities ⇒ `new.priority < worst.priority` is false ⇒ no eviction ⇒
+  first-`max` retained. So genuinely identical reads (same content ⇒ same hash) keep the old
+  first-N behavior — the existing `max_depth_caps_active_set_deterministically` test still passes.
+- Finding the max-priority resident: a linear scan over `self.active` (≤ `max` entries) is simple and
+  deterministic; acceptable for the first correct version (optimization to a heap is a later perf
+  fast-follow, not needed for correctness).
+
+**Determinism argument:** given a canonical (coordinate-sorted) input stream, "keep the `max`
+smallest-priority reads among those covering the cursor that we still hold" is order-independent
+(verified by case analysis in the design discussion: arrival orders R1,R2,R3 / R3,R2,R1 / R2,R1,R3
+all converge to the same kept set). Memory stays ≤ `max` active reads (the bounded-memory invariant
+is preserved exactly).
+
+**Tests (engine.rs):**
+- NEW `unbiased_cap_keeps_both_alleles_at_a_deep_het`: reference `A…`; `max_depth = 30`; 30 ref reads
+  whose spans start upstream of the variant column and 30 alt reads starting at the variant column
+  (so the biased cap would drop all alt). Assert the variant column observes **both** alleles
+  (alt count > 0) — i.e. the reproduced bug is fixed.
+- NEW `cap_is_order_independent_with_distinct_reads`: distinct-content reads in two input orders
+  produce identical kept allele counts and identical `over_max_depth`.
+- KEEP `max_depth_caps_active_set_deterministically` (identical reads ⇒ ties ⇒ unchanged) and
+  `working_set_is_bounded_by_coverage_not_input_size` green.
+
+### Item B — obs-order canonicalization (fixes the f64 QUAL/PL order-sensitivity)
+
+**Files:** `src/pileup/engine.rs` (`build_column`).
+
+After collecting `obs` for a column, **sort** it by a total key before returning:
+`(allele, base_qual, mapq, reverse as u8)`. Two observations equal on that key contribute identical
+terms to the log-likelihood sum, so the f64 accumulation in `germline.rs` becomes order-independent
+and byte-identical regardless of active-set order. Cost: sort of ≤ `max_depth` items per column —
+negligible.
+
+**Tests:**
+- NEW (germline.rs): `qual_pl_independent_of_obs_order` — same multiset of observations fed in two
+  orders yields byte-identical `qual`/`pl`. (Construct two `PileupColumn`s with shuffled `obs` and
+  assert equal `GermlineCall`.)
+- The existing determinism test (`tests/determinism.rs`) and golden VCF (`tests/golden_vcf.rs`) must
+  stay green (the canonical order must not change the *current* golden output — verify; if the golden
+  ordering differs, regenerate the snapshot under `ROSALIND_UPDATE_SNAPSHOTS` and note it in the PR).
+
+### Item C — surface SkipCounts on the `--index` path + in the receipt
+
+**Files:** `src/call/pipeline.rs`, `src/call/whole_genome.rs`, `src/main.rs` (modify).
+
+The engine already tracks `SkipCounts` and exposes `skip_counts()`. Plumb it out:
+
+- `call_germline_region_streaming` returns `Result<(WorkingSet, SkipCounts), CoreError>` (read
+  `engine.skip_counts()` after the iteration loop). Update `call_germline_region_tracked` and
+  `call_germline_region` accordingly (they discard the new field).
+- `call_germline_whole_genome` returns `Result<(WorkingSet, SkipCounts), CoreError>`, **summing**
+  `SkipCounts` across contigs (add a `SkipCounts` accumulator; needs field-wise add — add an
+  `impl std::ops::Add` or a `merge`/`accumulate` method on `SkipCounts`).
+- `run_variants_index` (`src/main.rs:1294-1350`): capture the returned `SkipCounts`; after the memory
+  line, print a stderr summary **only when any cap drop occurred**, e.g.
+  `pileup: dropped <over_max_depth> reads at --max-depth <d> (deep-site downsampling)`; print the
+  other skip reasons (low_mapq, secondary, …) if non-zero too (one concise line).
+- Manifest (`src/main.rs:1374-1428`): add params `over_max_depth` and `reads_skipped_total`
+  (`SkipCounts::total()`), so the receipt is honest about whether the cap was load-bearing.
+
+**Tests:**
+- Extend the whole-genome equivalence test (`whole_genome.rs`) to assert the summed `SkipCounts`
+  equals the per-contig sum.
+- `tests/plan_enforce.rs` (or `tests/variants_index.rs`): a `--max-depth`-engaging run records
+  `over_max_depth > 0` in the manifest; a non-engaging run records `0`.
+
+### Item D — `--max-read-len` ingest enforcement (close the live silent-OOM path under `--enforce`)
+
+**Files:** `src/pileup/engine.rs` (`PileupParams`, `advance_to`), `src/main.rs`, `src/call/plan.rs`
+(comment), `src/core` (error variant if needed).
+
+`--max-read-len` is currently prediction-only (`plan.rs`) and never checked at ingest, so a BAM with
+reads longer than the declared cap breaks the predicted envelope by ~40–200× in the under-estimation
+direction (the live "plan says FITS → OOM" path).
+
+- `PileupParams` gains `max_read_len: Option<u32>` (default `None` = no check). It is set to
+  `Some(max_read_len)` **only under `--enforce`** (so non-enforced runs stay backward-compatible and
+  accept long reads, just unbudgeted).
+- In `advance_to`, before ingesting a read that reaches the cursor, if `Some(m) = max_read_len` and
+  the read's `seq.len() as u32 > m`, return `Err(CoreError::…)` with a clear message:
+  `read length <N> exceeds declared --max-read-len <M>; raise --max-read-len or drop --enforce`.
+  Under `--enforce` this aborts the run loudly (propagates to a non-zero exit) rather than silently
+  blowing the envelope. (A reference variant of `CoreError` already exists; reuse the closest generic
+  one or add `ReadExceedsDeclaredLength`. Decide in the plan after reading `src/core/error.rs`.)
+- Honesty fixes (same item): correct the contradictory `plan.rs:19-20` comment (it claims
+  `max_read_len` is "enforced at runtime"); fix the stale `main.rs:96-97` `--memory-budget-mb` help
+  ("does not enforce (enforcement is a later phase)" — `--enforce` now exists); update the
+  `--max-read-len` flag help (`main.rs:104-106`) to state it is enforced at ingest under `--enforce`.
+
+**Tests:**
+- engine.rs: a read longer than `max_read_len` (when `Some`) yields `Err`; when `None`, long reads
+  pile up normally (the existing `long_read_piles_up_every_matched_base` stays green).
+- `tests/plan_enforce.rs`: `variants --index --enforce` on an alignment set containing an over-long
+  read exits non-zero with the clear message.
+
+### Item E — test the exit-4 realized-breach path
+
+**Files:** `src/util/rss.rs` (test seam) or `src/main.rs` (capture site), `tests/plan_enforce.rs`.
+
+The exit-4 branch (`src/main.rs:1449`, the literal "never a silent overrun" backstop) has zero tests.
+To force *predicted-fits-yet-realized-overruns* deterministically (without allocating gigabytes):
+
+- Add a **post-run-only** test seam: at the realized-peak capture (`main.rs:1352`), read
+  `ROSALIND_FORCE_PEAK_RSS_BYTES`; if set and parseable, use it as the realized peak instead of
+  `peak_rss_bytes()`. **It must NOT affect the pre-run baseline** (`main.rs:1267`), so the up-front
+  predicted peak still uses the real (small) baseline and the run passes the exit-3 gate. Document the
+  env var as a test-only seam in code.
+- Test (`tests/plan_enforce.rs`): run `variants --index --enforce --memory-budget-mb B -o <vcf>` on
+  the bundled fixture with `B` chosen above the real predicted peak (so exit-3 passes) and
+  `ROSALIND_FORCE_PEAK_RSS_BYTES` set above `B` (so the realized check fails). Assert: **exit 4**,
+  stderr contains `VIOLATED`, and the **VCF + manifest were still written** (the documented
+  "output + receipt written" semantics). Add a companion assertion that the manifest's
+  `contract_verdict` is `over`.
+
+### Item F — CI memory-envelope gate on the bounded `--index` path
+
+**Files:** `.github/workflows/ci.yml` (modify).
+
+CI has no RSS gate today and its e2e job exercises only the legacy `--reference` path. Add a job (or
+extend `cli-e2e`) that exercises the **bounded `--index` contract** on a fixture, asserting the
+contract fires — using deterministic, non-flaky signals (not a tight RSS threshold on a noisy
+runner):
+
+- index → sort → `variants --index --enforce --memory-budget-mb <fits> -o out.vcf` → assert exit 0
+  and stderr `contract: OK — realized peak … within`.
+- `variants --index --enforce --memory-budget-mb 1` → assert **exit 3** (`REFUSE`, pre-run,
+  deterministic) and that **no VCF was written**.
+- `verify` the receipt → assert exit 0.
+- Optionally assert the receipt's `max_working_set_bytes` (deterministic) is below a generous bound.
+
+This makes "the bounded contract is exercised in CI" literally true via the `--index` path and the
+exit-3 refuse, without depending on run-to-run RSS variance. (The exit-4 branch is covered
+deterministically by Item E's force-seam test, which runs under `cargo test` in CI.)
+
+## 5. Cross-cutting requirements
+
+- **Determinism is the non-negotiable invariant.** After Items A+B, the `variants --index` VCF must be
+  byte-identical regardless of input read order and of the (content-based) cap selection. The golden
+  VCF + determinism tests are the guard.
+- **No new warnings** (debug + release); `cargo fmt --check` clean; full `cargo test` green.
+- **Backward compatibility:** non-`--enforce` runs behave as before except for the (now unbiased) cap
+  and the canonical obs order. The cap default stays 1000.
+- **Honesty:** every place a number or guarantee is surfaced (stderr, receipt, help text) must match
+  the code. The Item-D help-text fixes are part of this.
+
+## 6. Risks
+
+- **Golden-snapshot churn (low):** obs-order canonicalization could change the byte order of the
+  current golden VCF if the existing arrival order happened to differ from the canonical key order.
+  Mitigation: verify; regenerate the snapshot deliberately under `ROSALIND_UPDATE_SNAPSHOTS` if needed
+  and call it out in the PR (the *values* must be unchanged — only obs accumulation order, which must
+  not change emitted QUAL/PL beyond the documented canonicalization).
+- **Eviction accounting (low):** counting both refused arrivals and evicted residents as
+  `over_max_depth` slightly overcounts "reads not present in any column," but it honestly reports
+  "reads the cap removed." Documented; the point is to surface that the cap engaged, not exact
+  bookkeeping.
+- **`--max-read-len` abort leaves a partial VCF (low/acceptable):** under `--enforce`, an over-long
+  read aborts mid-run after some rows are written. This is the *safe* direction (loud failure, not a
+  silent OOM); documented. A clean pre-scan would defeat streaming, so we accept the loud mid-run
+  abort.
+
+## 7. Out of scope (fast-follow increment 2)
+
+Deferred, with the audit severities noted — to be specced separately after this lands:
+- **sort k-way-merge tie-break** (finding #5, high) — `src/genomics/sort.rs`: add `source_idx`
+  (global arrival index) as the final tie-break in `HeapItem::cmp` so sort output is budget-invariant.
+  (Note: Item B already defuses the *VCF* propagation of this; the remaining issue is sorted-BAM
+  byte-identity across `--memory-mb`.)
+- **`@SQ` contig-length cross-check** (finding #7, high) — `src/io/bam.rs`: reject a BAM whose header
+  contig lengths disagree with the index.
+- **BSD `ru_maxrss` unit fix + cgroup-awareness + manifest os/arch provenance** (findings #6, medium)
+  — `src/util/rss.rs`, `src/provenance/mod.rs`.
+- **Front-door honesty pass** (low) — kill the `O(√t)` overclaim in `Cargo.toml` description, the CLI
+  `--help` about-string, and `scale_test_results.txt`; fix `CONTRACT.md`'s "byte-identical manifest".
+- **Merge PR #23** (the 41 B/base `BuildMemoryModel`) so `plan --reference` stops under-predicting
+  build RAM ~3.4× — a merge decision reserved for the user.
+
+## 8. Self-review
+
+- **Spec coverage:** all 6 approved items have a file list, a design, and tests. The two anchors
+  (depth-cap blocker; exit-4 + CI) are Items A/C and E/F. ✓
+- **Type consistency:** `SkipCounts` return-type change is threaded through all three call-path
+  functions (`_streaming`, `_tracked`, `_region`, `_whole_genome`) and the `main.rs` call sites;
+  `PileupParams` gains one optional field used in `advance_to`. ✓
+- **No placeholders:** the one deliberately-deferred detail is the exact `CoreError` variant for Item
+  D (decide after reading `src/core/error.rs` in the plan) — flagged, not hidden. ✓
+- **Scope:** single coherent PR on the call/contract path; cross-cutting items explicitly deferred
+  with severities (§7). ✓
+- **Determinism:** Items A+B are designed together precisely because the cap reorders the active set
+  and the f64 sum is order-sensitive; the golden/determinism tests guard byte-identity. ✓

--- a/src/call/pipeline.rs
+++ b/src/call/pipeline.rs
@@ -9,7 +9,7 @@ use crate::call::{
     call_germline, call_somatic, GermlineCall, GermlineParams, SomaticCall, SomaticParams,
 };
 use crate::core::{CoreError, Locus, WorkingSet};
-use crate::pileup::{PileupColumn, PileupEngine, PileupParams, ReadSource};
+use crate::pileup::{PileupColumn, PileupEngine, PileupParams, ReadSource, SkipCounts};
 
 /// Stream germline calls over `region` of `contig` to a sink, returning the
 /// maximum pileup-engine working set observed (the bounded-memory signal behind
@@ -25,7 +25,7 @@ pub fn call_germline_region_streaming<S: ReadSource>(
     pileup_params: PileupParams,
     germline_params: &GermlineParams,
     on_row: &mut dyn FnMut((Locus, u8, GermlineCall)) -> Result<(), CoreError>,
-) -> Result<WorkingSet, CoreError> {
+) -> Result<(WorkingSet, SkipCounts), CoreError> {
     let mut engine = PileupEngine::new(source, reference, contig, region, pileup_params);
     let mut max_ws = WorkingSet { bytes: 0 };
     while let Some(column) = engine.next() {
@@ -38,7 +38,7 @@ pub fn call_germline_region_streaming<S: ReadSource>(
             on_row((column.locus, column.ref_base, call))?;
         }
     }
-    Ok(max_ws)
+    Ok((max_ws, engine.skip_counts()))
 }
 
 /// Like [`call_germline_region`], but also returns the maximum pileup-engine
@@ -53,7 +53,7 @@ pub fn call_germline_region_tracked<S: ReadSource>(
     germline_params: &GermlineParams,
 ) -> Result<(Vec<(Locus, u8, GermlineCall)>, WorkingSet), CoreError> {
     let mut out = Vec::new();
-    let ws = call_germline_region_streaming(
+    let (ws, _skips) = call_germline_region_streaming(
         source,
         reference,
         contig,
@@ -265,7 +265,7 @@ mod tests {
         .unwrap();
         // Streaming path: push into a Vec via the sink, capture the working set.
         let mut streamed = Vec::new();
-        let ws = call_germline_region_streaming(
+        let (ws, _skips) = call_germline_region_streaming(
             SliceSource::new(reads),
             reference,
             0,

--- a/src/call/plan.rs
+++ b/src/call/plan.rs
@@ -15,9 +15,11 @@ use crate::core::{
 
 /// Estimate the peak streaming working set of a whole-genome germline call: the
 /// largest contig's reference (decoded, 1×) + the depth-capped active read set +
-/// the fixed engine overhead. A true upper bound when actual reads do not exceed
-/// `max_read_len` and depth is capped at `max_depth` (both enforced at runtime —
-/// `max_read_len` is the one assumption, with the post-run check as backstop).
+/// the fixed engine overhead. An upper bound when actual reads do not exceed
+/// `max_read_len` and depth is capped at `max_depth`. Depth is always enforced at
+/// runtime (the pileup reservoir bounds the active set); `max_read_len` is checked
+/// at ingest under `--enforce` (a longer read aborts the run, so it cannot silently
+/// exceed the bound), with the realized post-run RSS check as the final backstop.
 pub fn estimate_variants_working_set(
     largest_contig_len: u64,
     max_depth: u32,

--- a/src/call/whole_genome.rs
+++ b/src/call/whole_genome.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use crate::call::{call_germline_region_streaming, GermlineCall, GermlineParams};
 use crate::core::{AlignedRead, ContigSet, CoreError, Locus, WorkingSet};
 use crate::genomics::ReferenceView;
-use crate::pileup::{PileupParams, ReadSource};
+use crate::pileup::{PileupParams, ReadSource, SkipCounts};
 
 /// Per-contig view over a shared sorted stream: yields contig `contig`'s reads,
 /// then stops at (and buffers) the first read of a later contig.
@@ -52,8 +52,9 @@ pub fn call_germline_whole_genome<S: ReadSource>(
     pileup_params: PileupParams,
     germline_params: &GermlineParams,
     on_row: &mut dyn FnMut((Locus, u8, GermlineCall)) -> Result<(), CoreError>,
-) -> Result<WorkingSet, CoreError> {
+) -> Result<(WorkingSet, SkipCounts), CoreError> {
     let mut max_ws = WorkingSet { bytes: 0 };
+    let mut skips = SkipCounts::default();
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
@@ -72,7 +73,7 @@ pub fn call_germline_whole_genome<S: ReadSource>(
             peeked: &mut peeked,
         };
         let region: Range<u32> = 0..c.length;
-        let ws = call_germline_region_streaming(
+        let (ws, contig_skips) = call_germline_region_streaming(
             per,
             reference,
             c.id,
@@ -84,9 +85,10 @@ pub fn call_germline_whole_genome<S: ReadSource>(
         if ws.bytes > max_ws.bytes {
             max_ws = ws;
         }
+        skips.accumulate(&contig_skips);
     }
 
-    Ok(max_ws)
+    Ok((max_ws, skips))
 }
 
 #[cfg(test)]
@@ -149,7 +151,7 @@ mod tests {
         let gp = GermlineParams::default();
 
         let mut rows: Vec<(Locus, u8, GermlineCall)> = Vec::new();
-        let ws = call_germline_whole_genome(
+        let (ws, _skips) = call_germline_whole_genome(
             SliceSource::new(reads.clone()),
             &rv,
             contigs,
@@ -236,6 +238,7 @@ mod tests {
                 &mut |_row| Ok(()),
             )
             .unwrap()
+            .0
             .bytes
         };
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -21,6 +21,15 @@ pub enum CoreError {
     /// A contig id was not present in the active `ContigSet`.
     #[error("invalid contig id {0}")]
     InvalidContig(u32),
+    /// A read longer than the declared `--max-read-len` voids the predicted
+    /// memory envelope (raised only under `--enforce`).
+    #[error("read length {len} exceeds declared --max-read-len {declared}; raise --max-read-len or drop --enforce")]
+    ReadExceedsDeclaredLength {
+        /// The offending read's sequence length.
+        len: u32,
+        /// The declared cap.
+        declared: u32,
+    },
     /// An underlying I/O failure.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1353,7 +1353,13 @@ fn run_variants_index(
         }
     };
     // Realized peak (monotonic high-water mark) captured after the calling pass.
-    let peak_rss = peak_rss_bytes();
+    // Test-only seam: ROSALIND_FORCE_PEAK_RSS_BYTES overrides ONLY this post-run
+    // realized peak (never the pre-run baseline at the --enforce gate), so the
+    // exit-4 breach branch can be exercised deterministically without allocating.
+    let peak_rss = std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or_else(peak_rss_bytes);
 
     // Compute the contract verdict before writing the receipt (so it records it).
     let verdict = match memory_budget_mb.map(|mb| MemoryBudget::from_mb(mb).admits(peak_rss)) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,15 +93,16 @@ enum Commands {
         /// Minimum quality threshold for reporting variants.
         #[arg(long, default_value_t = 10.0)]
         quality_threshold: f32,
-        /// Declared memory budget (MiB) for the run — records a plan/peak line; does
-        /// not enforce (enforcement is a later phase). (`--index` path.)
+        /// Declared memory budget (MiB) for the run — records a plan/peak line.
+        /// With `--enforce` it is honored (exit 3 refuse / exit 4 breach). (`--index` path.)
         #[arg(long)]
         memory_budget_mb: Option<u64>,
-        /// Cap the active read set per position (deterministic downsampling); the
-        /// bound `plan`/`--enforce` rely on. `0` = uncapped.
+        /// Cap the active read set per position (unbiased min-hash downsampling);
+        /// the bound `plan`/`--enforce` rely on. `0` = uncapped.
         #[arg(long, default_value_t = 1000)]
         max_depth: u32,
-        /// Max read length assumed by the pre-run `--enforce` estimate.
+        /// Max read length assumed by the pre-run `--enforce` estimate AND enforced
+        /// at ingest under `--enforce` (a longer read aborts the run).
         #[arg(long, default_value_t = 250)]
         max_read_len: u32,
         /// Honor the budget: refuse up front if predicted peak exceeds it (exit 3),
@@ -1225,6 +1226,9 @@ fn run_variants_index(
         } else {
             Some(max_depth)
         },
+        // Under `--enforce` the predicted envelope assumes reads <= max_read_len;
+        // check it at ingest so a longer read aborts loudly instead of voiding it.
+        max_read_len: if enforce { Some(max_read_len) } else { None },
         ..PileupParams::default()
     };
     let germline_params = GermlineParams {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1291,13 +1291,13 @@ fn run_variants_index(
     // Stream calls straight to the VCF writer (header once, then one row per
     // emitted call) so no genome-wide row buffer accumulates. The returned
     // WorkingSet is the high-water (reference + active set), captured per contig.
-    let max_ws = match &output {
+    let (max_ws, skips) = match &output {
         Some(path) => {
             let file = File::create(path)
                 .with_context(|| format!("failed to create VCF file {}", path.display()))?;
             let mut writer = io::BufWriter::new(file);
             write_germline_header(&mut writer, contigs, "SAMPLE")?;
-            let ws = call_germline_whole_genome(
+            let (ws, sk) = call_germline_whole_genome(
                 source,
                 &ref_view,
                 contigs,
@@ -1318,13 +1318,13 @@ fn run_variants_index(
             )
             .map_err(|e| anyhow!("variant calling failed: {e}"))?;
             writer.flush()?;
-            ws
+            (ws, sk)
         }
         None => {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
             write_germline_header(&mut handle, contigs, "SAMPLE")?;
-            let ws = call_germline_whole_genome(
+            let (ws, sk) = call_germline_whole_genome(
                 source,
                 &ref_view,
                 contigs,
@@ -1345,7 +1345,7 @@ fn run_variants_index(
             )
             .map_err(|e| anyhow!("variant calling failed: {e}"))?;
             handle.flush()?;
-            ws
+            (ws, sk)
         }
     };
     // Realized peak (monotonic high-water mark) captured after the calling pass.
@@ -1410,6 +1410,13 @@ fn run_variants_index(
             "max_working_set_bytes".to_string(),
             max_ws.bytes.to_string(),
         );
+        manifest.params.insert(
+            "over_max_depth".to_string(),
+            skips.over_max_depth.to_string(),
+        );
+        manifest
+            .params
+            .insert("reads_skipped_total".to_string(), skips.total().to_string());
         if let Some(mb) = memory_budget_mb {
             manifest
                 .params
@@ -1432,6 +1439,22 @@ fn run_variants_index(
         peak_rss / (1 << 20),
         max_ws.bytes / 1024
     );
+    // Surface depth-cap downsampling: the cap engaging changes calls at deep
+    // sites (an unbiased bounded sample), so it must never be silent.
+    if skips.over_max_depth > 0 {
+        eprintln!(
+            "pileup: dropped {} reads at --max-depth {} (deep-site downsampling — \
+             calls at those sites use a bounded unbiased sample)",
+            skips.over_max_depth, max_depth
+        );
+    }
+    let other_skipped = skips.total() - skips.over_max_depth;
+    if other_skipped > 0 {
+        eprintln!(
+            "pileup: skipped {other_skipped} reads by filter \
+             (unmapped/wrong-contig/secondary/supplementary/duplicate/low-mapq)"
+        );
+    }
     if let Some(mb) = memory_budget_mb {
         let budget = MemoryBudget::from_mb(mb);
         let within = budget.admits(peak_rss);

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -102,6 +102,17 @@ impl SkipCounts {
             + self.low_mapq
             + self.over_max_depth
     }
+
+    /// Field-wise add (summing per-contig engines on the whole-genome path).
+    pub fn accumulate(&mut self, other: &SkipCounts) {
+        self.unmapped += other.unmapped;
+        self.wrong_contig += other.wrong_contig;
+        self.secondary += other.secondary;
+        self.supplementary += other.supplementary;
+        self.duplicate += other.duplicate;
+        self.low_mapq += other.low_mapq;
+        self.over_max_depth += other.over_max_depth;
+    }
 }
 
 /// A read currently overlapping the cursor, with its CIGAR projection precomputed.
@@ -542,6 +553,24 @@ mod tests {
         assert!(p.skip_secondary && p.skip_supplementary && p.skip_duplicate);
         assert_eq!(p.min_mapq, 0);
         assert_eq!(p.min_base_qual, 0);
+    }
+
+    #[test]
+    fn skip_counts_accumulate_sums_fieldwise() {
+        let mut a = SkipCounts {
+            over_max_depth: 2,
+            low_mapq: 1,
+            ..SkipCounts::default()
+        };
+        let b = SkipCounts {
+            over_max_depth: 3,
+            duplicate: 4,
+            ..SkipCounts::default()
+        };
+        a.accumulate(&b);
+        assert_eq!(a.over_max_depth, 5);
+        assert_eq!(a.low_mapq, 1);
+        assert_eq!(a.duplicate, 4);
     }
 
     #[test]

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -290,6 +290,18 @@ impl<S: ReadSource> PileupEngine<S> {
                 }
             }
         }
+        // Emit observations in a canonical total order so the downstream diploid
+        // log-likelihood accumulation (germline.rs, an order-sensitive f64 sum) is
+        // order-independent and the VCF stays byte-identical regardless of the
+        // active set's internal order (which the depth-cap reservoir may permute).
+        obs.sort_by(|a, b| {
+            (a.allele, a.base_qual, a.mapq, a.reverse as u8).cmp(&(
+                b.allele,
+                b.base_qual,
+                b.mapq,
+                b.reverse as u8,
+            ))
+        });
         PileupColumn {
             locus: Locus {
                 contig: self.contig,
@@ -362,6 +374,26 @@ mod tests {
             out.push(c.expect("pileup column"));
         }
         out
+    }
+
+    #[test]
+    fn obs_are_emitted_in_canonical_order() {
+        // A column with mixed alleles must emit obs sorted by
+        // (allele, base_qual, mapq, reverse) — independent of read arrival order,
+        // so the downstream f64 likelihood sum is order-stable.
+        let reference = b"AAAA";
+        // Three reads covering pos 0 with different alleles at offset 0:
+        // C (allele 1), A (allele 0, ref), G (allele 2). Arrival order C, A, G.
+        let reads = vec![
+            mread(0, b"C", false),
+            mread(0, b"A", false),
+            mread(0, b"G", false),
+        ];
+        let cols = columns(engine(reads, reference));
+        let at0 = cols.iter().find(|c| c.locus.pos.0 == 0).unwrap();
+        let alleles: Vec<u8> = at0.obs.iter().map(|o| o.allele).collect();
+        // Canonical: ascending by allele (0, 1, 2) regardless of C, A, G arrival.
+        assert_eq!(alleles, vec![0, 1, 2]);
     }
 
     #[test]

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -54,9 +54,14 @@ pub struct PileupParams {
     /// Skip PCR/optical duplicates (SAM flag 0x400).
     pub skip_duplicate: bool,
     /// Cap on the active read set per position (deterministic downsampling).
-    /// `None` = uncapped (default). When `Some(d)`, reads arriving at a position
-    /// already covered by `d` active reads are dropped (counted `over_max_depth`).
+    /// `None` = uncapped (default). When `Some(d)`, an unbiased min-hash reservoir
+    /// keeps `d` reads covering each position; reads removed are counted
+    /// `over_max_depth`.
     pub max_depth: Option<u32>,
+    /// When `Some(m)` (set only under `--enforce`), a read whose `seq.len()`
+    /// exceeds `m` aborts the run — the predicted memory envelope assumes `<= m`,
+    /// so a longer read would silently void it. `None` = no check (default).
+    pub max_read_len: Option<u32>,
 }
 
 impl Default for PileupParams {
@@ -68,6 +73,7 @@ impl Default for PileupParams {
             skip_supplementary: true,
             skip_duplicate: true,
             max_depth: None,
+            max_read_len: None,
         }
     }
 }
@@ -286,6 +292,17 @@ impl<S: ReadSource> PileupEngine<S> {
                     if read.end() <= pos {
                         continue; // does not reach the cursor
                     }
+                    // --enforce precondition: a read longer than the declared
+                    // --max-read-len voids the predicted envelope. Fail loud here
+                    // rather than silently over-allocate (the would-be OOM path).
+                    if let Some(maxlen) = self.params.max_read_len {
+                        if read.seq.len() as u32 > maxlen {
+                            return Err(CoreError::ReadExceedsDeclaredLength {
+                                len: read.seq.len() as u32,
+                                declared: maxlen,
+                            });
+                        }
+                    }
                     let prio = read_priority(&read);
                     if let Some(max) = self.params.max_depth {
                         if self.active.len() as u32 >= max {
@@ -454,6 +471,38 @@ mod tests {
         let alleles: Vec<u8> = at0.obs.iter().map(|o| o.allele).collect();
         // Canonical: ascending by allele (0, 1, 2) regardless of C, A, G arrival.
         assert_eq!(alleles, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn read_exceeding_declared_max_read_len_errors() {
+        // Under --enforce (max_read_len Some), a read longer than the declared cap
+        // aborts the run rather than silently voiding the predicted envelope.
+        let reference = b"AAAAAAAA";
+        let params = PileupParams {
+            max_read_len: Some(4),
+            ..PileupParams::default()
+        };
+        let mut e = PileupEngine::new(
+            SliceSource::new(vec![mread(0, b"CCCCCC", false)]), // len 6 > 4
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..8,
+            params,
+        );
+        let err = loop {
+            match e.next() {
+                Some(Ok(_)) => continue,
+                Some(Err(err)) => break err,
+                None => panic!("expected an error, got clean end"),
+            }
+        };
+        assert!(matches!(
+            err,
+            crate::core::CoreError::ReadExceedsDeclaredLength {
+                len: 6,
+                declared: 4
+            }
+        ));
     }
 
     #[test]

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -12,6 +12,34 @@ use crate::core::{
 use crate::pileup::column::{Obs, PileupColumn};
 use crate::pileup::source::ReadSource;
 
+/// Fixed-seed FNV-1a-64 over a read's identity (position, end, flags, CIGAR, seq,
+/// qual). Deterministic across runs and processes (NOT `DefaultHasher`, whose seed
+/// is per-process). The hash is uncorrelated with the allele a read carries at any
+/// single column — the basis of the unbiased depth-cap sample.
+fn read_priority(read: &AlignedRead) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    #[inline]
+    fn fold(mut h: u64, bytes: &[u8]) -> u64 {
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        h
+    }
+    let mut h = FNV_OFFSET;
+    h = fold(h, &read.pos.0.to_le_bytes());
+    h = fold(h, &read.end().to_le_bytes());
+    h = fold(h, &read.flags.0.to_le_bytes());
+    for op in &read.cigar {
+        h = fold(h, &[op.kind as u8]);
+        h = fold(h, &op.len.to_le_bytes());
+    }
+    h = fold(h, &read.seq);
+    h = fold(h, &read.qual);
+    h
+}
+
 /// Read-level filters applied as reads enter the pileup.
 #[derive(Debug, Clone)]
 pub struct PileupParams {
@@ -91,6 +119,8 @@ struct ActiveRead {
     mapq: u8,
     /// Reverse-strand flag (metadata only — never applied to `seq`).
     reverse: bool,
+    /// Fixed-seed content hash — the depth-cap reservoir admission/eviction key.
+    priority: u64,
 }
 
 /// Streaming, CIGAR-aware, bounded-memory pileup over one contig region.
@@ -188,7 +218,8 @@ impl<S: ReadSource> PileupEngine<S> {
     }
 
     /// Precompute a read's reference→read-offset map and add it to the active set.
-    fn ingest(&mut self, read: AlignedRead) {
+    /// `priority` is the precomputed reservoir key (see `read_priority`).
+    fn ingest(&mut self, read: AlignedRead, priority: u64) {
         let end = read.end();
         let mut ref_to_read = HashMap::new();
         for rb in read.projected_bases() {
@@ -201,6 +232,7 @@ impl<S: ReadSource> PileupEngine<S> {
             qual: Arc::clone(&read.qual),
             mapq: read.mapq,
             reverse: read.flags.is_reverse(),
+            priority,
         });
     }
 
@@ -243,16 +275,33 @@ impl<S: ReadSource> PileupEngine<S> {
                     if read.end() <= pos {
                         continue; // does not reach the cursor
                     }
-                    // Deterministic max-depth cap: once `max_depth` reads already
-                    // cover the cursor, drop arrivals (counted) so the active set —
-                    // and thus the working set — is bounded by the declared depth.
+                    let prio = read_priority(&read);
                     if let Some(max) = self.params.max_depth {
                         if self.active.len() as u32 >= max {
+                            // Unbiased min-hash reservoir: keep the `max`
+                            // smallest-priority reads covering the cursor. Evict the
+                            // greatest-priority resident iff the newcomer ranks below
+                            // it; otherwise refuse. Either way the cap removed one
+                            // read (counted). Priority is a fixed-seed content hash,
+                            // so selection is independent of start position / allele
+                            // (the leftmost-arrival bias that silently dropped deep
+                            // variants is gone). The active set stays bounded by
+                            // `max`, preserving the working-set guarantee.
+                            let mut worst = 0usize;
+                            for i in 1..self.active.len() {
+                                if self.active[i].priority > self.active[worst].priority {
+                                    worst = i;
+                                }
+                            }
                             self.skips.over_max_depth += 1;
+                            if prio < self.active[worst].priority {
+                                self.active.swap_remove(worst);
+                                self.ingest(read, prio);
+                            }
                             continue;
                         }
                     }
-                    self.ingest(read);
+                    self.ingest(read, prio);
                 }
             }
         }
@@ -394,6 +443,56 @@ mod tests {
         let alleles: Vec<u8> = at0.obs.iter().map(|o| o.allele).collect();
         // Canonical: ascending by allele (0, 1, 2) regardless of C, A, G arrival.
         assert_eq!(alleles, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn unbiased_cap_keeps_downstream_starting_reads() {
+        // The biased (leftmost-arrival) cap dropped reads that START at a deep
+        // variant, zeroing the alt allele. The min-hash reservoir keeps a
+        // start-position-independent sample, so a variant carried only by reads
+        // that begin AT the variant column survives. Reads must be DISTINCT
+        // (real reads are) — identical content shares one hash and degenerates.
+        let reference = vec![b'A'; 64];
+        let v = 32u32; // variant column
+        let cap = 30u32;
+        let mut reads = Vec::new();
+        // 30 ref reads starting upstream (pos 0), distinct lengths -> distinct
+        // hashes, all carrying A (ref) at v.
+        for i in 0..30u32 {
+            let len = 33 + i as usize; // covers v=32 (len>32); 33..62 < 64
+            reads.push(mread(0, &vec![b'A'; len], false));
+        }
+        // 30 alt reads starting AT v, distinct lengths, carrying C at v (offset 0).
+        for j in 0..30u32 {
+            let len = 1 + j as usize; // start v, covers v
+            let mut seq = vec![b'A'; len];
+            seq[0] = b'C';
+            reads.push(mread(v, &seq, false));
+        }
+        let params = PileupParams {
+            max_depth: Some(cap),
+            ..PileupParams::default()
+        };
+        let mut e = PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.into_boxed_slice()),
+            0,
+            0..64,
+            params,
+        );
+        let mut at_v = None;
+        while let Some(c) = e.next() {
+            let col = c.unwrap();
+            if col.locus.pos.0 == v {
+                at_v = Some(col);
+            }
+        }
+        let counts = at_v.expect("a column at v").allele_counts();
+        // Both alleles present: ref (A=0) AND alt (C=1) — the biased cap gave alt==0.
+        assert!(counts[1] > 0, "alt allele must survive the cap: {counts:?}");
+        assert!(counts[0] > 0, "ref allele must remain too: {counts:?}");
+        // Capped: total observed at v <= cap.
+        assert!(counts.iter().sum::<u32>() <= cap, "depth must be capped");
     }
 
     #[test]

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -268,6 +268,44 @@ fn verify_passes_on_an_untampered_run_and_fails_on_a_tampered_output() {
 }
 
 #[test]
+fn enforce_breach_exits_4_after_writing_output_and_receipt() {
+    // Budget 4096 MiB passes the pre-run exit-3 gate (tiny fixture), but a forced
+    // realized peak of 8 GiB trips the post-run breach -> exit 4, with the VCF +
+    // receipt still written (the documented "output + receipt written" semantics).
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .env("ROSALIND_FORCE_PEAK_RSS_BYTES", "8589934592") // 8 GiB
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected breach exit 4: {out:?}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("VIOLATED"),
+        "missing VIOLATED line: {stderr}"
+    );
+    // Output + receipt were still written before the breach exit.
+    assert!(vcf.exists(), "VCF must be written before exit 4");
+    let json = std::fs::read_to_string(&manifest).expect("receipt written");
+    assert!(
+        json.contains("\"contract_verdict\":\"over\""),
+        "verdict should be over: {json}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn enforce_aborts_on_a_read_longer_than_declared_max_read_len() {
     // Standard fixture has 16 bp reads. Declare --max-read-len 8 under --enforce
     // with a generous budget: the pre-run estimate (using 8) fits, so the run

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -268,6 +268,34 @@ fn verify_passes_on_an_untampered_run_and_fails_on_a_tampered_output() {
 }
 
 #[test]
+fn receipt_records_skip_counts() {
+    // The standard fixture (5 reads, well below the default max-depth 1000) drops
+    // nothing → over_max_depth 0. A tight --max-depth 1 forces drops → > 0.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let manifest = dir.join("run.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--max-depth", "1", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    let json = std::fs::read_to_string(&manifest).unwrap();
+    assert!(
+        json.contains("\"over_max_depth\":") && json.contains("\"reads_skipped_total\":"),
+        "manifest missing skip fields: {json}"
+    );
+    // At pos 0 the fixture stacks >1 read; --max-depth 1 must drop at least one.
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&json).unwrap();
+    let over: u64 = m.params.get("over_max_depth").unwrap().parse().unwrap();
+    assert!(over > 0, "tight cap should drop reads, got {over}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn estimator_upper_bounds_the_realized_working_set() {
     // Run the real pipeline, read max_working_set_bytes from the receipt, and
     // assert the pure estimator (same shared constants) is a true upper bound for

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -268,6 +268,37 @@ fn verify_passes_on_an_untampered_run_and_fails_on_a_tampered_output() {
 }
 
 #[test]
+fn enforce_aborts_on_a_read_longer_than_declared_max_read_len() {
+    // Standard fixture has 16 bp reads. Declare --max-read-len 8 under --enforce
+    // with a generous budget: the pre-run estimate (using 8) fits, so the run
+    // proceeds to ingest and hits the over-long-read abort.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args([
+            "--memory-budget-mb",
+            "4096",
+            "--max-read-len",
+            "8",
+            "--max-depth",
+            "1000",
+            "--enforce",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "over-long read must abort: {out:?}");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("exceeds declared --max-read-len"),
+        "missing clear message: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn receipt_records_skip_counts() {
     // The standard fixture (5 reads, well below the default max-depth 1000) drops
     // nothing → over_max_depth 0. A tight --max-depth 1 forces drops → > 0.


### PR DESCRIPTION
## Summary
The 6 call/contract-path items from the 2026-06-02 reflection audit — making the shipped memory contract's correctness and trust guarantees actually hold and be tested.

- **Unbiased depth cap** — replaces leftmost-arrival truncation with a fixed-seed min-hash bounded reservoir + eviction. Selection is independent of read start position (and thus allele), so a deep het variant carried by reads that start *at* the variant no longer gets silently dropped. Deterministic and bounded at `max_depth`. (Reproduced bug: a true 30:30 het → 0 calls under the old biased cap; regression test included.)
- **Canonical obs order** — `build_column` emits observations sorted by `(allele, base_qual, mapq, reverse)`, so the order-sensitive f64 QUAL/PL accumulation in `germline.rs` is order-independent and the VCF stays byte-identical regardless of the active set's internal order (which the reservoir permutes).
- **Surface skip counts** — thread `SkipCounts` out of the streaming + whole-genome callers; print a stderr summary when the cap engages, and record `over_max_depth` + `reads_skipped_total` in the receipt.
- **`--max-read-len` enforcement** — under `--enforce`, a read longer than the declared cap aborts loudly (`CoreError::ReadExceedsDeclaredLength`) instead of silently voiding the predicted envelope; fixes the contradictory `plan.rs` comment and the stale `--memory-budget-mb` / `--max-read-len` help text.
- **Exit-4 breach test** — a post-run-only `ROSALIND_FORCE_PEAK_RSS_BYTES` seam makes the "never a silent overrun" backstop testable: asserts exit 4 + `VIOLATED` + output/receipt still written. (Previously zero coverage.)
- **CI memory gate** — `cli-e2e` now exercises the bounded `variants --index` contract: fits (exit 0 + `contract: OK`) → `verify` → refuse (exit 3, no VCF). Validated locally against the bundled toy fixtures.

Spec: `docs/superpowers/specs/2026-06-02-trust-correctness-hardening-keystone-design.md`.
Plan: `docs/superpowers/plans/2026-06-02-trust-correctness-hardening-keystone.md`.

**Deferred to a fast-follow (out of scope here):** sort k-way-merge tie-break, `@SQ` contig-length cross-check, BSD `ru_maxrss` unit fix + cgroup-awareness, the front-door honesty pass, and merging PR #23.

## Test plan
- [x] `cargo test` green (incl. new unbiased-cap, obs-order, skip-count accumulate, max-read-len abort, receipt-skip-counts, and exit-4 breach tests)
- [x] `cargo fmt --all -- --check` clean; 0 warnings (debug + release)
- [x] Contract gate validated locally (fits exit 0 / refuse exit 3 / verify OK); now wired into CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)