### PR TITLE
chore: wire --version; cross-compile Intel macOS release on macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,14 @@ jobs:
           # the -sys crates build htslib/bzip2/lzma/zlib from bundled C source.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          # Native macOS builds (link only system libs present on every Mac).
+          # macOS builds on Apple Silicon runners (macos-14, plentiful). The
+          # aarch64 build is native; the x86_64 build is cross-compiled from arm64
+          # (the SDK ships both arches; the cc crate adds `-arch x86_64`) so the
+          # release never waits on the scarce/deprecated Intel macos-13 runners.
           - target: aarch64-apple-darwin
             os: macos-14
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
     steps:
       - uses: actions/checkout@v4
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use rust_htslib::bam::{
 #[derive(Parser, Debug)]
 #[command(
     name = "rosalind",
+    version,
     about = "Deterministic low-memory genomics engine with a verifiable memory contract"
 )]
 struct Cli {


### PR DESCRIPTION
## Summary
Two hygiene nits from the v0.1.0 release.

- **`rosalind --version`** — `#[command(version)]` now reports the crate version (was unset → `--version` errored).
- **`release.yml`** — the `x86_64-apple-darwin` build now runs on **`macos-14`** (Apple Silicon, plentiful) and **cross-compiles from arm64** (the macOS SDK ships both arches; the `cc` crate adds `-arch x86_64` for the bundled htslib/bzip2/lzma C). This avoids the scarce, deprecated Intel `macos-13` runners that stalled the v0.1.0 Intel asset (which I ended up cross-building locally). Verified the cross-compile + a Rosetta smoke test locally.

## Test plan
- [x] `cargo run -- --version` → `rosalind 0.1.0`; `cargo fmt --check` clean; 0 warnings
- [x] `release.yml` YAML valid; all three targets on plentiful runners
- [ ] CI green on this PR; a release dry run confirms the macos-14 cross-build

🤖 Generated with [Claude Code](https://claude.com/claude-code)