### PR TITLE
Germline accuracy validation (simulated diploid truth) + eval-germline

### DIFF
--- a/docs/findings/2026-06-02-germline-accuracy.md
+++ b/docs/findings/2026-06-02-germline-accuracy.md
@@ -1,0 +1,58 @@
+# Finding — germline caller detection accuracy (simulated diploid truth)
+
+**Date:** 2026-06-02. **Harness:** `tests/germline_accuracy.rs` (deterministic, fixed-seed, gated in
+CI). **Comparator:** the existing `compare_callsets` (detection by normalized pos+ref+alt) + the new
+`rosalind eval-germline` CLI. Addresses the reflection audit's #1 blind spot: the memory contract was
+validated, but the **calls themselves** had never been measured against ground truth.
+
+## What was measured
+
+A diploid donor is built by injecting ~40 known het/hom SNVs into a 20 kbp reference; reads are
+sampled 50/50 from the two haplotypes (with sequencing error) and written **directly as a sorted
+BAM** — bypassing the toy aligner, so this isolates the **caller's** detection accuracy (genotype
+model + the unbiased depth cap), not alignment. PASS = records passing the default filters
+(`min_qual 30`, `min_depth 8`); `all` = every emitted variant record.
+
+| Regime | metric | truth | calls | TP | FP | FN | precision | recall | F1 |
+|---|---|---|---|---|---|---|---|---|---|
+| 40× / 0.5% err (clean) | **PASS** | 40 | 40 | 40 | 0 | 0 | **1.000** | **1.000** | **1.000** |
+| 40× / 0.5% err (clean) | all | 40 | 40 | 40 | 0 | 0 | 1.000 | 1.000 | 1.000 |
+| 12× / 1.5% err (stress) | **PASS** | 40 | 53 | 36 | 17 | 4 | **0.679** | **0.900** | **0.774** |
+| 12× / 1.5% err (stress) | all | 40 | 138 | 40 | 98 | 0 | 0.290 | 1.000 | 0.449 |
+
+## Honest reading
+
+- **On clean data (40× / 0.5%) the caller is exact**: every het and hom-alt SNV is recovered with zero
+  false positives. The diploid GL model + the θ=1e-3 prior correctly abstain on error-driven thin alt.
+- **At low coverage + high error (12× / 1.5%) detection degrades, and the quality filter matters.**
+  Unfiltered, the caller finds *every* true variant (recall 1.000) but emits 98 error-driven false
+  positives (precision 0.290). The default PASS filter (`min_qual 30` / `min_depth 8`) cuts those FPs
+  to 17 (precision → 0.679) at the cost of 4 true variants flagged low-quality (recall → 0.900). So
+  the caller has a **working precision/recall knob**, and the honest characterization is: *robust
+  recall, precision that is filter- and coverage-dependent.*
+- **The depth-cap fix holds in an accuracy frame.** A deep het site (alt reads starting *at* the
+  variant, under a cap below local depth) is recovered as a PASS call — the unbiased reservoir, which
+  the old leftmost-arrival cap would have silently dropped.
+
+## Scope + honest limitations
+
+- **Simulated, not GIAB.** Reads are simulated and the BAM is built from known coordinates (no real
+  alignment). This measures the caller on clean, indel-free, single-contig data — it does **not** cover
+  alignment error, mapping ambiguity, repeats, or real error profiles. A real **GIAB HG002** run is the
+  natural next step and plugs into the *same* comparator via `rosalind eval-germline --reference
+  --calls --truth --regions <highconf.bed>`; it needs a downloaded pre-aligned BAM slice (out of scope
+  here — this environment has no bwa/samtools and GIAB BAMs are large).
+- **Detection only.** Matching is pos+ref+alt; **genotype concordance** (het vs hom) is not scored — a
+  documented future refinement.
+- **SNV only.** The caller is biallelic-SNV; indels are out of scope (they need local realignment,
+  which is not a per-column streaming operation).
+
+## Reproduce
+
+```
+cargo test --test germline_accuracy -- --nocapture
+```
+
+The numbers above are deterministic (fixed-seed LCG). The CI gate asserts a margin below the measured
+PASS values (clean ≥ 0.97/0.97; stress recall ≥ 0.85, precision ≥ 0.60) so a real regression fails
+loudly without flaking.

--- a/docs/superpowers/specs/2026-06-02-germline-accuracy-harness-design.md
+++ b/docs/superpowers/specs/2026-06-02-germline-accuracy-harness-design.md
@@ -1,0 +1,116 @@
+# Simulated-Truth Germline Accuracy Harness (design)
+
+**Status:** DESIGN SPEC — 2026-06-02. **Branch:** `rosalind/germline-accuracy` (off `main` `95c4ba8`).
+Addresses the reflection audit's #1 blind spot: the memory contract is validated, but the variant
+**calls** have never been measured against ground truth (only simulated E. coli with no injected
+variants). User chose "simulated diploid truth" as the first accuracy increment.
+
+## 1. Goal
+
+Measure the germline caller's **detection precision / recall / F1** against a known truth set,
+deterministically and in-house (no downloads), and gate it in CI. Reuse the existing GIAB-shaped
+comparator (`compare_callsets` + `BedIndex` + `VcfVariant`) so a real GIAB BAM slice can plug into the
+same interface later. Specifically validate the depth-cap fix in an accuracy frame (a deep het site
+whose alt reads start at the variant must be recovered).
+
+## 2. What already exists (reuse, don't rebuild)
+
+- `compare_callsets(reference: &[u8], calls: &[VcfVariant], truth: &[VcfVariant], bed) ->
+  ComparisonReport` with `true_positive`/`false_positive`/`false_negative`, `precision()`,
+  `recall()`, and a per-`VariantType` breakdown. Matching is **detection by normalized (pos, ref,
+  alt)** — genotype is not compared (the standard primary metric; genotype concordance is a later
+  refinement).
+- `VcfVariant { chrom: String, pos0: u32, reference: Vec<u8>, alternate: Vec<u8>, qual, filter }`,
+  `read_vcf_variants`, `BedIndex::from_str` — `src/genomics/eval/`.
+- `run_eval_somatic` (`src/main.rs:400`) is already VCF-agnostic comparison logic.
+- BAM construction from hand-built `Record`s (the pattern in `tests/truthset_validation.rs`).
+- `call_germline_whole_genome` (library) returns `(Locus, ref_base, GermlineCall)` rows;
+  `GermlineCall { genotype, alt_base: u8, qual, filter, … }`.
+
+## 3. Deliverables
+
+### 3a. `eval-germline` CLI (the GIAB-ready interface)
+
+Generalize `run_eval_somatic` → a shared `run_eval(reference, calls, truth, regions)`; keep
+`Commands::EvalSomatic` calling it; add `Commands::EvalGermline { reference, calls, truth, regions }`
+calling the same `run_eval`. Add **F1** to the printed report:
+`f1 = 2·P·R / (P + R)` (0 when `P + R == 0`). A real GIAB germline run uses exactly this command
+(`rosalind eval-germline --reference grch38.fa --calls out.vcf --truth giab.vcf --regions
+highconf.bed`).
+
+### 3b. `tests/germline_accuracy.rs` — the gated accuracy harness
+
+A deterministic, download-free integration test. Bypasses the toy aligner (builds the BAM directly
+from known coordinates) so it measures the **caller**, not alignment.
+
+**Simulation (fixed-seed LCG — no `rand` dependency):**
+- Reference: `N = 20_000` bp of deterministic pseudo-random DNA (LCG over `ACGT`). Single contig
+  `chr1`.
+- Truth variants: `~40` SNVs at positions spaced ~`N/45` apart, avoiding the first/last 200 bp. Each
+  is `Het` or `HomAlt` (assigned by the LCG). `alt_base = next base after ref_base in "ACGT"`
+  (guarantees alt ≠ ref).
+- Two haplotype arrays built once: `hap1 = reference + HomAlt variants`; `hap2 = reference + HomAlt +
+  Het variants`. (So Het sites carry alt on hap2 only; HomAlt on both.)
+- Reads: length `L = 100`, target coverage `~40×` via tiled starts with small LCG jitter. Each read is
+  sampled from `hap1`/`hap2` 50/50; `SEQ = hap[start..start+L]` with each base flipped to a random
+  other base with probability `E = 0.005` (sequencing error). Record: tid 0, `pos = start`, CIGAR
+  `L M`, qual `40`. All forward strand (strand is metadata; the reverse path is covered elsewhere).
+- **Deep-het probe (the depth-cap fix in an accuracy frame):** pick one Het truth site; additionally
+  emit `~30` ref-bearing reads that START upstream and span it, and `~30` alt-bearing reads that START
+  AT the site — so with a depth cap below the local depth, the biased (old) cap would drop the
+  at-variant alt reads and miss the het, while the unbiased reservoir recovers it. The test runs with
+  `PileupParams.max_depth = Some(50)` so normal ~40× sites do not cap but the deep-het site (~60×+)
+  does.
+
+**Call + compare:**
+- Write the reads to a BAM, `sort_bam_deterministic` → sorted BAM. Build a Rosalind index for the
+  reference (`IndexWriter`/`IndexReader`), get `ReferenceView` + `ContigSet`.
+- `call_germline_whole_genome(StreamingBamSource, …, PileupParams{ max_depth: Some(50), .. },
+  GermlineParams::default(), sink)` collecting rows.
+- Convert each emitted row → `VcfVariant { chrom: "chr1", pos0: locus.pos.0, reference:
+  vec![ref_base], alternate: vec![call.alt_base], qual: Some(call.qual as f32), filter: "." }`.
+  (Compare ALL emitted variant records = detection recall; the caller already abstains on hom-ref.)
+- Truth → `VcfVariant` from the injected list.
+- `report = compare_callsets(&reference_bytes, &calls, &truth, None)`.
+
+**Assertions (thresholds CALIBRATED to the measured run, set a margin below — report the actuals):**
+- `report.recall() >= R_MIN` and `report.precision() >= P_MIN` (initial targets `R_MIN = 0.90`,
+  `P_MIN = 0.90`; adjust to the measured numbers, never paper over a low result — a low number is a
+  real finding about the caller, to be surfaced).
+- The deep-het site is in the called set (a TP) — the cap fix, proven on accuracy.
+- A clear panic message printing the full report on failure (so CI shows the numbers).
+
+## 4. Honesty + scope
+
+- **Report the real numbers.** If precision is dragged down by error-driven FPs, that is a genuine
+  finding about the diploid model's error-robustness; surface it (and `min_qual` is a legitimate knob
+  to discuss), do not silently tune until green.
+- Detection metrics only (pos+ref+alt); **genotype concordance** (het-vs-hom) is a documented future
+  refinement, not in scope.
+- Real **GIAB HG002** is out of scope here (needs a downloaded pre-aligned BAM slice; this env has no
+  bwa/samtools and GIAB BAMs are large) — but the `eval-germline` CLI + the `VcfVariant`/BED interface
+  make it a drop-in second increment.
+- A short **findings doc** (`docs/findings/2026-06-02-germline-accuracy.md`) records the measured
+  precision/recall/F1 and the simulation parameters.
+
+## 5. Risks
+
+- **FPs from sequencing errors (medium).** At 0.5%/40× the diploid θ=1e-3 prior should abstain on thin
+  alt, but clustered errors could produce a few FPs. Mitigation: measure; if precision is low, report
+  it honestly and consider a `min_qual`/`min_depth` in the harness (documented), not a silent fudge.
+- **Edge effects (low).** Variants near contig ends or reads spilling past the end — keep variants ≥
+  200 bp from both ends; reads clamp at the contig end (handled).
+- **Threshold brittleness (low).** Fixed-seed determinism makes the measured numbers stable;
+  thresholds are set a margin below the measured value, so normal runs don't flake.
+
+## 6. Self-review
+
+- **Coverage:** the comparator already exists; new = `eval-germline` CLI (3a) + the gated simulated
+  harness (3b) + a findings doc. ✓
+- **Type consistency:** `VcfVariant` fields match `compare_callsets`; `GermlineCall.alt_base: u8` and
+  the row's `ref_base: u8` map to `Vec<u8>` alleles. ✓
+- **No placeholders:** the one calibration step (R_MIN/P_MIN) is explicitly "measure then set a margin
+  below, report actuals." ✓
+- **Determinism:** fixed-seed LCG for reference, variants, haplotype/read/error sampling →
+  reproducible numbers, non-flaky gate. ✓
+- **Scope:** detection-only, simulated-only; GIAB + genotype concordance explicitly deferred. ✓

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ enum Commands {
         #[arg(long, default_value_t = 1024)]
         memory_mb: usize,
     },
-    /// Compare a called VCF against a truth VCF (optionally masked by BED).
+    /// Compare a called somatic VCF against a truth VCF (optionally masked by BED).
     EvalSomatic {
         /// Reference FASTA (single contig slice used by the VCFs).
         #[arg(long)]
@@ -175,6 +175,22 @@ enum Commands {
         #[arg(long)]
         truth: PathBuf,
         /// Optional BED mask (0-based half-open).
+        #[arg(long)]
+        regions: Option<PathBuf>,
+    },
+    /// Compare a called germline VCF against a truth VCF (e.g. a GIAB benchmark),
+    /// optionally masked by a high-confidence BED. Reports precision/recall/F1.
+    EvalGermline {
+        /// Reference FASTA (the contigs the VCFs use).
+        #[arg(long)]
+        reference: PathBuf,
+        /// Called VCF path.
+        #[arg(long)]
+        calls: PathBuf,
+        /// Truth VCF path.
+        #[arg(long)]
+        truth: PathBuf,
+        /// Optional high-confidence BED mask (0-based half-open).
         #[arg(long)]
         regions: Option<PathBuf>,
     },
@@ -369,7 +385,15 @@ fn main() -> Result<()> {
             truth,
             regions,
         } => {
-            run_eval_somatic(reference, calls, truth, regions)?;
+            run_eval(reference, calls, truth, regions)?;
+        }
+        Commands::EvalGermline {
+            reference,
+            calls,
+            truth,
+            regions,
+        } => {
+            run_eval(reference, calls, truth, regions)?;
         }
         Commands::Index {
             reference,
@@ -397,7 +421,10 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn run_eval_somatic(
+/// Compare a called VCF against a truth VCF over a reference, optionally masked by
+/// a BED. VCF-agnostic — used by both `eval-somatic` and `eval-germline` (and the
+/// drop-in interface for a real GIAB germline benchmark).
+fn run_eval(
     reference_path: PathBuf,
     calls_path: PathBuf,
     truth_path: PathBuf,
@@ -431,8 +458,15 @@ fn run_eval_somatic(
     println!("tp={}", report.true_positive);
     println!("fp={}", report.false_positive);
     println!("fn={}", report.false_negative);
-    println!("precision={:.6}", report.precision());
-    println!("recall={:.6}", report.recall());
+    let (p, r) = (report.precision(), report.recall());
+    let f1 = if p + r == 0.0 {
+        0.0
+    } else {
+        2.0 * p * r / (p + r)
+    };
+    println!("precision={p:.6}");
+    println!("recall={r:.6}");
+    println!("f1={f1:.6}");
     for (ty, (tp, fp, fn_)) in report.by_type.iter() {
         println!("type={:?} tp={} fp={} fn={}", ty, tp, fp, fn_);
     }

--- a/tests/germline_accuracy.rs
+++ b/tests/germline_accuracy.rs
@@ -1,0 +1,342 @@
+//! Simulated-truth germline ACCURACY harness.
+//!
+//! Inject a known set of het/hom SNVs into a reference, build diploid-sampled
+//! coordinate-sorted BAMs directly (bypassing the toy aligner, so this measures
+//! the CALLER not alignment), call with `call_germline_whole_genome`, and measure
+//! detection precision/recall/F1 against the truth via the existing
+//! `compare_callsets`. Deterministic (fixed-seed LCG, no `rand` dependency) so the
+//! numbers are stable and the gate is non-flaky. Two regimes: a clean baseline
+//! (40x / 0.5% error) and a low-coverage stress case (12x / 1.5% error). Also
+//! exercises the unbiased depth-cap fix: a deep het site is recovered under a
+//! depth cap below local depth.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rust_htslib::bam;
+use rust_htslib::bam::record::{Cigar, CigarString, Record};
+
+use rosalind::call::Filter;
+use rosalind::core::Locus;
+use rosalind::genomics::{
+    compare_callsets, sort_bam_deterministic, ComparisonReport, GenomeIndex, IndexReader,
+    IndexWriter, VcfVariant,
+};
+use rosalind::{
+    call_germline_whole_genome, GermlineCall, GermlineParams, PileupParams, StreamingBamSource,
+};
+
+const NUCS: [u8; 4] = [b'A', b'C', b'G', b'T'];
+const N: usize = 20_000;
+const READ_LEN: usize = 100;
+
+/// Deterministic LCG (PCG-style multiplier) — reproducible, no `rand` dependency.
+struct Lcg(u64);
+impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (self.0 >> 32) as u32
+    }
+    fn below(&mut self, n: u32) -> u32 {
+        self.next_u32() % n
+    }
+    fn frac(&mut self) -> f64 {
+        self.next_u32() as f64 / (u32::MAX as f64 + 1.0)
+    }
+}
+
+/// A deterministic alt allele distinct from the reference base.
+fn alt_of(base: u8) -> u8 {
+    match base {
+        b'A' => b'C',
+        b'C' => b'G',
+        b'G' => b'T',
+        _ => b'A',
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TruthVar {
+    pos: usize,
+    refb: u8,
+    altb: u8,
+    het: bool,
+}
+
+fn tmp_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let d = std::env::temp_dir().join(format!("rosalind-acc-{nanos}"));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+struct AccuracyOutcome {
+    /// Detection report over ALL emitted variant records (incl. LowQual/LowDepth).
+    report_all: ComparisonReport,
+    /// Detection report over PASS records only (the GIAB-standard metric).
+    report_pass: ComparisonReport,
+    deep_site: usize,
+    /// Whether the deep-het probe site was recovered as a PASS call.
+    deep_called: bool,
+}
+
+/// Run the full simulate -> call -> compare pipeline for one regime. Returns the
+/// detection report plus whether the deep-het probe site was recovered.
+fn run_accuracy(coverage: usize, error_rate: f64, cap: u32, seed: u64) -> AccuracyOutcome {
+    let dir = tmp_dir();
+    let mut rng = Lcg(seed);
+
+    // 1. Deterministic reference.
+    let reference: Vec<u8> = (0..N).map(|_| NUCS[rng.below(4) as usize]).collect();
+
+    // 2. Truth variants: ~40 SNVs, spaced, away from edges; ~60% het / 40% hom-alt.
+    let n_vars = 40usize;
+    let margin = 200usize;
+    let span = N - 2 * margin;
+    let step = span / n_vars;
+    let mut truth: Vec<TruthVar> = Vec::new();
+    for k in 0..n_vars {
+        let pos = margin + k * step + rng.below((step / 2) as u32) as usize;
+        if pos >= N - margin {
+            continue;
+        }
+        let refb = reference[pos];
+        truth.push(TruthVar {
+            pos,
+            refb,
+            altb: alt_of(refb),
+            het: rng.frac() < 0.6,
+        });
+    }
+    truth.sort_by_key(|v| v.pos);
+    truth.dedup_by_key(|v| v.pos);
+
+    // 3. Two haplotypes. hom-alt -> both haps; het -> hap2 only.
+    let mut hap1 = reference.clone();
+    let mut hap2 = reference.clone();
+    for v in &truth {
+        hap2[v.pos] = v.altb;
+        if !v.het {
+            hap1[v.pos] = v.altb;
+        }
+    }
+    let deep_site = truth
+        .iter()
+        .find(|v| v.het)
+        .map(|v| v.pos)
+        .expect("at least one het site");
+
+    // 4. Simulate reads -> BAM.
+    let mut header = bam::Header::new();
+    {
+        let mut sq = bam::header::HeaderRecord::new(b"SQ");
+        sq.push_tag(b"SN", &"chr1");
+        sq.push_tag(b"LN", &(N as i64));
+        header.push_record(&sq);
+    }
+    let raw_bam = dir.join("reads.bam");
+    let sorted_bam = dir.join("sorted.bam");
+    {
+        let mut w = bam::Writer::from_path(&raw_bam, &header, bam::Format::Bam).unwrap();
+        let mut rid = 0u64;
+        let mut emit =
+            |w: &mut bam::Writer, start: usize, hap: &[u8], rng: &mut Lcg, rid: &mut u64| {
+                let end = (start + READ_LEN).min(N);
+                if end <= start + 20 {
+                    return;
+                }
+                let len = end - start;
+                let mut seq: Vec<u8> = hap[start..end].to_vec();
+                for b in seq.iter_mut() {
+                    if rng.frac() < error_rate {
+                        let mut nb = NUCS[rng.below(4) as usize];
+                        while nb == *b {
+                            nb = NUCS[rng.below(4) as usize];
+                        }
+                        *b = nb;
+                    }
+                }
+                let cigar = CigarString(vec![Cigar::Match(len as u32)]);
+                let qual = vec![40u8; len];
+                let mut rec = Record::new();
+                let name = format!("r{}", *rid);
+                *rid += 1;
+                rec.set(name.as_bytes(), Some(&cigar), &seq, &qual);
+                rec.set_tid(0);
+                rec.set_pos(start as i64);
+                rec.set_mapq(60);
+                w.write(&rec).unwrap();
+            };
+
+        // 4a. Genome-wide ~coverage x at random starts, random haplotype.
+        let n_reads = coverage * N / READ_LEN;
+        for _ in 0..n_reads {
+            let start = rng.below((N - 20) as u32) as usize;
+            let pick_hap2 = rng.frac() < 0.5;
+            let hap: &[u8] = if pick_hap2 { &hap2 } else { &hap1 };
+            emit(&mut w, start, hap, &mut rng, &mut rid);
+        }
+        // 4b. Deep-het probe: ref reads starting upstream + alt reads starting AT
+        // the site, so the cap engages at a deep site (the unbiased reservoir must
+        // keep the at-variant alt reads — the old leftmost-arrival cap dropped them).
+        let up = deep_site.saturating_sub(READ_LEN - 10);
+        for _ in 0..30 {
+            emit(&mut w, up, &hap1, &mut rng, &mut rid);
+        }
+        for _ in 0..30 {
+            emit(&mut w, deep_site, &hap2, &mut rng, &mut rid);
+        }
+    }
+    sort_bam_deterministic(&raw_bam, &sorted_bam, 64 << 20).unwrap();
+
+    // 5. Index + call.
+    let idx = dir.join("ref.idx");
+    let index =
+        GenomeIndex::from_named_sequences(&[("chr1".to_string(), reference.clone())]).unwrap();
+    IndexWriter::create(&idx)
+        .unwrap()
+        .write_genome_index(&index)
+        .unwrap();
+    let reader = IndexReader::open(&idx).unwrap();
+    let rv = reader.reference_view().unwrap();
+    let contigs = reader.contigs();
+
+    let pp = PileupParams {
+        max_depth: Some(cap),
+        ..PileupParams::default()
+    };
+    let gp = GermlineParams::default();
+    let src = StreamingBamSource::new(&sorted_bam, contigs).unwrap();
+    let mut calls_all: Vec<VcfVariant> = Vec::new();
+    let mut calls_pass: Vec<VcfVariant> = Vec::new();
+    call_germline_whole_genome(src, &rv, contigs, pp, &gp, &mut |(locus, refb, call): (
+        Locus,
+        u8,
+        GermlineCall,
+    )| {
+        let v = VcfVariant {
+            chrom: "chr1".to_string(),
+            pos0: locus.pos.0,
+            reference: vec![refb],
+            alternate: vec![call.alt_base],
+            qual: Some(call.qual as f32),
+            filter: format!("{:?}", call.filter),
+            info: BTreeMap::new(),
+        };
+        if matches!(call.filter, Filter::Pass) {
+            calls_pass.push(v.clone());
+        }
+        calls_all.push(v);
+        Ok(())
+    })
+    .unwrap();
+
+    // 6. Compare against truth (detection: pos + ref + alt).
+    let truth_vcf: Vec<VcfVariant> = truth
+        .iter()
+        .map(|v| VcfVariant {
+            chrom: "chr1".to_string(),
+            pos0: v.pos as u32,
+            reference: vec![v.refb],
+            alternate: vec![v.altb],
+            qual: None,
+            filter: ".".to_string(),
+            info: BTreeMap::new(),
+        })
+        .collect();
+
+    let report_all = compare_callsets(&reference, &calls_all, &truth_vcf, None).unwrap();
+    let report_pass = compare_callsets(&reference, &calls_pass, &truth_vcf, None).unwrap();
+    let deep_called = calls_pass.iter().any(|c| c.pos0 as usize == deep_site);
+
+    std::fs::remove_dir_all(&dir).ok();
+    AccuracyOutcome {
+        report_all,
+        report_pass,
+        deep_site,
+        deep_called,
+    }
+}
+
+fn f1(report: &ComparisonReport) -> f64 {
+    let (p, r) = (report.precision(), report.recall());
+    if p + r == 0.0 {
+        0.0
+    } else {
+        2.0 * p * r / (p + r)
+    }
+}
+
+fn log_report(label: &str, o: &AccuracyOutcome) {
+    for (which, r) in [("PASS", &o.report_pass), ("all", &o.report_all)] {
+        eprintln!(
+            "germline accuracy [{label}/{which}]: truth={} calls={} tp={} fp={} fn={} precision={:.4} recall={:.4} f1={:.4}",
+            r.total_truth,
+            r.total_calls,
+            r.true_positive,
+            r.false_positive,
+            r.false_negative,
+            r.precision(),
+            r.recall(),
+            f1(r),
+        );
+    }
+}
+
+#[test]
+fn detection_accuracy_clean_baseline_40x() {
+    // Clean regime: 40x, 0.5% error, cap 50. Expect near-perfect PASS detection.
+    let o = run_accuracy(40, 0.005, 50, 0x9E37_79B9_7F4A_7C15);
+    log_report("40x/0.5%", &o);
+    assert!(
+        o.deep_called,
+        "deep het site at {} must be recovered as a PASS call under the cap",
+        o.deep_site
+    );
+    // Measured PASS: precision=1.0000, recall=1.0000 (2026-06-02). Gate a margin below.
+    let r = &o.report_pass;
+    assert!(
+        r.recall() >= 0.97,
+        "PASS recall {:.4} below 0.97",
+        r.recall()
+    );
+    assert!(
+        r.precision() >= 0.97,
+        "PASS precision {:.4} below 0.97",
+        r.precision()
+    );
+}
+
+#[test]
+fn detection_accuracy_low_coverage_stress_12x() {
+    // Harder regime: 12x, 1.5% error, cap 50 — fewer reads per site and more noise.
+    // Shows the harness produces graded, honest numbers and that the PASS filter
+    // (min_qual 30, min_depth 8) controls the error-driven false positives that
+    // flood the unfiltered (`all`) callset.
+    let o = run_accuracy(12, 0.015, 50, 0xD1B5_4A32_D192_ED03);
+    log_report("12x/1.5%", &o);
+    // Calibrated to the measured PASS run (margin below — see the findings doc).
+    let r = &o.report_pass;
+    assert!(
+        r.recall() >= LOW_COV_R_MIN,
+        "PASS recall {:.4} below {LOW_COV_R_MIN}",
+        r.recall()
+    );
+    assert!(
+        r.precision() >= LOW_COV_P_MIN,
+        "PASS precision {:.4} below {LOW_COV_P_MIN}",
+        r.precision()
+    );
+}
+
+// Calibrated to the measured 12x/1.5% PASS run (recall 0.90, precision 0.68 on
+// 2026-06-02) — a margin below, so the gate catches regression without flaking.
+const LOW_COV_R_MIN: f64 = 0.85;
+const LOW_COV_P_MIN: f64 = 0.60;


### PR DESCRIPTION
## Summary
Closes the reflection audit's #1 blind spot: the memory contract was validated, but the **variant calls themselves** had never been measured against ground truth (only simulated E. coli with no injected variants).

- **`eval-germline` CLI** — generalizes the (already VCF-agnostic) somatic comparator into a shared `run_eval` and adds F1. This is the **GIAB-ready interface**: a real GIAB germline benchmark runs `rosalind eval-germline --reference --calls --truth --regions <highconf.bed>` against the same `compare_callsets` + `BedIndex` path.
- **`tests/germline_accuracy.rs`** — a deterministic, download-free harness that injects known het/hom SNVs into a reference, builds diploid-sampled sorted BAMs **directly** (bypassing the toy aligner, so it measures the *caller*), calls, and compares PASS + all records to truth. Two regimes:

| Regime | metric | precision | recall | F1 |
|---|---|---|---|---|
| 40× / 0.5% (clean) | PASS | **1.000** | **1.000** | **1.000** |
| 12× / 1.5% (stress) | PASS | 0.679 | 0.900 | 0.774 |
| 12× / 1.5% (stress) | all (unfiltered) | 0.290 | 1.000 | 0.449 |

  Honest reading: exact on clean data; at low-cov/high-error the caller finds every true variant (all-recall 1.000) but the `min_qual 30` / `min_depth 8` PASS filter is what controls error-driven FPs (98→17). The deep-het probe (alt reads starting *at* the variant, under a cap below local depth) is recovered as a PASS call — the unbiased reservoir fix in an accuracy frame.

Spec: `docs/superpowers/specs/2026-06-02-germline-accuracy-harness-design.md`. Findings: `docs/findings/2026-06-02-germline-accuracy.md`.

**Honest scope (documented):** simulated (not GIAB), detection-only (pos+ref+alt; no genotype concordance), SNV-only. Real GIAB HG002 plugs into the same `eval-germline` interface and is the natural next increment (needs a downloaded pre-aligned BAM slice; out of scope here).

## Test plan
- [x] `cargo test --test germline_accuracy -- --nocapture` — both regimes pass; numbers deterministic
- [x] `cargo test` green; `cargo fmt --all -- --check` clean; 0 warnings (debug + release)
- [x] Thresholds set a margin below the measured PASS values (non-flaky regression gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)