### PR TITLE
fix(contract): predicted peak RSS is a true upper bound on real genomes (Act-1 PR-A)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-act1-contract-hardening.md
+++ b/docs/superpowers/plans/2026-06-02-act1-contract-hardening.md
@@ -1,0 +1,208 @@
+# Act 1 — Contract Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Execute INLINE (not via subagents) — this repo is a single shared tree; subagents running `cargo`/git concurrently corrupt it ([[feedback_subagent_shared_tree_no_cargo_fix]]).
+
+**Goal:** Make the memory contract *true and trusted on real genomes* — close the gaps where the contract holds on the synthetic/single-contig demo path but breaks on a real multi-contig human reference, and where the advertised first-60-seconds isn't actually verifiable.
+
+**Architecture:** Three focused PRs in sequence, each independently shippable. This plan details **PR-A (soundness)** fully; **PR-B (real-genome correctness)** and **PR-C (trust on-ramp + hygiene)** are scoped at the end and will each get their own detailed plan when reached.
+
+**Tech Stack:** Rust 2021 (MSRV 1.72), rust-htslib (BAM/VCF), BLAKE3 receipts, clap CLI, subprocess integration tests.
+
+**Source of truth:** the 60-agent reflection audit (`/private/tmp/.../tasks/audit.json`), findings triaged in [[project_rosalind_strategy]]. Every fix below traces to an adversarially-verified gap.
+
+---
+
+## The Act-1 sequence (header — full detail for PR-A only)
+
+- **PR-A — Soundness: make the predicted peak a true upper bound.** (§A) The keystone. The `Arc::from(decoded)` reallocation in `whole_genome.rs:69` makes two ASCII-decoded copies of the largest contig briefly co-resident, but the estimator (`plan.rs:33`) and accountant (`engine.rs:195`) both count the reference once — so a `[FITS]` plan can breach at runtime, caught only post-hoc by exit 4. And **no test compares predicted *peak RSS* to realized *peak RSS***. This PR records the prediction in the receipt, adds the missing real-peak soundness test, kills the transient, and gives the estimator an honest RSS-level margin.
+- **PR-B — Real-genome correctness.** (§B) Multi-contig `eval` (load all FASTA records + per-variant reference lookup), contig-naming guard (error when BAM `@SQ` ∩ index names is empty; warn when 0 reads contributed), IUPAC ambiguity codes → `N` at index build. (Somatic streaming-co-walk + contract surface is a larger separate item — note, don't bundle.)
+- **PR-C — Trust on-ramp + hygiene.** (§C/§D) Fix the README/CHANGELOG Action snippet (`logannye/rosalind-budget@v1` → `logannye/rosalind@v0.1.0`); make `install.sh` actually verify the `.sha256`; fix the CI `cli-e2e` checksum tautology (`--length 4000`); add `verify` manifest self-hash + cross-consistency; address the `IndexFreeIterator` public-API `unimplemented!()` panic; track `Cargo.lock`.
+
+---
+
+## PR-A: Soundness — predicted peak is a true upper bound
+
+**Files:**
+- Modify: `src/main.rs` (record prediction in receipt; ~`run_variants_index` near line 1634/1722, and the features path ~line 1373)
+- Modify: `src/call/plan.rs` (RSS-level margin in `predicted_peak_rss_bytes` + `render_variants_plan`)
+- Modify: `src/core/budget.rs` (new `PILEUP_IO_RSS_OVERHEAD` constant + re-export)
+- Modify: `src/genomics/index/view.rs` (new `decode_window_arc`)
+- Modify: `src/call/whole_genome.rs` + `src/call/features.rs` (use `decode_window_arc`; kill the transient)
+- Test: `tests/plan_enforce.rs` (new real-peak soundness test), `src/genomics/index/view.rs` (unit test), `src/call/plan.rs` (update value test)
+
+### Task 1: Record the predicted peak in the receipt
+
+The receipt records `peak_rss_bytes` (realized) but not the prediction. Recording it (a) enables the soundness assertion to read both numbers from one manifest, and (b) is exactly what the Act-2 `plan --fleet` scheduler needs. Compute it unconditionally (not only under `--enforce`).
+
+- [ ] **Step 1: Locate the realized-peak recording in `run_variants_index`.** In `src/main.rs`, the post-run block records `peak_rss_bytes` (~line 1781) and `max_working_set_bytes` (~line 1783). The `--enforce` gate (~line 1634) already computes `let baseline = peak_rss_bytes();` then `let predicted = predicted_peak_rss_bytes(largest, max_depth, max_read_len, baseline);`. Currently that lives *inside* the `if enforce {…}` block.
+
+- [ ] **Step 2: Lift baseline+predicted out of the enforce block so it's always computed.** Just before calling begins (before the `if enforce` gate), add:
+  ```rust
+  // Measured baseline (binary + libs + index/BAM open) → predicted peak RSS.
+  // Recorded in the receipt unconditionally: it is the contract's up-front
+  // claim, and the post-run check + `verify` assert the realized peak honors it.
+  let predicted_peak = rosalind::call::plan::predicted_peak_rss_bytes(
+      largest, max_depth, max_read_len, peak_rss_bytes(),
+  );
+  ```
+  Have the existing `--enforce` gate reuse `predicted_peak` instead of recomputing (keep its REFUSE message). Confirm `largest`, `max_depth`, `max_read_len` are in scope at that point (the enforce gate uses them, so they are).
+
+- [ ] **Step 3: Record it in the receipt params** alongside `peak_rss_bytes`:
+  ```rust
+  params.insert("predicted_peak_rss_bytes".to_string(), predicted_peak.to_string());
+  ```
+
+- [ ] **Step 4: Mirror the same recording in the features path** (`run_features`, ~line 1373) so `features --index` receipts also carry the prediction (it shares the engine and contract).
+
+- [ ] **Step 5: Build.** Run: `cargo build` — Expected: compiles, 0 warnings.
+
+### Task 2: The failing real-peak soundness test (TDD red)
+
+- [ ] **Step 1: Add the test to `tests/plan_enforce.rs`.** It builds an index with ONE multi-MiB contig and SHALLOW coverage (so the reference decode, not the active set, is the high-water — this is exactly where the transient dominates), runs the real binary, and asserts the recorded prediction bounds the recorded realized peak:
+  ```rust
+  #[test]
+  fn predicted_peak_rss_upper_bounds_realized_peak() {
+      // A multi-MiB contig with SHALLOW coverage: the reference decode is the
+      // RSS high-water, so the Arc::from transient (two copies of the contig)
+      // shows up in realized peak_rss but NOT in a reference-counted-once model.
+      // This is the contract's core inequality (predicted peak >= realized peak),
+      // which no existing test exercises (the others compare working-set vs
+      // working-set, both modeling the reference exactly once).
+      let dir = unique_dir("peak-soundness");
+      let idx = dir.join("ref.idx");
+
+      // ~8 MiB single contig of 'A'.
+      let bases = vec![b'A'; 8 * 1024 * 1024];
+      let index = rosalind::genomics::GenomeIndex::from_named_sequences(&[(
+          "chr1".to_string(),
+          bases,
+      )])
+      .unwrap();
+      rosalind::genomics::IndexWriter::create(&idx)
+          .unwrap()
+          .write_genome_index(&index)
+          .unwrap();
+
+      // A handful of short reads → shallow coverage; reference dominates RSS.
+      let bam = dir.join("reads.bam");
+      write_sorted_bam(&bam, &idx, &shallow_reads()); // helper below
+
+      let vcf = dir.join("calls.vcf");
+      let manifest = dir.join("calls.vcf.manifest.json");
+      let out = Command::new(bin())
+          .args(["variants", "--index"])
+          .arg(&idx)
+          .arg("--alignments")
+          .arg(&bam)
+          .args(["--max-depth", "1000", "--max-read-len", "250", "-o"])
+          .arg(&vcf)
+          .output()
+          .unwrap();
+      assert!(out.status.success(), "run failed: {out:?}");
+
+      let text = std::fs::read_to_string(&manifest).unwrap();
+      let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
+      let predicted: u64 = m.params.get("predicted_peak_rss_bytes").unwrap().parse().unwrap();
+      let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
+      assert!(
+          predicted >= realized,
+          "predicted peak RSS {predicted} must be >= realized peak RSS {realized} \
+           (gap = the unmodeled reference-decode transient)"
+      );
+      std::fs::remove_dir_all(&dir).ok();
+  }
+  ```
+  Reuse the fixture helpers already in the file (`unique_dir`, `bin`, the sorted-BAM builder used by `build_sorted_bam_fixture`). If a small standalone `write_sorted_bam`/`shallow_reads` helper is needed, factor it from the existing fixture builder — do NOT duplicate htslib glue.
+
+- [ ] **Step 2: Run it — expect RED.** Run: `cargo test --test plan_enforce predicted_peak_rss_upper_bounds_realized_peak -- --nocapture`. Expected: **FAIL** — realized peak ≈ baseline + ~16 MiB (8 MiB Arc + 8 MiB transient Vec), predicted ≈ baseline + ~8 MiB. This pins the soundness gap. (If it unexpectedly passes, the contig is too small for the transient to clear measurement noise — raise to 16–32 MiB.)
+
+### Task 3: Kill the reference-decode transient (green, part 1)
+
+- [ ] **Step 1: Add `decode_window_arc` to `ReferenceView`** in `src/genomics/index/view.rs`, building the `Arc<[u8]>` directly from a `TrustedLen` range iterator so there is no full intermediate ASCII `Vec` (no two-copies-resident spike):
+  ```rust
+  /// Decode `[start, end.min(len))` directly into an `Arc<[u8]>` without
+  /// materializing a separate owned `Vec` first — the collect writes into the
+  /// Arc's allocation in place (the range iterator is `TrustedLen`), so peak
+  /// resident reference memory is ONE copy, not the transient two that
+  /// `Arc::from(vec)` (which reallocates) would hold. Same bytes as
+  /// `decode_window`; bounded by the window size.
+  pub fn decode_window_arc(&self, start: usize, end: usize) -> std::sync::Arc<[u8]> {
+      let end = end.min(self.len);
+      (start..end).map(|i| self.base_at(i)).collect()
+  }
+  ```
+
+- [ ] **Step 2: Unit test byte-equivalence with `decode_window`** (in `view.rs` tests): decode the same window both ways on a small fixture, assert the `Arc` slice equals the `Vec`. This guarantees zero behavior change in the reference bytes the caller sees.
+
+- [ ] **Step 3: Use it in `call_germline_whole_genome`** (`src/call/whole_genome.rs:67-69`). Replace:
+  ```rust
+  let mut decoded = Vec::new();
+  ref_view.decode_window(start, end, &mut decoded);
+  let reference: Arc<[u8]> = Arc::from(decoded);
+  ```
+  with:
+  ```rust
+  let reference: Arc<[u8]> = ref_view.decode_window_arc(start, end);
+  ```
+  Update the comment block (lines 62-64) to state the transient is gone.
+
+- [ ] **Step 4: Use it in the features whole-genome driver** too — grep `decode_window` + `Arc::from` in `src/call/features.rs` and apply the same replacement (the features `--enforce` path inherits the identical contract).
+
+- [ ] **Step 5: Run the existing equivalence + bounded tests.** Run: `cargo test --test '*' whole_genome && cargo test -p rosalind --lib call::features`. Expected: PASS (byte-identical calls; `whole_genome_equals_per_contig_calls` still green).
+
+### Task 4: Honest RSS-level margin (green, part 2)
+
+The working-set estimate stays the pure pileup working set (comparable to the engine's accountant). The *RSS* prediction adds a named margin for what realized peak RSS includes but the working set omits: the BGZF decompression input buffer, the VCF `BufWriter`, and allocator slack.
+
+- [ ] **Step 1: Add the constant to `src/core/budget.rs`** next to the other `PILEUP_*` constants, and re-export it from the crate's core prelude the way the others are:
+  ```rust
+  /// Peak-RSS overhead the streaming *working set* does not model: BGZF input
+  /// buffer + VCF BufWriter + allocator slack between RSS and live bytes. Added
+  /// to the predicted peak RSS (not the working-set estimate) so the contract's
+  /// up-front claim is a conservative upper bound, not a steady-state count.
+  pub const PILEUP_IO_RSS_OVERHEAD: u64 = 16 * 1024 * 1024; // 16 MiB; calibrated by the soundness test
+  ```
+  (Start at 16 MiB; Task 4 Step 3 calibrates it against the measured gap.)
+
+- [ ] **Step 2: Add it in `predicted_peak_rss_bytes` and `render_variants_plan`** (`src/call/plan.rs`) — at the RSS level only, NOT in `estimate_variants_working_set`:
+  ```rust
+  pub fn predicted_peak_rss_bytes(/* …unchanged args… */) -> u64 {
+      baseline_rss_bytes
+          .saturating_add(estimate_variants_working_set(largest_contig_len, max_depth, max_read_len).bytes)
+          .saturating_add(PILEUP_IO_RSS_OVERHEAD)
+  }
+  ```
+  Add a matching `io overhead (RSS): N MiB` line to the `render_variants_plan` breakdown so `rosalind plan` stays transparent about the margin.
+
+- [ ] **Step 3: Update the value-level unit test** `predicted_peak_is_baseline_plus_working_set` in `plan.rs` to `assert_eq!(predicted, 50_000_000 + ws + PILEUP_IO_RSS_OVERHEAD)`. The working-set exact-value test (`estimate_grows_…`) is unchanged (the working-set estimate did not move). Leave `estimator_upper_bounds_the_realized_working_set` unchanged (still holds).
+
+- [ ] **Step 4: Run the soundness test — expect GREEN.** Run: `cargo test --test plan_enforce predicted_peak_rss_upper_bounds_realized_peak -- --nocapture`. Expected: PASS, with the transient eliminated (Task 3) and the margin (Task 4) covering io/allocator slack. If it still fails, read the printed predicted/realized gap and raise `PILEUP_IO_RSS_OVERHEAD` to cover it with headroom (this is the calibration step — the test is the spec).
+
+### Task 5: Full verification + commit
+
+- [ ] **Step 1: Whole suite.** Run: `cargo test` — Expected: all sections green (the new test + all existing, including `frontdoor_demo`, `germline_accuracy`, golden VCF).
+- [ ] **Step 2: Lints + format.** Run: `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo build --release`. Expected: clean, 0 warnings debug+release.
+- [ ] **Step 3: Re-run the flagship contract path locally** on the toy fixture to confirm `plan`/`--enforce`/`verify` still behave and the receipt now carries `predicted_peak_rss_bytes`. Eyeball that predicted ≥ realized in the receipt.
+- [ ] **Step 4: Commit** (use `git commit -F -` with a quoted heredoc — backticks in `-m` trigger shell substitution, [[project_rosalind_strategy]] lesson):
+  ```
+  fix(contract): predicted peak RSS is a true upper bound on real genomes
+
+  - kill the Arc::from(Vec) reference-decode transient (decode_window_arc)
+  - record predicted_peak_rss_bytes in the receipt (unconditional)
+  - honest PILEUP_IO_RSS_OVERHEAD margin at the RSS level
+  - the missing real peak-RSS soundness test (predicted >= realized)
+  ```
+
+---
+
+## Self-review (run before opening the PR)
+
+1. **Spec coverage:** §A's two halves — eliminate the transient AND make the estimator honest — both land, and the real-peak inequality is now a test (the audit's named gap "the contract's core soundness claim is NOT tested" is closed).
+2. **Soundness direction:** the margin only ever makes `predicted` larger → the contract can over-refuse but never under-predict. Correct safe direction.
+3. **No behavior change in calls:** `decode_window_arc` is byte-equivalent to `decode_window` (unit-tested); `whole_genome_equals_per_contig_calls` and the golden VCF pin output bytes.
+4. **Type consistency:** `decode_window_arc` returns `Arc<[u8]>` — the exact type `call_germline_region_streaming` already takes; no signature ripple.
+
+## Follow-on (PR-B, PR-C) — to be detailed when reached
+
+- **PR-B (correctness):** `read_fasta` → load ALL records into a `name→seq` map for `eval`; `compare_callsets` looks up the per-variant reference by `chrom` (error on absent contig, naming it); `StreamingBamSource::new` errors when no `@SQ` name resolves into the index and `run_variants_index` warns loudly when `reads_used == 0`; `sanitize_reference` maps IUPAC codes to `N` (report contig:coord on the strict path).
+- **PR-C (trust/hygiene):** README/CHANGELOG `rosalind-budget@v1` → `logannye/rosalind@v0.1.0` (+ a CI lint that the snippet ref resolves); `install.sh` fetches and checks the `.sha256`; CI `cli-e2e` passes `--length 4000` and stops overwriting the committed fixture; `verify` adds a manifest self-hash + `max_working_set_bytes <= peak_rss_bytes` / verdict-vs-budget consistency checks; doc-or-remove the `IndexFreeIterator::next_item()` `unimplemented!()` from the public API; track `Cargo.lock`.

--- a/src/call/features.rs
+++ b/src/call/features.rs
@@ -109,11 +109,12 @@ pub fn stream_features_whole_genome<S: ReadSource>(
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
+        // Decode straight into the Arc (no intermediate Vec) — one resident copy,
+        // not the transient two, so the predicted-peak bound holds (same as the
+        // germline whole-genome driver).
         let start = c.global_offset as usize;
         let end = c.global_offset as usize + c.length as usize;
-        let mut decoded = Vec::new();
-        ref_view.decode_window(start, end, &mut decoded);
-        let reference: Arc<[u8]> = Arc::from(decoded);
+        let reference: Arc<[u8]> = ref_view.decode_window_arc(start, end);
 
         let per = PerContig {
             source: &mut source,

--- a/src/call/plan.rs
+++ b/src/call/plan.rs
@@ -9,8 +9,8 @@
 //! prediction is comparable to the realized `peak_rss` the post-run check uses.
 
 use crate::core::{
-    MemoryBudget, WorkingSet, PILEUP_ENGINE_OVERHEAD, PILEUP_MAP_BYTES_PER_BASE,
-    PILEUP_PER_READ_OVERHEAD, PILEUP_SEQQUAL_BYTES_PER_BASE,
+    MemoryBudget, WorkingSet, PILEUP_ENGINE_OVERHEAD, PILEUP_IO_RSS_OVERHEAD,
+    PILEUP_MAP_BYTES_PER_BASE, PILEUP_PER_READ_OVERHEAD, PILEUP_SEQQUAL_BYTES_PER_BASE,
 };
 
 /// Estimate the peak streaming working set of a whole-genome germline call: the
@@ -37,16 +37,23 @@ pub fn estimate_variants_working_set(
 }
 
 /// Predicted peak process RSS = a measured process baseline + the estimated
-/// working set. Comparable to the realized `peak_rss` the post-run check uses.
+/// working set + a fixed I/O-buffer + allocator-slack margin
+/// (`PILEUP_IO_RSS_OVERHEAD`). Comparable to — and a conservative upper bound on
+/// — the realized `peak_rss` the post-run check uses. The margin is at the RSS
+/// level only (the working-set estimate stays comparable to the realized
+/// accountant); the reference-decode transient is eliminated at the source, so
+/// the margin need not scale with the reference.
 pub fn predicted_peak_rss_bytes(
     largest_contig_len: u64,
     max_depth: u32,
     max_read_len: u32,
     baseline_rss_bytes: u64,
 ) -> u64 {
-    baseline_rss_bytes.saturating_add(
-        estimate_variants_working_set(largest_contig_len, max_depth, max_read_len).bytes,
-    )
+    baseline_rss_bytes
+        .saturating_add(
+            estimate_variants_working_set(largest_contig_len, max_depth, max_read_len).bytes,
+        )
+        .saturating_add(PILEUP_IO_RSS_OVERHEAD)
 }
 
 /// Render the `rosalind plan --index` breakdown: a measured baseline + the
@@ -86,6 +93,7 @@ pub fn render_variants_plan(
          reference decode (largest contig):  {} MiB\n  \
          active set @ max-depth {}:           {} MiB\n  \
          engine overhead:                    {} MiB\n  \
+         I/O buffers + allocator slack:      {} MiB\n  \
          -------------------------------------------------\n  \
          predicted peak: ~{} MiB {}\n",
         baseline_rss_bytes / MIB,
@@ -93,6 +101,7 @@ pub fn render_variants_plan(
         max_depth,
         active / MIB,
         PILEUP_ENGINE_OVERHEAD / MIB,
+        PILEUP_IO_RSS_OVERHEAD / MIB,
         predicted / MIB,
         verdict,
     )
@@ -115,10 +124,10 @@ mod tests {
     }
 
     #[test]
-    fn predicted_peak_is_baseline_plus_working_set() {
+    fn predicted_peak_is_baseline_plus_working_set_plus_io_margin() {
         let ws = estimate_variants_working_set(248_000_000, 1_000, 250).bytes;
         let predicted = predicted_peak_rss_bytes(248_000_000, 1_000, 250, 50_000_000);
-        assert_eq!(predicted, 50_000_000 + ws);
+        assert_eq!(predicted, 50_000_000 + ws + PILEUP_IO_RSS_OVERHEAD);
     }
 
     #[test]

--- a/src/call/whole_genome.rs
+++ b/src/call/whole_genome.rs
@@ -59,14 +59,13 @@ pub fn call_germline_whole_genome<S: ReadSource>(
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
-        // Decode this contig's reference into a fresh Vec and MOVE it into the
-        // Arc — no persistent second copy (the steady-state reference resident is
-        // one contig, not two). Peak = the largest contig; bounded.
+        // Decode this contig's reference straight into the Arc — no intermediate
+        // Vec, so peak resident reference memory is ONE copy, not the transient
+        // two that `Arc::from(decoded)` (a reallocation) would briefly hold. Peak
+        // = the largest contig; bounded, and the predicted-peak bound holds.
         let start = c.global_offset as usize;
         let end = c.global_offset as usize + c.length as usize;
-        let mut decoded = Vec::new();
-        ref_view.decode_window(start, end, &mut decoded);
-        let reference: Arc<[u8]> = Arc::from(decoded);
+        let reference: Arc<[u8]> = ref_view.decode_window_arc(start, end);
 
         let per = PerContig {
             source: &mut source,

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -13,6 +13,15 @@ pub const PILEUP_SEQQUAL_BYTES_PER_BASE: u64 = 2;
 pub const PILEUP_PER_READ_OVERHEAD: u64 = 64;
 /// Fixed per-engine overhead.
 pub const PILEUP_ENGINE_OVERHEAD: u64 = 256;
+/// Peak-RSS overhead the streaming *working set* does not model: htslib/BGZF
+/// decompression buffers, the VCF `BufWriter`, and allocator slack between RSS
+/// and live bytes. Added to the *predicted peak RSS* (not the working-set
+/// estimate, which stays comparable to the realized accountant) so the
+/// contract's up-front claim is a conservative upper bound on real RSS rather
+/// than a steady-state live-bytes count. The reference-decode transient is
+/// eliminated at the source (`decode_window_arc`), so this margin covers only
+/// fixed I/O buffers + slack, not a per-contig reference copy.
+pub const PILEUP_IO_RSS_OVERHEAD: u64 = 8 * 1024 * 1024;
 
 /// A declared cap on a streaming stage's working set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,8 +11,8 @@ pub mod sequence;
 pub use sequence::{allele_index, BaseCode};
 
 pub use budget::{
-    MemoryBudget, WorkingSet, PILEUP_ENGINE_OVERHEAD, PILEUP_MAP_BYTES_PER_BASE,
-    PILEUP_PER_READ_OVERHEAD, PILEUP_SEQQUAL_BYTES_PER_BASE,
+    MemoryBudget, WorkingSet, PILEUP_ENGINE_OVERHEAD, PILEUP_IO_RSS_OVERHEAD,
+    PILEUP_MAP_BYTES_PER_BASE, PILEUP_PER_READ_OVERHEAD, PILEUP_SEQQUAL_BYTES_PER_BASE,
 };
 pub use error::CoreError;
 pub use locus::{Contig, ContigSet, Locus, Position};

--- a/src/genomics/index/io.rs
+++ b/src/genomics/index/io.rs
@@ -869,6 +869,9 @@ mod tests {
                 &reference[s..e.min(n)],
                 "decode_window {s}..{e}"
             );
+            // The transient-free Arc decoder must be byte-identical to decode_window.
+            let arc = rv.decode_window_arc(s, e);
+            assert_eq!(&*arc, buf.as_slice(), "decode_window_arc {s}..{e}");
         }
         let _ = std::fs::remove_file(path);
     }

--- a/src/genomics/index/view.rs
+++ b/src/genomics/index/view.rs
@@ -397,6 +397,19 @@ impl<'a> ReferenceView<'a> {
             out.push(self.base_at(i));
         }
     }
+
+    /// Decode `[start, end.min(len))` directly into an `Arc<[u8]>`, with no
+    /// separate owned `Vec` materialized first. `Arc::from(Vec<u8>)` REALLOCATES
+    /// — source and Arc buffers are both fully resident during the copy, so a
+    /// per-contig decode briefly holds two copies of the contig (the reference-
+    /// decode transient that broke the predicted-peak bound). Collecting a
+    /// `TrustedLen` range straight into the `Arc` writes into its allocation in
+    /// place, so peak resident reference memory is ONE copy. Byte-identical to
+    /// `decode_window`; bounded by the window size.
+    pub fn decode_window_arc(&self, start: usize, end: usize) -> std::sync::Arc<[u8]> {
+        let end = end.min(self.len);
+        (start..end).map(|i| self.base_at(i)).collect()
+    }
 }
 
 /// Validate that every block record (at the directory's offsets) lies fully

--- a/src/main.rs
+++ b/src/main.rs
@@ -1357,8 +1357,13 @@ fn run_features(
     let source = StreamingBamSource::new(&alignments_path, contigs)
         .map_err(|e| anyhow!("failed to open BAM {}: {e}", alignments_path.display()))?;
 
-    // Same `--enforce` admission as `variants` — it is the same pileup engine, so
-    // the predicted working set is identical.
+    // Same prediction + `--enforce` admission as `variants` — it is the same
+    // pileup engine, so the predicted working set is identical. Computed
+    // unconditionally and recorded in the receipt.
+    let largest = contigs.iter().map(|c| c.length as u64).max().unwrap_or(0);
+    let baseline = peak_rss_bytes();
+    let predicted_peak =
+        rosalind::call::plan::predicted_peak_rss_bytes(largest, max_depth, max_read_len, baseline);
     if enforce {
         if memory_budget_mb.is_none() {
             bail!("--enforce requires --memory-budget-mb");
@@ -1369,21 +1374,13 @@ fn run_features(
             );
         }
         let mb = memory_budget_mb.unwrap();
-        let largest = contigs.iter().map(|c| c.length as u64).max().unwrap_or(0);
-        let baseline = peak_rss_bytes();
-        let predicted = rosalind::call::plan::predicted_peak_rss_bytes(
-            largest,
-            max_depth,
-            max_read_len,
-            baseline,
-        );
-        if !MemoryBudget::from_mb(mb).admits(predicted) {
+        if !MemoryBudget::from_mb(mb).admits(predicted_peak) {
             eprintln!(
                 "contract: REFUSE — declared {} MiB, predicted peak ~{} MiB (largest contig {} MiB \
                  + active @ max-depth {} / max-read-len {} atop a {} MiB baseline). Raise \
                  --memory-budget-mb, lower --max-depth, or drop --enforce.",
                 mb,
-                predicted / (1 << 20),
+                predicted_peak / (1 << 20),
                 largest / (1 << 20),
                 max_depth,
                 max_read_len,
@@ -1488,6 +1485,10 @@ fn run_features(
         manifest
             .params
             .insert("peak_rss_bytes".to_string(), peak_rss.to_string());
+        manifest.params.insert(
+            "predicted_peak_rss_bytes".to_string(),
+            predicted_peak.to_string(),
+        );
         manifest.params.insert(
             "max_working_set_bytes".to_string(),
             max_ws.bytes.to_string(),
@@ -1617,9 +1618,16 @@ fn run_variants_index(
     let source = StreamingBamSource::new(&alignments_path, contigs)
         .map_err(|e| anyhow!("failed to open BAM {}: {e}", alignments_path.display()))?;
 
-    // `--enforce` contract: predict the peak RSS up front (measured baseline +
-    // the depth-capped working set) and refuse cleanly if it won't fit — before
-    // doing any work. Never a silent OOM.
+    // Predict the peak RSS up front: a measured baseline (binary + libs + index/
+    // BAM open) plus the depth-capped working set plus an RSS margin. Computed
+    // unconditionally and recorded in the receipt — it is the contract's up-front
+    // claim, which the post-run check and `verify` assert the realized peak honors.
+    // Under `--enforce` it also gates the run: refuse cleanly before any work,
+    // never a silent OOM.
+    let largest = contigs.iter().map(|c| c.length as u64).max().unwrap_or(0);
+    let baseline = peak_rss_bytes();
+    let predicted_peak =
+        rosalind::call::plan::predicted_peak_rss_bytes(largest, max_depth, max_read_len, baseline);
     if enforce {
         if memory_budget_mb.is_none() {
             bail!("--enforce requires --memory-budget-mb");
@@ -1630,22 +1638,14 @@ fn run_variants_index(
             );
         }
         let mb = memory_budget_mb.unwrap();
-        let largest = contigs.iter().map(|c| c.length as u64).max().unwrap_or(0);
-        let baseline = peak_rss_bytes();
-        let predicted = rosalind::call::plan::predicted_peak_rss_bytes(
-            largest,
-            max_depth,
-            max_read_len,
-            baseline,
-        );
-        if !MemoryBudget::from_mb(mb).admits(predicted) {
+        if !MemoryBudget::from_mb(mb).admits(predicted_peak) {
             eprintln!(
                 "contract: REFUSE — declared {} MiB, predicted peak ~{} MiB \
                  (largest contig {} MiB + active @ max-depth {} / max-read-len {} \
                  atop a {} MiB baseline). Raise --memory-budget-mb, lower --max-depth, \
                  or drop --enforce.",
                 mb,
-                predicted / (1 << 20),
+                predicted_peak / (1 << 20),
                 largest / (1 << 20),
                 max_depth,
                 max_read_len,
@@ -1779,6 +1779,10 @@ fn run_variants_index(
         manifest
             .params
             .insert("peak_rss_bytes".to_string(), peak_rss.to_string());
+        manifest.params.insert(
+            "predicted_peak_rss_bytes".to_string(),
+            predicted_peak.to_string(),
+        );
         manifest.params.insert(
             "max_working_set_bytes".to_string(),
             max_ws.bytes.to_string(),

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -402,3 +402,126 @@ fn estimator_upper_bounds_the_realized_working_set() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// Deterministic pseudo-random ACGT reference (no external rng): a multi-MiB
+// contig so the reference-decode step is the RSS high-water — exactly where the
+// `Arc::from(Vec)` reallocation transient lives.
+fn pseudo_ref(n: usize) -> Vec<u8> {
+    const BASES: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    (0..n)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            BASES[((state >> 33) & 0b11) as usize]
+        })
+        .collect()
+}
+
+// Build a single big contig + a handful of reads → index/align/sort, returning
+// (dir, index_path, sorted_bam_path). The reads are 60 bp substrings of the
+// reference at known offsets (unique in a random sequence → fast, unambiguous
+// alignment); coverage is shallow so the reference decode, not the active set,
+// dominates RSS.
+fn build_big_contig_fixture(ref_len: usize) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_dir("rosalind-peak");
+    let seq = pseudo_ref(ref_len);
+    let fa = dir.join("ref.fa");
+    let mut fasta = String::with_capacity(ref_len + ref_len / 70 + 16);
+    fasta.push_str(">chr1\n");
+    for chunk in seq.chunks(70) {
+        fasta.push_str(std::str::from_utf8(chunk).unwrap());
+        fasta.push('\n');
+    }
+    std::fs::write(&fa, &fasta).unwrap();
+
+    let fq = dir.join("reads.fq");
+    let mut fastq = String::new();
+    for (i, &off) in [1000usize, ref_len / 4, ref_len / 2, ref_len - 2000, 100_000]
+        .iter()
+        .enumerate()
+    {
+        let read = std::str::from_utf8(&seq[off..off + 60]).unwrap();
+        let qual: String = std::iter::repeat('I').take(60).collect();
+        fastq.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
+    }
+    std::fs::write(&fq, fastq).unwrap();
+
+    let idx = dir.join("ref.idx");
+    let raw = dir.join("raw.bam");
+    let bam = dir.join("sorted.bam");
+    assert!(run(&[
+        "index",
+        "--reference",
+        fa.to_str().unwrap(),
+        "--output",
+        idx.to_str().unwrap()
+    ])
+    .status
+    .success());
+    assert!(run(&[
+        "align",
+        "--reference",
+        fa.to_str().unwrap(),
+        "--reads",
+        fq.to_str().unwrap(),
+        "--format",
+        "bam",
+        "--output",
+        raw.to_str().unwrap()
+    ])
+    .status
+    .success());
+    assert!(run(&[
+        "sort",
+        "--input",
+        raw.to_str().unwrap(),
+        "--output",
+        bam.to_str().unwrap()
+    ])
+    .status
+    .success());
+    (dir, idx, bam)
+}
+
+#[test]
+fn predicted_peak_rss_upper_bounds_realized_peak() {
+    // THE contract's core inequality: predicted peak RSS >= realized peak RSS.
+    // No other test exercises it — the working-set tests compare working-set vs
+    // working-set, both modeling the reference exactly once, so they are blind by
+    // construction to the `Arc::from(decoded)` reference-decode transient (two
+    // copies of the largest contig briefly co-resident). A 4 MiB contig with
+    // shallow coverage makes that transient the RSS high-water; before the fix the
+    // realized peak exceeds the prediction by ~one contig copy.
+    let (dir, idx, bam) = build_big_contig_fixture(4 * 1024 * 1024);
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--max-depth", "1000", "--max-read-len", "250", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
+    let predicted: u64 = m
+        .params
+        .get("predicted_peak_rss_bytes")
+        .expect("receipt must record predicted_peak_rss_bytes")
+        .parse()
+        .unwrap();
+    let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
+    assert!(
+        predicted >= realized,
+        "predicted peak RSS {predicted} must be >= realized peak RSS {realized} \
+         (gap = {} bytes of unmodeled reference-decode transient)",
+        realized.saturating_sub(predicted)
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

**Act-1 hardening, PR-A (soundness keystone).** The predicted-peak memory contract held on the synthetic/single-contig demo path but could be **breached at runtime on a real multi-contig reference** — the highest-severity finding from the reflection audit.

**The gap (mechanism confirmed + quantified):** `call_germline_whole_genome` decoded each contig with `Arc::from(decoded)`, which **reallocates** — two ASCII-decoded copies of the largest contig briefly co-resident. But both the estimator (`call/plan.rs`) and the realized accountant (`pileup/engine.rs`) counted the reference **once**. So a `[FITS]` plan + the pre-run exit-3 gate could pass, then the run spikes past budget — caught only *after the fact* by the exit-4 check, i.e. after the allocation the contract promises to prevent up front. And **no test compared predicted *peak RSS* to realized *peak RSS*** (the existing soundness test is working-set-vs-working-set, both modeling the reference once → blind to the transient by construction).

## What changed

- **`decode_window_arc`** — decode straight into the `Arc<[u8]>` via a `TrustedLen` collect (no intermediate `Vec`), so peak resident reference memory is **one copy, not the transient two**. Used by both the germline and features whole-genome drivers. Byte-identical to `decode_window` (unit-tested).
- **Record `predicted_peak_rss_bytes` in the receipt**, computed unconditionally — the contract's up-front claim, now carried in the manifest (also what the Act-2 `plan --fleet` scheduler needs).
- **`PILEUP_IO_RSS_OVERHEAD`** — an honest RSS-level margin (htslib/BGZF buffers + `BufWriter` + allocator slack) added to the *prediction only*; the working-set estimate stays comparable to the realized accountant. The transient is eliminated at the source, so this margin covers fixed I/O buffers + slack, **not** a per-contig reference copy (so it need not scale with the genome).
- **The missing soundness test** — `predicted_peak_rss_upper_bounds_realized_peak`: a 4 MiB-contig, shallow-coverage run asserting predicted peak RSS ≥ realized peak RSS, read from the receipt.

## Measured (the TDD red→green)

| | predicted | realized | result |
|---|---|---|---|
| before fix | 18.9 MiB | **22.5 MiB** | ❌ RED — realized exceeds predicted by 3.4 MiB (the transient) |
| after fix | 26.0 MiB | 15.4 MiB | ✅ +10.6 MiB headroom — transient eliminated (realized dropped 22.5→15.4) |

The realized peak dropping by ~one contig copy confirms `decode_window_arc` eliminates the transient *at scale* — so the contract is sound on chr1-sized references by **elimination**, not by a fixed margin trying to cover a 237 MiB transient.

## Test plan

- [x] New soundness test green; `plan_enforce` 11/11
- [x] `decode_window_arc` == `decode_window` byte-equivalence (unit)
- [x] Calls byte-identical — golden VCF + `whole_genome_equals_per_contig_calls` green
- [x] Full suite green (26 files); rustc **0 warnings** debug+release; `cargo fmt` clean
- [x] Flagship `plan`/`--enforce`/`verify` re-run on the bundled toy fixture; receipt carries `predicted_peak_rss_bytes`
- [x] PR-A additions are clippy-clean (the repo's 59 pre-existing clippy lints + a CI clippy gate are a tracked PR-C hygiene item)

## Act-1 sequence

This is **PR-A of 3**. Next: **PR-B** (real-genome correctness — multi-contig `eval`, contig-naming guard, IUPAC→N) and **PR-C** (trust on-ramp + hygiene — Action snippet, `install.sh` checksum, CI tautology, `verify` self-hash, clippy gate). Plan: `docs/superpowers/plans/2026-06-02-act1-contract-hardening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)