### PR TITLE
feat(governor): the unbreakable bound — runtime memory governor (Sprint 1.1)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -45,6 +45,11 @@ With `--enforce`:
   message (raise the budget, lower `--max-depth`, or drop `--enforce`);
 - **realized peak > budget → fail loud** (exit **4**) *after* writing the VCF + receipt (you keep the data
   and the proof it overran) — never a silent overrun;
+- a **runtime governor** polls process RSS *during* the run and fails loud the moment the realized peak
+  crosses the budget — exit **4** with the partial output + a `governor=tripped`, `contract_verdict=over`
+  receipt — so a misprediction is caught mid-run instead of by a silent kernel OOM. The receipt also
+  records the realized RSS residual (`rss_residual_bytes`) against the assumed margin
+  (`io_rss_overhead_assumed_bytes`);
 - otherwise the run completes within budget.
 
 Without `--enforce`, the budget is **record-only**: the run always completes and the verdict is recorded in

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -62,4 +62,15 @@ Rosalind should maintain:
 - **Repeat-run tests**: run the same pipeline twice and compare output bytes.
 - **Thread-count invariance tests** (when multithreading is added): `--threads 1` vs `--threads N` must match.
 
+### The memory governor and determinism
+
+Under `--enforce`, a background governor thread reads process RSS and, on a breach,
+cooperatively aborts the run (exit 4). This does **not** weaken determinism: the guard
+never touches output bytes, and a run that fits never fires it — identical inputs still
+produce a byte-identical VCF/feature table. A *breach* is a non-deterministic abort
+(which locus trips depends on timing), but a breach exits non-zero and is a failure, not
+a reproducible artifact, so no determinism guarantee is affected. (The receipt's
+`peak_rss_bytes` / `baseline_rss_bytes` / `rss_residual_bytes` are machine-dependent
+measurements, like any realized-memory field — the primary output stays byte-identical.)
+
 

--- a/docs/superpowers/plans/2026-06-02-sprint1-unbreakable-bound.md
+++ b/docs/superpowers/plans/2026-06-02-sprint1-unbreakable-bound.md
@@ -1,0 +1,1032 @@
+# Sprint 1.1 — The Unbreakable Bound: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a process-global runtime memory governor so an `--enforce`'d run fails **loud** (exit 4, output + receipt written) the instant realized peak RSS crosses the declared budget — closing the silent-kernel-OOM window between the pre-run refuse (exit 3) and the post-run check — and record the measured RSS residual in every receipt so the 8 MiB prediction margin becomes evidence-backed.
+
+**Architecture:** A new `src/core/governor.rs` holds process-global cancellation state (RSS *is* process-global) behind a `checkpoint()` function and an RAII `MemoryGovernor` (a background poll thread). The bounded streaming drivers gain a one-line `governor::checkpoint()?` at six hot-loop sites — **no public-API signature changes**, so the ColumnKit SDK stays intact. The CLI (`run_variants_index`/`run_features`) holds a `MemoryGovernor` under `--enforce`, inspects the driver result instead of `?`-propagating it, and routes a governor trip into the existing exit-4 path. Four telemetry fields (`baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`, `governor`) are added to the receipt.
+
+**Tech Stack:** Rust (edition 2021, MSRV 1.72), `std::sync::atomic` + `std::thread`, the existing `CoreError::BudgetExceeded` variant, `getrusage`-based `peak_rss_bytes()`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md`
+
+---
+
+### Task 1: The governor module (`core::governor`)
+
+**Files:**
+- Create: `src/core/governor.rs`
+- Modify: `src/core/mod.rs`
+- Test: `tests/governor.rs` (new — a separate test binary so arming the process-global state cannot contaminate the in-process streaming unit tests)
+
+- [ ] **Step 1: Write the failing library test** (`tests/governor.rs`)
+
+```rust
+//! Library-API tests for the process-global memory governor. These run in their
+//! OWN test binary (separate process) so arming the global breach state cannot
+//! contaminate the in-process streaming unit tests; a module-local lock serializes
+//! the (process-global) governor tests against each other.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rosalind::core::governor::{checkpoint, GovernorError, MemoryGovernor};
+use rosalind::core::CoreError;
+
+// The governor state is process-global; serialize these tests against each other.
+static LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn checkpoint_is_ok_when_no_governor_is_armed() {
+    let _l = LOCK.lock().unwrap();
+    assert!(checkpoint().is_ok());
+}
+
+#[test]
+fn governor_trips_when_rss_crosses_budget_and_disarms_on_drop() {
+    let _l = LOCK.lock().unwrap();
+    // rss rises 100 bytes per call; budget 250 -> trips on the 3rd sample (300).
+    let counter = Arc::new(AtomicU64::new(0));
+    let c = Arc::clone(&counter);
+    let gov = MemoryGovernor::start(250, Duration::from_millis(1), move || {
+        c.fetch_add(100, Ordering::SeqCst) + 100
+    })
+    .expect("start");
+
+    // Spin (bounded) until checkpoint observes the breach.
+    let mut tripped = false;
+    for _ in 0..2000 {
+        if checkpoint().is_err() {
+            tripped = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(tripped, "checkpoint should observe the breach");
+    match checkpoint() {
+        Err(CoreError::BudgetExceeded { needed, budget }) => {
+            assert!(needed > 250, "needed {needed} should exceed the budget");
+            assert_eq!(budget, 250);
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    drop(gov);
+    // Disarmed on drop -> checkpoint is Ok again, and a fresh governor can start.
+    assert!(checkpoint().is_ok(), "drop must disarm the global state");
+    let again = MemoryGovernor::start(1000, Duration::from_millis(1), || 0).expect("re-start");
+    drop(again);
+}
+
+#[test]
+fn a_below_budget_source_never_trips() {
+    let _l = LOCK.lock().unwrap();
+    let gov = MemoryGovernor::start(1_000_000, Duration::from_millis(1), || 100).expect("start");
+    std::thread::sleep(Duration::from_millis(20));
+    assert!(checkpoint().is_ok(), "a source below budget must never trip");
+    drop(gov);
+}
+
+#[test]
+fn a_second_governor_while_one_is_active_is_rejected() {
+    let _l = LOCK.lock().unwrap();
+    let first = MemoryGovernor::start(1_000_000, Duration::from_millis(50), || 0).expect("first");
+    match MemoryGovernor::start(1_000_000, Duration::from_millis(50), || 0) {
+        Err(GovernorError::AlreadyActive) => {}
+        _ => panic!("a second concurrent governor must be rejected"),
+    }
+    drop(first);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile**
+
+Run: `cargo test --test governor`
+Expected: FAIL — `unresolved import rosalind::core::governor` (the module does not exist yet).
+
+- [ ] **Step 3: Create `src/core/governor.rs`**
+
+```rust
+//! Process-global runtime memory governor.
+//!
+//! Closes the window between the pre-run refuse (exit 3) and the post-run check
+//! where an `--enforce`'d run that mispredicts its peak could be silently
+//! OOM-killed by the kernel. While a [`MemoryGovernor`] is alive, a background
+//! thread polls process RSS; the first sample above the declared budget arms a
+//! process-global breach flag that the bounded streaming drivers observe via
+//! [`checkpoint`] and turn into a loud `Err(CoreError::BudgetExceeded)`.
+//!
+//! The state is process-global because RSS *is* a process-global resource — the
+//! budget is on the whole process, not one call. This keeps the public streaming
+//! API (the ColumnKit SDK) signature-stable: a driver checks the budget with a
+//! one-line [`checkpoint`] call, not a threaded parameter.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::core::error::CoreError;
+
+/// Is a governor active in this process? Guards against two concurrent governors.
+static ARMED: AtomicBool = AtomicBool::new(false);
+/// Has the active governor observed a breach?
+static TRIPPED: AtomicBool = AtomicBool::new(false);
+/// Realized peak RSS (bytes) at the breach — carried into the error + receipt.
+static PEAK_AT_TRIP: AtomicU64 = AtomicU64::new(0);
+/// Declared budget (bytes) of the active governor — carried into the error.
+static BUDGET: AtomicU64 = AtomicU64::new(0);
+
+/// A cooperative cancellation point for the bounded streaming drivers. Returns
+/// `Err(CoreError::BudgetExceeded)` once the active governor has observed a breach,
+/// else `Ok(())`. A single relaxed atomic load on the hot path; a no-op (always
+/// `Ok`) when no governor is armed (library callers, record-only runs).
+pub fn checkpoint() -> Result<(), CoreError> {
+    if TRIPPED.load(Ordering::Relaxed) {
+        Err(CoreError::BudgetExceeded {
+            needed: PEAK_AT_TRIP.load(Ordering::Acquire),
+            budget: BUDGET.load(Ordering::Acquire),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Failure starting a [`MemoryGovernor`].
+#[derive(Debug)]
+pub enum GovernorError {
+    /// A governor is already active in this process (the CLI is one-job-per-process).
+    AlreadyActive,
+}
+
+impl std::fmt::Display for GovernorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GovernorError::AlreadyActive => write!(f, "a memory governor is already active"),
+        }
+    }
+}
+
+impl std::error::Error for GovernorError {}
+
+/// An RAII runtime memory governor. While alive, a background thread polls
+/// `rss_source` every `poll`; the first sample above `budget_bytes` arms the
+/// process-global breach state [`checkpoint`] observes. Dropping it stops the
+/// thread and disarms the state.
+pub struct MemoryGovernor {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MemoryGovernor {
+    /// Start a governor for `budget_bytes`, polling `rss_source` every `poll`.
+    /// Performs one synchronous check before spawning (so an already-breached
+    /// source trips deterministically, before the first `checkpoint`). Errors if a
+    /// governor is already active in this process.
+    pub fn start<F>(budget_bytes: u64, poll: Duration, rss_source: F) -> Result<Self, GovernorError>
+    where
+        F: Fn() -> u64 + Send + 'static,
+    {
+        if ARMED.swap(true, Ordering::AcqRel) {
+            return Err(GovernorError::AlreadyActive);
+        }
+        TRIPPED.store(false, Ordering::Release);
+        PEAK_AT_TRIP.store(0, Ordering::Release);
+        BUDGET.store(budget_bytes, Ordering::Release);
+
+        // Synchronous initial check: a source already above budget trips now, so
+        // the very first driver checkpoint fails (no race with the poll thread).
+        let initial = rss_source();
+        if initial > budget_bytes {
+            PEAK_AT_TRIP.store(initial, Ordering::Release);
+            TRIPPED.store(true, Ordering::Release);
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || loop {
+            let rss = rss_source();
+            if rss > budget_bytes {
+                PEAK_AT_TRIP.store(rss, Ordering::Release);
+                TRIPPED.store(true, Ordering::Release);
+                break;
+            }
+            if stop_thread.load(Ordering::Acquire) {
+                break;
+            }
+            std::thread::sleep(poll);
+        });
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for MemoryGovernor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        TRIPPED.store(false, Ordering::Release);
+        PEAK_AT_TRIP.store(0, Ordering::Release);
+        ARMED.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Non-arming check only (arming tests live in tests/governor.rs, a separate
+    // process, so they cannot trip the global flag during in-process unit tests).
+    #[test]
+    fn checkpoint_ok_when_unarmed_and_governor_error_displays() {
+        assert!(checkpoint().is_ok());
+        assert!(GovernorError::AlreadyActive.to_string().contains("already active"));
+    }
+}
+```
+
+- [ ] **Step 4: Wire the module into `src/core/mod.rs`**
+
+Find the module declarations and the re-export block. Add the module declaration alongside the others (e.g. after `pub mod error;`):
+
+```rust
+pub mod governor;
+```
+
+And add a re-export next to the existing `pub use` lines:
+
+```rust
+pub use governor::{checkpoint, GovernorError, MemoryGovernor};
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --test governor && cargo test --lib governor`
+Expected: PASS — all four `tests/governor.rs` tests and the in-crate `checkpoint_ok_when_unarmed_and_governor_error_displays`.
+
+- [ ] **Step 6: Verify no warnings and commit**
+
+Run: `cargo build --release 2>&1 | grep -i warning || echo "no warnings"`
+Expected: `no warnings`
+
+```bash
+git add src/core/governor.rs src/core/mod.rs tests/governor.rs
+git commit -m "feat(governor): process-global memory governor + checkpoint (core::governor)"
+```
+
+---
+
+### Task 2: Insert `checkpoint()` at the six hot-loop sites
+
+No behavior change when no governor is armed (every `checkpoint()` is `Ok`), so the entire existing suite must stay green. The observable effect lands in Task 3.
+
+**Files:**
+- Modify: `src/call/whole_genome.rs`, `src/call/pipeline.rs`, `src/call/features.rs`, `src/call/gvcf.rs`
+
+- [ ] **Step 1: `src/call/whole_genome.rs` — per-contig pre-decode check**
+
+Add the import near the top (with the other `use crate::...` lines):
+
+```rust
+use crate::core::governor;
+```
+
+In `call_germline_whole_genome`, at the very top of the `for c in contigs.iter() {` loop body (before the `let start = ...` decode), insert:
+
+```rust
+        // Cooperative budget check (no-op unless an --enforce governor is armed):
+        // catch a breach before decoding the next contig's reference.
+        governor::checkpoint()?;
+```
+
+- [ ] **Step 2: `src/call/pipeline.rs` — per-column germline check**
+
+Add the import near the top:
+
+```rust
+use crate::core::governor;
+```
+
+In `call_germline_region_streaming`, inside `while let Some(column) = engine.next() {`, immediately after `let column = column?;`, insert:
+
+```rust
+        governor::checkpoint()?;
+```
+
+- [ ] **Step 3: `src/call/features.rs` — per-contig and per-column checks**
+
+Add the import near the top:
+
+```rust
+use crate::core::governor;
+```
+
+In `stream_features_whole_genome`, at the top of the `for c in contigs.iter() {` loop body (before `let start = ...`), insert:
+
+```rust
+        governor::checkpoint()?;
+```
+
+In `stream_features_region`, inside `while let Some(column) = engine.next() {`, immediately after `let column = column?;`, insert:
+
+```rust
+        governor::checkpoint()?;
+```
+
+- [ ] **Step 4: `src/call/gvcf.rs` — per-contig and per-column checks**
+
+Add the import near the top:
+
+```rust
+use crate::core::governor;
+```
+
+In `stream_gvcf_whole_genome`, at the top of the `for c in contigs.iter() {` loop body (before `let start = ...`), insert:
+
+```rust
+        governor::checkpoint()?;
+```
+
+In `stream_gvcf_region`, inside `while let Some(column) = engine.next() {`, immediately after `let column = column?;`, insert:
+
+```rust
+        governor::checkpoint()?;
+```
+
+- [ ] **Step 5: Run the full suite to verify no regression**
+
+Run: `cargo test 2>&1 | tail -20`
+Expected: all tests PASS (the checkpoints are no-ops with no governor armed).
+
+- [ ] **Step 6: Verify no warnings and commit**
+
+Run: `cargo build --release 2>&1 | grep -i warning || echo "no warnings"`
+Expected: `no warnings`
+
+```bash
+git add src/call/whole_genome.rs src/call/pipeline.rs src/call/features.rs src/call/gvcf.rs
+git commit -m "feat(governor): cooperative checkpoint() at the 6 bounded-driver hot-loop sites"
+```
+
+---
+
+### Task 3: CLI governor wiring + breach path in `run_variants_index`
+
+**Files:**
+- Modify: `src/main.rs` (`run_variants_index`, ~1798–2106)
+- Test: `tests/plan_enforce.rs`
+
+- [ ] **Step 1: Write the failing integration test** (append to `tests/plan_enforce.rs`)
+
+Use this file's existing helpers (verified present): `bin()` (the binary path), `build_sorted_bam_fixture() -> (dir, idx, bam)` (single-contig index + sorted BAM via index/align/sort), and `Command::new(bin())`. With `-o calls.vcf` the receipt sidecar is `calls.vcf.manifest.json`.
+
+```rust
+#[test]
+fn governor_aborts_loud_when_live_rss_exceeds_budget() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    // 4096 MiB passes the pre-run exit-3 gate, but the live-RSS seam reports
+    // 5000 MiB > budget, so the governor trips mid-run -> exit 4.
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .env("ROSALIND_FORCE_LIVE_RSS_BYTES", (5_000u64 * 1024 * 1024).to_string())
+        .env("ROSALIND_GOVERNOR_POLL_MS", "1")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(4), "governor breach must exit 4: {out:?}");
+    let m = std::fs::read_to_string(&manifest).expect("manifest written on breach");
+    assert!(m.contains("\"governor\":\"tripped\""), "manifest: {m}");
+    assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --test plan_enforce governor_aborts_loud -- --nocapture`
+Expected: FAIL — today the run completes (exit 0) and the `ROSALIND_FORCE_LIVE_RSS_BYTES` seam + `governor` field do not exist.
+
+- [ ] **Step 3: Add the governor lifecycle + live-RSS seam in `run_variants_index`**
+
+In `src/main.rs`, add the import inside `run_variants_index`'s `use` block (near `use rosalind::provenance::...`):
+
+```rust
+    use rosalind::core::governor::MemoryGovernor;
+```
+
+Immediately AFTER the `--enforce` pre-run gate (after the closing `}` of `if enforce { ... }` at ~line 1902, before the `macro_rules! drive!`), insert the governor start + seam:
+
+```rust
+    // Live RSS source for the governor: a test seam (ROSALIND_FORCE_LIVE_RSS_BYTES)
+    // standing in for live RSS, else the real getrusage high-water mark. Distinct
+    // from ROSALIND_FORCE_PEAK_RSS_BYTES, which overrides only the POST-run peak.
+    let live_rss = || {
+        std::env::var("ROSALIND_FORCE_LIVE_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let poll_ms = std::env::var("ROSALIND_GOVERNOR_POLL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    // Under --enforce, the governor fails the run LOUD the moment live RSS crosses
+    // the budget (exit 4 with output + receipt) — never a silent kernel OOM. Held
+    // for the duration of the calling pass; dropped (thread stopped) at scope end.
+    let _governor_guard = if enforce {
+        let mb = memory_budget_mb.expect("--enforce requires --memory-budget-mb (checked above)");
+        Some(
+            MemoryGovernor::start(
+                MemoryBudget::from_mb(mb).bytes,
+                std::time::Duration::from_millis(poll_ms),
+                live_rss,
+            )
+            .map_err(|e| anyhow!("failed to start memory governor: {e}"))?,
+        )
+    } else {
+        None
+    };
+```
+
+- [ ] **Step 4: Make `drive!` flush unconditionally and stop `?`-propagating the driver error**
+
+Replace the existing `drive!` macro body so the driver `Result` is returned (not `?`-mapped) and the writer flushes on both paths:
+
+```rust
+    macro_rules! drive {
+        ($writer:expr) => {{
+            let w = $writer;
+            let r = if gvcf {
+                write_gvcf_header(&mut *w, contigs, "SAMPLE")?;
+                stream_gvcf_whole_genome(
+                    source,
+                    &ref_view,
+                    contigs,
+                    pileup_params,
+                    &germline_params,
+                    &mut *w,
+                )
+            } else {
+                write_germline_header(&mut *w, contigs, "SAMPLE")?;
+                call_germline_whole_genome(
+                    source,
+                    &ref_view,
+                    contigs,
+                    pileup_params,
+                    &germline_params,
+                    &mut |(locus, ref_base, call)| {
+                        write_germline_row(
+                            &mut *w,
+                            contigs,
+                            &GermlineRow {
+                                locus,
+                                ref_base,
+                                call,
+                            },
+                        )
+                        .map_err(rosalind::core::CoreError::from)
+                    },
+                )
+            };
+            // Flush even on a governed abort so partial output survives; surface a
+            // genuine flush failure only when the calling pass itself succeeded.
+            if r.is_ok() {
+                w.flush()?;
+            } else {
+                let _ = w.flush();
+            }
+            r
+        }};
+    }
+```
+
+- [ ] **Step 5: Inspect the driver result and derive the breach state**
+
+Replace the `let (max_ws, skips) = match &output { ... };` block AND the subsequent `let peak_rss = ...` / `let verdict = ...` block with:
+
+```rust
+    let drive_result: Result<(rosalind::core::WorkingSet, rosalind::pileup::SkipCounts), rosalind::core::CoreError> =
+        match &output {
+            Some(path) => {
+                let file = File::create(path)
+                    .with_context(|| format!("failed to create VCF file {}", path.display()))?;
+                let mut writer = io::BufWriter::new(file);
+                drive!(&mut writer)
+            }
+            None => {
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                drive!(&mut handle)
+            }
+        };
+
+    // A governor trip is the one error we do NOT bail on: we still write the proof
+    // receipt (verdict=over, governor=tripped) and exit 4 via the existing post-run
+    // check. Any other error is a genuine failure.
+    let (max_ws, skips, breached, breach_peak) = match drive_result {
+        Ok((ws, sk)) => (ws, sk, false, 0u64),
+        Err(rosalind::core::CoreError::BudgetExceeded { needed, .. }) => (
+            rosalind::core::WorkingSet { bytes: 0 },
+            rosalind::pileup::SkipCounts::default(),
+            true,
+            needed,
+        ),
+        Err(e) => return Err(anyhow!("variant calling failed: {e}")),
+    };
+
+    // Realized peak: the governor's tripping peak on a breach, else the post-run
+    // high-water (ROSALIND_FORCE_PEAK_RSS_BYTES overrides only this post-run value).
+    let peak_rss = if breached {
+        breach_peak
+    } else {
+        std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let verdict = match memory_budget_mb.map(|mb| MemoryBudget::from_mb(mb).admits(peak_rss)) {
+        None => "unset",
+        Some(true) => "within",
+        Some(false) => "over",
+    };
+    let governor_state = if breached {
+        "tripped"
+    } else if enforce {
+        "enforced"
+    } else {
+        "record-only"
+    };
+```
+
+(Note: `breached` ⇒ `verdict == "over"` because `breach_peak > budget`; the existing post-run check at the end then prints `VIOLATED` and exits 4 — no new exit branch needed.)
+
+- [ ] **Step 6: Insert the `governor` field into the receipt block**
+
+In the receipt-writing block (`if let Some(dest) = receipt_dest { ... }`), immediately after the existing `max_working_set_bytes` insert (~line 2034), add:
+
+```rust
+        manifest
+            .params
+            .insert("governor".to_string(), governor_state.to_string());
+```
+
+- [ ] **Step 7: Run the test to verify it passes, then commit Task 3**
+
+Run: `cargo test --test plan_enforce governor_aborts_loud -- --nocapture && cargo build --release 2>&1 | grep -i warning || echo "no warnings"`
+Expected: PASS (exit 4 + `governor=tripped` + `contract_verdict=over` on breach), `no warnings`.
+
+```bash
+git add src/main.rs tests/plan_enforce.rs
+git commit -m "feat(governor): wire the runtime governor into variants --index (loud exit-4 on breach)"
+```
+
+---
+
+### Task 4: Residual telemetry fields in `run_variants_index`
+
+**Files:**
+- Modify: `src/main.rs` (`run_variants_index` receipt block, ~2008–2049)
+- Test: `tests/plan_enforce.rs`
+
+- [ ] **Step 1: Write the failing residual-recorded test** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn receipt_records_residual_and_governor_fields_on_a_fitting_run() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "a fitting run should exit 0: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).expect("manifest");
+    for key in [
+        "\"baseline_rss_bytes\":",
+        "\"rss_residual_bytes\":",
+        "\"io_rss_overhead_assumed_bytes\":",
+        "\"governor\":\"enforced\"",
+    ] {
+        assert!(text.contains(key), "manifest missing {key}: {text}");
+    }
+    // The receipt round-trips through the canonical parser.
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&text).expect("parse");
+    assert_eq!(m.params.get("governor").map(String::as_str), Some("enforced"));
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --test plan_enforce receipt_records_residual -- --nocapture`
+Expected: FAIL — `governor=enforced` is present (from Task 3) but the three residual fields are not in the manifest yet.
+
+- [ ] **Step 3: Derive the residual and add the three telemetry fields**
+
+In `run_variants_index`, add the import for the constant inside the `use` block:
+
+```rust
+    use rosalind::core::PILEUP_IO_RSS_OVERHEAD;
+```
+
+Just before the receipt-writing block (`if let Some(dest) = receipt_dest {`), derive the residual locals (all in scope: `baseline` from ~line 1874, `peak_rss`/`max_ws` from Task 3):
+
+```rust
+    let baseline_rss_bytes = baseline;
+    let rss_residual_bytes = peak_rss
+        .saturating_sub(max_ws.bytes)
+        .saturating_sub(baseline_rss_bytes);
+```
+
+In the receipt-writing block, immediately after the `governor` insert added in Task 3, add the three residual fields:
+
+```rust
+        manifest.params.insert(
+            "baseline_rss_bytes".to_string(),
+            baseline_rss_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "rss_residual_bytes".to_string(),
+            rss_residual_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "io_rss_overhead_assumed_bytes".to_string(),
+            PILEUP_IO_RSS_OVERHEAD.to_string(),
+        );
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --test plan_enforce receipt_records_residual -- --nocapture`
+Expected: PASS — the three residual fields + `governor=enforced` are present and the receipt round-trips.
+
+- [ ] **Step 5: Run the full suite + warnings check, then commit Task 4**
+
+Run: `cargo test 2>&1 | tail -15 && cargo build --release 2>&1 | grep -i warning || echo "no warnings"`
+Expected: all PASS, `no warnings`.
+
+```bash
+git add src/main.rs tests/plan_enforce.rs
+git commit -m "feat(governor): record baseline + RSS residual telemetry in the variants receipt"
+```
+
+---
+
+### Task 5: Mirror the governor + residual fields in `run_features`
+
+**Files:**
+- Modify: `src/main.rs` (`run_features`, ~1557–1796)
+- Test: `tests/plan_enforce.rs` (or `tests/features.rs` if that is where feature CLI tests live)
+
+- [ ] **Step 1: Write the failing test** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn features_governor_aborts_loud_and_records_residual() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let tsv = dir.join("feats.tsv");
+    let manifest = dir.join("feats.tsv.manifest.json");
+    let out = Command::new(bin())
+        .args(["features", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&tsv)
+        .env("ROSALIND_FORCE_LIVE_RSS_BYTES", (5_000u64 * 1024 * 1024).to_string())
+        .env("ROSALIND_GOVERNOR_POLL_MS", "1")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(4), "features breach must exit 4: {out:?}");
+    let m = std::fs::read_to_string(&manifest).expect("manifest on breach");
+    assert!(m.contains("\"governor\":\"tripped\""), "manifest: {m}");
+    assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --test plan_enforce features_governor_aborts_loud -- --nocapture`
+Expected: FAIL — no seam / `governor` field in `run_features` yet.
+
+- [ ] **Step 3: Add the governor lifecycle in `run_features`**
+
+Add the imports inside `run_features`'s `use` block:
+
+```rust
+    use rosalind::core::governor::MemoryGovernor;
+    use rosalind::core::PILEUP_IO_RSS_OVERHEAD;
+```
+
+Immediately AFTER the `--enforce` pre-run gate (after the closing `}` of `if enforce { ... }` at ~line 1637, before the `let mut analyzer = ...`), insert the SAME governor block as Task 3 Step 3:
+
+```rust
+    let live_rss = || {
+        std::env::var("ROSALIND_FORCE_LIVE_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let poll_ms = std::env::var("ROSALIND_GOVERNOR_POLL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    let _governor_guard = if enforce {
+        let mb = memory_budget_mb.expect("--enforce requires --memory-budget-mb (checked above)");
+        Some(
+            MemoryGovernor::start(
+                MemoryBudget::from_mb(mb).bytes,
+                std::time::Duration::from_millis(poll_ms),
+                live_rss,
+            )
+            .map_err(|e| anyhow!("failed to start memory governor: {e}"))?,
+        )
+    } else {
+        None
+    };
+```
+
+- [ ] **Step 4: Inspect the driver result (flush unconditionally) in `run_features`**
+
+Replace the `let (max_ws, skips) = match &output { ... };` block (the two `run_bounded_whole_genome(...)` arms) with an inspecting version that flushes on both paths:
+
+```rust
+    let mut analyzer = rosalind::call::FeatureAnalyzer::default();
+    // Inline both arms (match arms are exclusive, so moving `source`/`pileup_params`
+    // in each is fine — the same pattern the original code used). Flush on BOTH
+    // paths so partial output survives a governed abort; inspect the Result rather
+    // than `?`-propagating it.
+    let drive_result: Result<(rosalind::core::WorkingSet, rosalind::pileup::SkipCounts), rosalind::core::CoreError> =
+        match &output {
+            Some(path) => {
+                let file = File::create(path)
+                    .with_context(|| format!("failed to create features file {}", path.display()))?;
+                let mut writer = io::BufWriter::new(file);
+                let r = run_bounded_whole_genome(
+                    &mut analyzer,
+                    source,
+                    &ref_view,
+                    contigs,
+                    pileup_params,
+                    &mut writer,
+                );
+                if r.is_ok() {
+                    writer.flush()?;
+                } else {
+                    let _ = writer.flush();
+                }
+                r
+            }
+            None => {
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                let r = run_bounded_whole_genome(
+                    &mut analyzer,
+                    source,
+                    &ref_view,
+                    contigs,
+                    pileup_params,
+                    &mut handle,
+                );
+                if r.is_ok() {
+                    handle.flush()?;
+                } else {
+                    let _ = handle.flush();
+                }
+                r
+            }
+        };
+    let (max_ws, skips, breached, breach_peak) = match drive_result {
+        Ok((ws, sk)) => (ws, sk, false, 0u64),
+        Err(rosalind::core::CoreError::BudgetExceeded { needed, .. }) => (
+            rosalind::core::WorkingSet { bytes: 0 },
+            rosalind::pileup::SkipCounts::default(),
+            true,
+            needed,
+        ),
+        Err(e) => return Err(anyhow!("feature streaming failed: {e}")),
+    };
+    let feature_rows = analyzer.rows();
+```
+
+Then replace the `let peak_rss = ...` / `let verdict = ...` block with the full derivation (`run_features` is a single task, so it derives the residual locals and inserts all four receipt fields together):
+
+```rust
+    let peak_rss = if breached {
+        breach_peak
+    } else {
+        std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let verdict = match memory_budget_mb.map(|mb| MemoryBudget::from_mb(mb).admits(peak_rss)) {
+        None => "unset",
+        Some(true) => "within",
+        Some(false) => "over",
+    };
+    let governor_state = if breached {
+        "tripped"
+    } else if enforce {
+        "enforced"
+    } else {
+        "record-only"
+    };
+    let baseline_rss_bytes = baseline;
+    let rss_residual_bytes = peak_rss
+        .saturating_sub(max_ws.bytes)
+        .saturating_sub(baseline_rss_bytes);
+```
+
+- [ ] **Step 5: Add the four receipt fields in `run_features`**
+
+In the `run_features` receipt block, immediately after the existing `max_working_set_bytes` insert (~line 1738), add:
+
+```rust
+        manifest.params.insert(
+            "baseline_rss_bytes".to_string(),
+            baseline_rss_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "rss_residual_bytes".to_string(),
+            rss_residual_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "io_rss_overhead_assumed_bytes".to_string(),
+            PILEUP_IO_RSS_OVERHEAD.to_string(),
+        );
+        manifest
+            .params
+            .insert("governor".to_string(), governor_state.to_string());
+```
+
+- [ ] **Step 6: Run the test + full suite, then commit**
+
+Run: `cargo test --test plan_enforce features_governor -- --nocapture && cargo test 2>&1 | tail -15`
+Expected: PASS. Then `cargo build --release 2>&1 | grep -i warning || echo "no warnings"` → `no warnings`.
+
+```bash
+git add src/main.rs tests/plan_enforce.rs
+git commit -m "feat(governor): wire the governor + residual telemetry into features --index"
+```
+
+---
+
+### Task 6: Near-saturation soundness test
+
+Validate that the 8 MiB prediction margin actually covers the real residual at the budget boundary on a contig large enough that reference-decode dominates — and that the governor does NOT spuriously fire on a run that genuinely fits.
+
+**Files:**
+- Test: `tests/plan_enforce.rs`
+
+- [ ] **Step 1: Write the near-saturation soundness test**
+
+Uses the file's existing `build_big_contig_fixture(ref_len) -> (dir, idx, bam)` (the same fixture the 4 MiB `predicted_peak_rss_upper_bounds_realized_peak` test uses) and the canonical-manifest parser. Single-process (no cross-process baseline jitter), and it validates the new `rss_residual_bytes` field directly against the assumed margin.
+
+```rust
+#[test]
+fn near_saturation_margin_holds_on_a_larger_contig() {
+    // Soundness of the 8 MiB prediction margin at a bigger scale than the 4 MiB
+    // sibling test: on an ~8 MB contig (reference-decode dominates), the predicted
+    // peak must still upper-bound the realized peak — the fixed I/O+slack margin
+    // covers the real residual — AND the recorded residual is within that margin.
+    // (Governor no-false-fire on fitting runs is covered by the existing --enforce
+    // tests, which now run with the governor armed and still exit 0.)
+    let (dir, idx, bam) = build_big_contig_fixture(8 * 1024 * 1024);
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--max-depth", "1000", "--max-read-len", "250", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let m = rosalind::provenance::RunManifest::from_canonical_json(
+        &std::fs::read_to_string(&manifest).unwrap(),
+    )
+    .unwrap();
+    let predicted: u64 = m.params.get("predicted_peak_rss_bytes").unwrap().parse().unwrap();
+    let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
+    let residual: u64 = m.params.get("rss_residual_bytes").unwrap().parse().unwrap();
+    let assumed: u64 = m.params.get("io_rss_overhead_assumed_bytes").unwrap().parse().unwrap();
+    assert!(
+        predicted >= realized,
+        "8 MB contig: predicted {predicted} must be >= realized {realized}"
+    );
+    assert!(
+        residual <= assumed,
+        "recorded residual {residual} should be within the assumed margin {assumed} \
+         (if not, the 8 MiB constant is too small for this workload — a REAL finding, \
+          not a test to silence)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test --test plan_enforce near_saturation_margin -- --nocapture`
+Expected: PASS — predicted ≥ realized and the recorded residual is within the assumed margin. (If it FAILS, that is a real finding — the 8 MiB margin is too small for this workload; record it and raise the issue rather than silencing the test.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/plan_enforce.rs
+git commit -m "test(governor): near-saturation soundness — budget == predicted peak still fits"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `src/core/budget.rs` (doc-comment), `CONTRACT.md`, `docs/determinism.md`
+
+- [ ] **Step 1: `src/core/budget.rs` — reframe the constant's role**
+
+Extend the doc-comment on `PILEUP_IO_RSS_OVERHEAD` (currently ~lines 16–24) with a sentence on the governor reframe (no value change):
+
+```rust
+/// ...existing text...
+///
+/// Reframe (Sprint 1.1): this margin's correctness is no longer load-bearing for
+/// *safety*. Under `--enforce` a runtime `MemoryGovernor` (`core::governor`) fails
+/// the run loud (exit 4, output + receipt written) the moment realized peak RSS
+/// crosses the budget, so an under-prediction here is caught live rather than
+/// silently OOM-killed. The realized residual (`peak − working_set − baseline`) is
+/// now recorded in every receipt (`rss_residual_bytes`) to make a future, evidence-
+/// based re-tuning of this constant possible.
+```
+
+- [ ] **Step 2: `CONTRACT.md` — document the live governor in the "Honor" section**
+
+In the `### 3. Honor` section, after the bullet describing `realized peak > budget → fail loud (exit 4)`, add:
+
+```markdown
+- **runtime governor** — under `--enforce`, a background guard polls process RSS and
+  fails the run **loud at the moment of breach** (exit 4, partial output + a
+  `governor=tripped`, `contract_verdict=over` receipt), so a misprediction is caught
+  *during* the run, not by a silent kernel OOM. The receipt also records the realized
+  RSS residual (`rss_residual_bytes`) against the assumed margin
+  (`io_rss_overhead_assumed_bytes`).
+```
+
+- [ ] **Step 3: `docs/determinism.md` — the breach-determinism note**
+
+Add a short paragraph:
+
+```markdown
+## The memory governor and determinism
+
+Under `--enforce`, a background governor thread reads process RSS and, on a breach,
+cooperatively aborts the run (exit 4). This does **not** weaken determinism: the
+guard never touches output bytes, and a run that fits never fires it — identical
+inputs still produce a byte-identical VCF/feature table. A *breach* is a
+non-deterministic abort (which locus trips depends on timing), but a breach exits
+non-zero and is a failure, not a reproducible artifact.
+```
+
+- [ ] **Step 4: Verify the build + full suite, then commit**
+
+Run: `cargo test 2>&1 | tail -15 && cargo build --release 2>&1 | grep -i warning || echo "no warnings"`
+Expected: all PASS, `no warnings`.
+
+```bash
+git add src/core/budget.rs CONTRACT.md docs/determinism.md
+git commit -m "docs(governor): document the runtime governor + residual telemetry + determinism"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full suite green:** `cargo test 2>&1 | tail -20` — all sections PASS.
+- [ ] **Zero warnings:** `cargo build --release 2>&1 | grep -i warning || echo "no warnings"` and `cargo build --release --examples 2>&1 | grep -i warning || echo "no warnings"`.
+- [ ] **Format clean:** `cargo fmt --check`.
+- [ ] **Smoke the contract end-to-end** on the bundled fixture: `cargo run --release -- variants --index <toy.idx> --alignments <toy.sorted.bam> --memory-budget-mb 512 --enforce -o /tmp/c.vcf` → `contract: OK`, and the manifest contains `governor`, `baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`.
+- [ ] **ColumnKit SDK signature unchanged:** confirm `run_bounded_whole_genome` and the re-exports in `src/lib.rs` / `src/call/mod.rs` are byte-for-byte the same as before (no parameter added).
+- [ ] CI green on GitHub before reporting done (local-green ≠ CI-green).

--- a/docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md
@@ -45,55 +45,76 @@ future increment can re-tune the constant with evidence rather than a guess.
 
 ## 3. Design
 
-### 3.1 The governor (`src/core/governor.rs`, new)
+### 3.1 The governor (`src/core/governor.rs`, new) — process-global
+
+RSS is a **process-global** resource (the budget is on the whole process, not one call), so the
+governor's cancellation is process-global state, not a value threaded through every call. This keeps
+the entire public streaming API — including the `run_bounded_whole_genome` ColumnKit SDK entry point
+and every crate-root re-export — **signature-stable**: a breach is observed by a one-line
+`governor::checkpoint()?` at the hot-loop sites, with no parameter changes anywhere.
+
+Process-global cancellation state (private to `core::governor`), read on the hot path with a single
+relaxed atomic load:
 
 ```text
-MemoryGovernor::start(budget_bytes: u64, poll: Duration, rss_source: fn() -> u64) -> MemoryGovernor
-  - spawns ONE background thread:
-      loop { if rss_source() > budget_bytes { tripped.store(true, Release); break }
-             if stop.load(Acquire) { break }
-             sleep(poll) }
-  - holds: Arc<AtomicBool> tripped, Arc<AtomicBool> stop, JoinHandle
-MemoryGovernor::tripped() -> &AtomicBool        // the cancel token the drivers observe
-MemoryGovernor::stop(self)                       // sets stop, joins the thread
-impl Drop                                        // stop-and-join if not already stopped
+static ARMED: AtomicBool         // is a governor active? (one per process)
+static TRIPPED: AtomicBool       // has the budget been breached?
+static PEAK_AT_TRIP: AtomicU64   // realized peak at the breach (for the error / receipt)
+static BUDGET: AtomicU64         // declared budget in bytes (for the error)
+
+pub fn checkpoint() -> Result<(), CoreError>
+  // if TRIPPED (relaxed load) -> Err(CoreError::BudgetExceeded { needed: PEAK_AT_TRIP, budget: BUDGET })
+  // else Ok(())   — a single relaxed load when no governor is armed (library callers, record-only)
 ```
 
-- `rss_source` defaults to `rosalind::util::rss::peak_rss_bytes` (getrusage `ru_maxrss`, a
-  monotonic high-water mark — exactly "did peak ever cross the budget"). It is injectable purely as
-  the **test seam** (§3.5): a test feeds a rising sequence with no real memory pressure.
+The RAII handle owns the poll thread and arms/disarms the global state:
+
+```text
+MemoryGovernor::start(budget_bytes, poll, rss_source: impl Fn() -> u64 + Send + 'static)
+    -> Result<MemoryGovernor, GovernorError>
+  - ARMED.swap(true) == true  -> Err(AlreadyActive)   (one governor per process)
+  - reset TRIPPED=false, PEAK_AT_TRIP=0, BUDGET=budget_bytes
+  - spawn ONE thread: loop { let r = rss_source();
+                             if r > budget_bytes { PEAK_AT_TRIP=r; TRIPPED=true; break }
+                             if stop { break } sleep(poll) }
+impl Drop  // stop + join the thread, then ARMED=false, TRIPPED=false (clean for the next run)
+```
+
+- `rss_source` is `impl Fn() -> u64 + Send + 'static`. Production passes `|| peak_rss_bytes()`
+  (getrusage `ru_maxrss`, a monotonic high-water mark — exactly "did peak ever cross the budget").
+  It is injectable purely as the **unit-test seam** (§3.6): a closure capturing a rising counter
+  trips the governor with no real memory pressure.
 - `poll` defaults to **100 ms**; `run_variants_index`/`run_features` read an override from
   `ROSALIND_GOVERNOR_POLL_MS` (tests use a small value for responsiveness).
-- The governor is **started only under `--enforce`**. Record-only runs construct **no** governor and
-  pass `None` as the cancel token (telemetry in §3.3 is still recorded — it is pure measurement).
+- The governor is **constructed only under `--enforce`** (held in a local; dropped at function end).
+  Record-only runs never arm it, so `checkpoint()` is always `Ok` — the telemetry in §3.3 is still
+  recorded (it is pure measurement, independent of the governor).
 
 ### 3.2 Cooperative cancellation (the abort path)
 
 The guard never interrupts the main thread mid-allocation (that would corrupt the
-*"you keep the data and the proof it overran"* property). It sets `tripped`; the bounded drivers
-observe it cooperatively and return an error that flows through the **existing** exit-4 machinery.
+*"you keep the data and the proof it overran"* property). The poll thread sets `TRIPPED`; the bounded
+drivers observe it cooperatively at `checkpoint()` calls and return an error that the CLI routes into
+the exit-4 machinery.
 
-- **Signature change:** add `cancel: Option<&AtomicBool>` to:
-  - `call_germline_whole_genome` (`call/whole_genome.rs:49`) and the per-region caller it drives,
-    `call_germline_region_streaming` (`call/pipeline.rs:20`).
-  - `run_bounded_whole_genome` (`call/columnkit.rs:61`).
-  - the features region helpers `stream_features_whole_genome` (`call/features.rs:100`) /
-    `stream_features_region` (`call/features.rs:74`).
-  - `None` preserves today's behavior; **all existing call sites and tests pass `None`** and are
-    unchanged.
-- **Two check points** (each a single `Relaxed` atomic load — negligible):
-  1. **Top of the per-contig loop, before `decode_window_arc`** (`whole_genome.rs:61`,
-     `features.rs:111`, the columnkit driver loop). This catches the *dominant* breach mode — decoding
-     the next large contig's reference — **before** the allocation happens.
-  2. **Once per column** in the region loop (`call_germline_region_streaming` `pipeline.rs:31`;
-     `stream_features_region` `features.rs:84`). Catches within-contig drift (I/O buffers, allocator
-     growth).
-- **On `tripped`** → the driver returns `Err(CoreError::BudgetExceeded { .. })`, reusing the existing
-  (currently unraised) variant (`core/error.rs:12`). The driver needs to know only *that* it was
-  cancelled, not the budget; `run_variants_index` / `run_features` **catch the error and populate the
-  authoritative numbers** for the loud message + receipt — `budget` = the declared budget, `needed` =
-  the post-trip `peak_rss_bytes()`. (Field population by the caller keeps the driver decoupled from
-  the budget it does not otherwise hold.)
+- **No signature changes.** Insert `governor::checkpoint()?;` at six hot-loop sites (one line each):
+  1. **Top of each per-contig loop, before `decode_window_arc`** — `call_germline_whole_genome`
+     (`whole_genome.rs:61`), `stream_features_whole_genome` (`features.rs:111`),
+     `stream_gvcf_whole_genome` (`gvcf.rs:259`). Catches the *dominant* breach mode — decoding the
+     next large contig's reference — **before** the allocation happens.
+  2. **Once per column** in each region loop — `call_germline_region_streaming` (`pipeline.rs:31`),
+     `stream_features_region` (`features.rs:84`), `stream_gvcf_region` (`gvcf.rs:226`). Catches
+     within-contig drift (I/O buffers, allocator growth). `run_bounded_whole_genome` inherits the
+     features checks (it delegates to `stream_features_whole_genome`).
+  - Each call is a single relaxed atomic load when no governor is armed — negligible, and a no-op for
+    every library caller and existing test (no behavior change).
+- **The gVCF path is covered too** — `variants --index --gvcf --enforce` is a real path; omitting it
+  would leave a governor gap in the very feature being built.
+- **On `TRIPPED`** → `checkpoint()` returns `Err(CoreError::BudgetExceeded { needed, budget })` with
+  **authoritative numbers** carried in the global state (`needed` = `PEAK_AT_TRIP`, `budget` =
+  `BUDGET`), so the driver stays decoupled (it raises the error without holding the budget). The CLI
+  catches it (§3.5). The existing (currently unraised) `BudgetExceeded` variant (`core/error.rs:12`)
+  is reused unchanged.
 
 ### 3.3 Receipt — the measured residual (telemetry)
 
@@ -106,7 +127,7 @@ the receipt's existing convention:
 | `baseline_rss_bytes` | the baseline measured at `main.rs:1610` (already computed, just not recorded) |
 | `rss_residual_bytes` | `peak_rss.saturating_sub(max_working_set).saturating_sub(baseline)` — the real I/O+slack overhead this run incurred |
 | `io_rss_overhead_assumed_bytes` | the `PILEUP_IO_RSS_OVERHEAD` constant (assumed-vs-realized, side by side) |
-| `governor` | `"enforced"` when `--enforce`, else `"record-only"` |
+| `governor` | `"enforced"` (ran under `--enforce`, fit) · `"tripped"` (governor aborted the run mid-stream) · `"record-only"` (no `--enforce`) |
 
 > Determinism note: `baseline_rss_bytes` and `rss_residual_bytes` are machine-dependent
 > measurements, exactly like the already-present `peak_rss_bytes`. The VCF/feature output stays
@@ -125,26 +146,39 @@ doc-comment and the `CONTRACT.md` "honor" section.
 
 ### 3.5 Error handling, exit codes, determinism
 
-- `Err(CoreError::BudgetExceeded)` propagates to `run_variants_index` / `run_features`, which route it
-  into the **existing exit-4 path**: write the partial output, write the receipt with
-  `contract_verdict = "over"`, print the loud breach message, `std::process::exit(4)`. A live breach
-  now yields the *same* artifacts a post-run breach does.
-- The **post-run check stays** as a backstop, covering the ≤ `poll` sampling gap between the last
-  poll and a breach.
-- **Determinism for fitting runs is preserved.** The guard only reads RSS and sets a flag; it never
-  touches output bytes, and in a run that fits it never fires. A breach is by nature a
-  nondeterministic abort (which column trips depends on timing) — but a breach exits non-zero and is
-  a *failure*, not a reproducible artifact, so no determinism guarantee is weakened. Stated
-  explicitly in `docs/determinism.md`.
+- The driver call in `run_variants_index` / `run_features` is wrapped so its `Result` is **inspected,
+  not `?`-propagated**, and the writer is **flushed unconditionally** (so partial output survives a
+  breach):
+  - `Ok((max_ws, skips))` → today's path unchanged (post-run peak, verdict, receipt, backstop exit 4).
+  - `Err(CoreError::BudgetExceeded { needed, .. })` (governor abort) → record `peak_rss = needed`,
+    `governor = "tripped"`, `contract_verdict = "over"`, `max_working_set_bytes = 0` (the run did not
+    complete, so no working-set high-water was returned — `0` is the honest sentinel), the residual
+    fields best-effort; **write the receipt**, print the loud `VIOLATED` message, `std::process::exit(4)`.
+  - `Err(other)` → `bail!` as today.
+- This keeps the promise: a live breach yields the **proof** (a `verdict=over`, `governor=tripped`
+  receipt) plus whatever partial output was flushed — never a silent OOM.
+- The **post-run check stays** as a backstop on the `Ok` path, covering the ≤ `poll` sampling gap
+  between the last poll and a breach that the kernel did not preempt.
+- **Determinism for fitting runs is preserved.** The poll thread only reads RSS and sets a flag; it
+  never touches output bytes, and in a run that fits it never fires (every `checkpoint()` is `Ok`). A
+  breach is by nature a nondeterministic abort (which column trips depends on timing) — but a breach
+  exits non-zero and is a *failure*, not a reproducible artifact, so no determinism guarantee is
+  weakened. Stated explicitly in `docs/determinism.md`.
 
 ### 3.6 Testing
 
-1. **Governor abort (integration, deterministic).** Inject an `rss_source` that returns a rising
-   sequence crossing the budget after a few polls; run a small `variants --index --enforce`; assert:
-   exit 4, `contract_verdict=over` in the receipt, and the partial VCF **and** manifest exist. No real
-   memory pressure → CI-safe and fast.
-2. **Governor unit test.** `MemoryGovernor` with a stub `rss_source` trips `tripped` once the stub
-   crosses the budget and not before; `stop()` joins cleanly; below-budget never trips.
+1. **Governor abort (integration, deterministic).** The CLI's `rss_source` closure reads an env seam
+   `ROSALIND_FORCE_LIVE_RSS_BYTES` (a fixed value standing in for live RSS; falls back to
+   `peak_rss_bytes()`). The test runs `variants --index --enforce` with a budget *above* the predicted
+   peak (so the exit-3 gate passes) but with `ROSALIND_FORCE_LIVE_RSS_BYTES` set *above* the budget, so
+   the governor trips on the first poll; assert: exit 4, `governor=tripped` + `contract_verdict=over`
+   in the receipt, and the manifest exists. No real memory pressure → CI-safe and fast. (This seam is
+   distinct from `ROSALIND_FORCE_PEAK_RSS_BYTES`, which overrides only the *post-run* peak.)
+2. **Governor unit test.** `MemoryGovernor::start` with a closure `rss_source` capturing a rising
+   counter: `governor::checkpoint()` returns `Ok` before the counter crosses the budget and
+   `Err(BudgetExceeded { needed, budget })` after; `Drop` joins cleanly and disarms (a second
+   `start` then succeeds); a below-budget source never trips. A second `start` while one is active
+   returns `GovernorError::AlreadyActive`.
 3. **Near-saturation soundness.** Extend `predicted_peak_rss_upper_bounds_realized_peak`: build a
    larger synthetic contig (a few MB — large enough that reference-decode dominates), run with
    `budget == predicted_peak` (zero extra headroom), assert the run completes within budget (the
@@ -159,15 +193,16 @@ doc-comment and the `CONTRACT.md` "honor" section.
 
 | File | Change |
 |---|---|
-| `src/core/governor.rs` (new) | `MemoryGovernor` (poll thread, injectable `rss_source`, `tripped`/`stop`/`Drop`). |
-| `src/core/mod.rs` | Export `governor` + `MemoryGovernor`. |
-| `src/core/budget.rs` | Doc-comment: the prediction-margin reframe (governor is the safety net, not the constant). No value change. |
-| `src/call/whole_genome.rs` | `cancel: Option<&AtomicBool>` param; check at per-contig top (pre-decode); thread into the region caller. |
-| `src/call/pipeline.rs` | `cancel` param on `call_germline_region_streaming` (+ `_tracked` wrapper); per-column check in the `while let Some(column)` loop. |
-| `src/call/columnkit.rs` | `cancel: Option<&AtomicBool>` param on `run_bounded_whole_genome`; per-contig + per-column checks. |
-| `src/call/features.rs` | `cancel` threaded into `stream_features_region` / `stream_features_whole_genome`; per-column check. |
-| `src/main.rs` | `run_variants_index` + `run_features`: under `--enforce` start a `MemoryGovernor`, pass `governor.tripped()` as `cancel`, stop on completion; map `Err(BudgetExceeded)` to the exit-4 path; record the four new receipt fields (`baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`, `governor`). |
-| `tests/plan_enforce.rs` | Governor-abort integration test; near-saturation soundness; residual-recorded assertions. |
+| `src/core/governor.rs` (new) | Process-global `ARMED`/`TRIPPED`/`PEAK_AT_TRIP`/`BUDGET` statics; `pub fn checkpoint() -> Result<(), CoreError>`; `MemoryGovernor::start(budget, poll, rss_source)` (poll thread) + `Drop` (stop/join/disarm); `GovernorError::AlreadyActive`; unit tests. **No signature changes anywhere else.** |
+| `src/core/mod.rs` | `pub mod governor;` + re-export `checkpoint`, `MemoryGovernor`, `GovernorError`. |
+| `src/core/budget.rs` | Doc-comment: the prediction-margin reframe (the governor is the safety net, not the constant). No value change. |
+| `src/call/whole_genome.rs` | One line: `governor::checkpoint()?;` at the top of the `for c in contigs.iter()` loop (`:61`), before `decode_window_arc`. |
+| `src/call/pipeline.rs` | One line: `governor::checkpoint()?;` at the top of the `while let Some(column)` loop in `call_germline_region_streaming` (`:31`). |
+| `src/call/features.rs` | Two lines: `checkpoint()?` at the per-contig loop top (`:111`) and the per-column loop top in `stream_features_region` (`:84`). |
+| `src/call/gvcf.rs` | Two lines: `checkpoint()?` at the per-contig loop top (`:259`) and the per-column loop top in `stream_gvcf_region` (`:226`). |
+| `src/call/columnkit.rs` | No change — `run_bounded_whole_genome` delegates to `stream_features_whole_genome`, inheriting its checks. Public SDK signature **unchanged**. |
+| `src/main.rs` | `run_variants_index` + `run_features`: under `--enforce`, hold a `MemoryGovernor` (rss_source = the `ROSALIND_FORCE_LIVE_RSS_BYTES`-aware closure); flush the writer unconditionally and **inspect** the driver `Result` instead of `?`-propagating it; on `Err(BudgetExceeded)` write the `governor=tripped`/`verdict=over` receipt and `exit(4)`; record the four new receipt fields (`baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`, `governor`) on both paths. |
+| `tests/plan_enforce.rs` | Governor-abort integration test (env seam); near-saturation soundness; residual-recorded assertions. |
 | `CONTRACT.md`, `docs/determinism.md` | Document the live governor + the breach-determinism note. |
 
 ## 5. Risks & mitigations
@@ -176,10 +211,15 @@ doc-comment and the `CONTRACT.md` "honor" section.
   working set grows gradually with coverage (depth-capped), the dominant breach (reference decode) is
   caught pre-allocation at the contig boundary, and the post-run check remains a backstop. 100 ms is
   conservative for genome-scale runs that take seconds-to-minutes per contig.
-- **Thread + determinism.** Covered in §3.5 — guard is read-only w.r.t. output; fitting runs never
-  fire.
-- **Signature churn.** Mitigated by `Option<&AtomicBool>` defaulting to `None`, so every existing
-  caller/test is a one-token change with identical behavior.
+- **Thread + determinism.** Covered in §3.5 — the poll thread is read-only w.r.t. output; fitting runs
+  never fire.
+- **Global mutable state.** The cancellation state is process-global because RSS *is* process-global.
+  It is fully encapsulated in `core::governor` behind `checkpoint()` + the RAII `MemoryGovernor`, armed
+  only while a governor lives, with an `AlreadyActive` guard against two concurrent governors (the CLI
+  is one-job-per-process). This buys a **signature-stable public API** — the ColumnKit SDK and every
+  re-export are untouched — which is worth more than avoiding one well-scoped global.
+- **`checkpoint()` hot-path cost.** A single relaxed atomic load per column; a no-op (always `Ok`) when
+  no governor is armed, so library callers and existing tests pay effectively nothing.
 - **getrusage cost.** A cheap syscall every 100 ms is negligible.
 
 ## 6. References

--- a/docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md
@@ -1,0 +1,192 @@
+# Sprint 1.1 — The Unbreakable Bound (design)
+
+**Status:** Approved design — 2026-06-02. Increment 1.1 of the engineering roadmap
+([`docs/ROADMAP.md`](../../ROADMAP.md), Sprint 1). Companion to [`CONTRACT.md`](../../../CONTRACT.md).
+
+---
+
+## 1. Problem
+
+Rosalind's headline promise is *"never a silent OOM — it fits, or it tells you up front, and it
+proves the realized peak with a receipt."* Today that promise has a hole and an unproven assumption:
+
+1. **The silent-OOM window.** Under `--enforce`, the budget is checked **before** the run
+   (`main.rs:1623`, refuse exit 3) and **after** the run (`main.rs:1681`, fail-loud exit 4). Between
+   them, the BAM streams (`call_germline_whole_genome` / `run_bounded_whole_genome`) with **no live
+   guard**. If the realized peak crosses the budget mid-run — e.g. the prediction was wrong — the
+   kernel OOM-killer can fire *before* the post-run check is ever reached. The one failure mode the
+   thesis explicitly forbids is currently reachable.
+
+2. **The unproven margin.** The entire "predicted peak is an upper bound" claim rests on
+   `PILEUP_IO_RSS_OVERHEAD = 8 MiB` (`core/budget.rs:24`) — a hard-coded constant standing in for
+   {htslib/BGZF buffers, the VCF `BufWriter`, allocator slack}. There is no evidence that
+   `realized_peak − working_set − baseline ≤ 8 MiB` across platforms, allocators, and htslib
+   versions, and the only upper-bound test (`tests/plan_enforce.rs`, `predicted_peak_rss_upper_bounds_realized_peak`)
+   uses a 4 MiB contig where the margin is never stressed near saturation.
+
+This increment closes the window with a runtime governor and starts measuring the real margin, so a
+future increment can re-tune the constant with evidence rather than a guess.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A runtime **memory governor** that, under `--enforce`, fails **loud** (exit 4, with output +
+  receipt written) at the moment a breach is detected — never a silent kernel OOM.
+- Record the **measured RSS residual** (`peak − working_set − baseline`) and the assumed margin in
+  every receipt, so the 8 MiB constant becomes an evidence-backed decision later.
+- A **near-saturation** soundness test that stresses the margin at the budget boundary on a contig
+  large enough that reference-decode dominates — not the 4 MiB toy.
+
+**Non-goals (explicitly deferred)**
+- Re-tuning / replacing the `PILEUP_IO_RSS_OVERHEAD` value (future, evidence-driven — we record first).
+- Receipt self-hash / tamper-evidence / `SCHEMA_VERSION` (Sprint 1.2).
+- `cargo publish`, clippy/MSRV gate, doc-drift fixes (Sprint 1.3).
+- Any change to the prediction formula or the exit-3 pre-run refuse path.
+
+## 3. Design
+
+### 3.1 The governor (`src/core/governor.rs`, new)
+
+```text
+MemoryGovernor::start(budget_bytes: u64, poll: Duration, rss_source: fn() -> u64) -> MemoryGovernor
+  - spawns ONE background thread:
+      loop { if rss_source() > budget_bytes { tripped.store(true, Release); break }
+             if stop.load(Acquire) { break }
+             sleep(poll) }
+  - holds: Arc<AtomicBool> tripped, Arc<AtomicBool> stop, JoinHandle
+MemoryGovernor::tripped() -> &AtomicBool        // the cancel token the drivers observe
+MemoryGovernor::stop(self)                       // sets stop, joins the thread
+impl Drop                                        // stop-and-join if not already stopped
+```
+
+- `rss_source` defaults to `rosalind::util::rss::peak_rss_bytes` (getrusage `ru_maxrss`, a
+  monotonic high-water mark — exactly "did peak ever cross the budget"). It is injectable purely as
+  the **test seam** (§3.5): a test feeds a rising sequence with no real memory pressure.
+- `poll` defaults to **100 ms**; `run_variants_index`/`run_features` read an override from
+  `ROSALIND_GOVERNOR_POLL_MS` (tests use a small value for responsiveness).
+- The governor is **started only under `--enforce`**. Record-only runs construct **no** governor and
+  pass `None` as the cancel token (telemetry in §3.3 is still recorded — it is pure measurement).
+
+### 3.2 Cooperative cancellation (the abort path)
+
+The guard never interrupts the main thread mid-allocation (that would corrupt the
+*"you keep the data and the proof it overran"* property). It sets `tripped`; the bounded drivers
+observe it cooperatively and return an error that flows through the **existing** exit-4 machinery.
+
+- **Signature change:** add `cancel: Option<&AtomicBool>` to:
+  - `call_germline_whole_genome` (`call/whole_genome.rs:49`) and the per-region caller it drives,
+    `call_germline_region_streaming` (`call/pipeline.rs:20`).
+  - `run_bounded_whole_genome` (`call/columnkit.rs:61`).
+  - the features region helpers `stream_features_whole_genome` (`call/features.rs:100`) /
+    `stream_features_region` (`call/features.rs:74`).
+  - `None` preserves today's behavior; **all existing call sites and tests pass `None`** and are
+    unchanged.
+- **Two check points** (each a single `Relaxed` atomic load — negligible):
+  1. **Top of the per-contig loop, before `decode_window_arc`** (`whole_genome.rs:61`,
+     `features.rs:111`, the columnkit driver loop). This catches the *dominant* breach mode — decoding
+     the next large contig's reference — **before** the allocation happens.
+  2. **Once per column** in the region loop (`call_germline_region_streaming` `pipeline.rs:31`;
+     `stream_features_region` `features.rs:84`). Catches within-contig drift (I/O buffers, allocator
+     growth).
+- **On `tripped`** → the driver returns `Err(CoreError::BudgetExceeded { .. })`, reusing the existing
+  (currently unraised) variant (`core/error.rs:12`). The driver needs to know only *that* it was
+  cancelled, not the budget; `run_variants_index` / `run_features` **catch the error and populate the
+  authoritative numbers** for the loud message + receipt — `budget` = the declared budget, `needed` =
+  the post-trip `peak_rss_bytes()`. (Field population by the caller keeps the driver decoupled from
+  the budget it does not otherwise hold.)
+
+### 3.3 Receipt — the measured residual (telemetry)
+
+Recorded in the `params` map of the `variants` **and** `features` receipts, in **all** modes
+(record-only and enforce — it is measurement, not enforcement). All values are decimal strings, as
+the receipt's existing convention:
+
+| key | value |
+|---|---|
+| `baseline_rss_bytes` | the baseline measured at `main.rs:1610` (already computed, just not recorded) |
+| `rss_residual_bytes` | `peak_rss.saturating_sub(max_working_set).saturating_sub(baseline)` — the real I/O+slack overhead this run incurred |
+| `io_rss_overhead_assumed_bytes` | the `PILEUP_IO_RSS_OVERHEAD` constant (assumed-vs-realized, side by side) |
+| `governor` | `"enforced"` when `--enforce`, else `"record-only"` |
+
+> Determinism note: `baseline_rss_bytes` and `rss_residual_bytes` are machine-dependent
+> measurements, exactly like the already-present `peak_rss_bytes`. The VCF/feature output stays
+> byte-identical; the manifest differs only in these measured fields (the same caveat
+> `CONTRACT.md` already documents for `peak_rss_bytes`). `verify`'s existing internal-consistency
+> checks are unaffected; the new fields are recorded, not re-derived.
+
+### 3.4 The constant + prediction reframe (no value change)
+
+`PILEUP_IO_RSS_OVERHEAD` **stays 8 MiB**. You cannot measure a run before running it, so the up-front
+prediction keeps a fixed conservative margin. What changes is that **its correctness is no longer
+load-bearing for safety**: if it ever under-predicts, the governor catches the live breach and fails
+loud (exit 4) instead of a silent kernel OOM. We deliberately do **not** re-tune it here — we record
+`rss_residual_bytes` first and tune later with data. This reframe is documented in the `budget.rs`
+doc-comment and the `CONTRACT.md` "honor" section.
+
+### 3.5 Error handling, exit codes, determinism
+
+- `Err(CoreError::BudgetExceeded)` propagates to `run_variants_index` / `run_features`, which route it
+  into the **existing exit-4 path**: write the partial output, write the receipt with
+  `contract_verdict = "over"`, print the loud breach message, `std::process::exit(4)`. A live breach
+  now yields the *same* artifacts a post-run breach does.
+- The **post-run check stays** as a backstop, covering the ≤ `poll` sampling gap between the last
+  poll and a breach.
+- **Determinism for fitting runs is preserved.** The guard only reads RSS and sets a flag; it never
+  touches output bytes, and in a run that fits it never fires. A breach is by nature a
+  nondeterministic abort (which column trips depends on timing) — but a breach exits non-zero and is
+  a *failure*, not a reproducible artifact, so no determinism guarantee is weakened. Stated
+  explicitly in `docs/determinism.md`.
+
+### 3.6 Testing
+
+1. **Governor abort (integration, deterministic).** Inject an `rss_source` that returns a rising
+   sequence crossing the budget after a few polls; run a small `variants --index --enforce`; assert:
+   exit 4, `contract_verdict=over` in the receipt, and the partial VCF **and** manifest exist. No real
+   memory pressure → CI-safe and fast.
+2. **Governor unit test.** `MemoryGovernor` with a stub `rss_source` trips `tripped` once the stub
+   crosses the budget and not before; `stop()` joins cleanly; below-budget never trips.
+3. **Near-saturation soundness.** Extend `predicted_peak_rss_upper_bounds_realized_peak`: build a
+   larger synthetic contig (a few MB — large enough that reference-decode dominates), run with
+   `budget == predicted_peak` (zero extra headroom), assert the run completes within budget (the
+   margin holds at the boundary), and `predicted_peak ≥ realized_peak`.
+4. **Residual recorded.** Assert `baseline_rss_bytes`, `rss_residual_bytes`,
+   `io_rss_overhead_assumed_bytes`, `governor` appear in the receipt and round-trip through
+   `RunManifest::from_canonical_json` / `verify`.
+5. **Regression.** Existing exit-3, exit-4 (`ROSALIND_FORCE_PEAK_RSS_BYTES`), and determinism tests
+   stay green; all non-enforce call sites compile with `None`.
+
+## 4. File-by-file change list
+
+| File | Change |
+|---|---|
+| `src/core/governor.rs` (new) | `MemoryGovernor` (poll thread, injectable `rss_source`, `tripped`/`stop`/`Drop`). |
+| `src/core/mod.rs` | Export `governor` + `MemoryGovernor`. |
+| `src/core/budget.rs` | Doc-comment: the prediction-margin reframe (governor is the safety net, not the constant). No value change. |
+| `src/call/whole_genome.rs` | `cancel: Option<&AtomicBool>` param; check at per-contig top (pre-decode); thread into the region caller. |
+| `src/call/pipeline.rs` | `cancel` param on `call_germline_region_streaming` (+ `_tracked` wrapper); per-column check in the `while let Some(column)` loop. |
+| `src/call/columnkit.rs` | `cancel: Option<&AtomicBool>` param on `run_bounded_whole_genome`; per-contig + per-column checks. |
+| `src/call/features.rs` | `cancel` threaded into `stream_features_region` / `stream_features_whole_genome`; per-column check. |
+| `src/main.rs` | `run_variants_index` + `run_features`: under `--enforce` start a `MemoryGovernor`, pass `governor.tripped()` as `cancel`, stop on completion; map `Err(BudgetExceeded)` to the exit-4 path; record the four new receipt fields (`baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`, `governor`). |
+| `tests/plan_enforce.rs` | Governor-abort integration test; near-saturation soundness; residual-recorded assertions. |
+| `CONTRACT.md`, `docs/determinism.md` | Document the live governor + the breach-determinism note. |
+
+## 5. Risks & mitigations
+
+- **Sampling gap.** A breach faster than one `poll` interval could still OOM. *Mitigation:* the
+  working set grows gradually with coverage (depth-capped), the dominant breach (reference decode) is
+  caught pre-allocation at the contig boundary, and the post-run check remains a backstop. 100 ms is
+  conservative for genome-scale runs that take seconds-to-minutes per contig.
+- **Thread + determinism.** Covered in §3.5 — guard is read-only w.r.t. output; fitting runs never
+  fire.
+- **Signature churn.** Mitigated by `Option<&AtomicBool>` defaulting to `None`, so every existing
+  caller/test is a one-token change with identical behavior.
+- **getrusage cost.** A cheap syscall every 100 ms is negligible.
+
+## 6. References
+
+- `CONTRACT.md` — the four verbs; this hardens "honor".
+- `core/budget.rs:24`, `call/plan.rs` — the constant and the predictor.
+- `main.rs:1610` (baseline), `:1623` (exit 3), `:1681` (post-run peak), `:1925` (germline driver),
+  `:1651/:1666` (features driver) — the integration points.
+- `core/error.rs:12` — the reused `BudgetExceeded` variant.
+- `tests/plan_enforce.rs:predicted_peak_rss_upper_bounds_realized_peak` — the test extended in §3.6(3).

--- a/src/call/features.rs
+++ b/src/call/features.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::call::whole_genome::PerContig;
-use crate::core::{AlignedRead, ContigSet, CoreError, WorkingSet};
+use crate::core::{governor, AlignedRead, ContigSet, CoreError, WorkingSet};
 use crate::genomics::ReferenceView;
 use crate::pileup::{PileupColumn, PileupEngine, PileupParams, ReadSource, SkipCounts};
 
@@ -83,6 +83,7 @@ pub fn stream_features_region<S: ReadSource>(
     let mut max_ws = WorkingSet { bytes: 0 };
     while let Some(column) = engine.next() {
         let column = column?;
+        governor::checkpoint()?;
         let ws = engine.current_working_set();
         if ws.bytes > max_ws.bytes {
             max_ws = ws;
@@ -109,6 +110,9 @@ pub fn stream_features_whole_genome<S: ReadSource>(
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
+        // Cooperative budget check (no-op unless an --enforce governor is armed):
+        // catch a breach before decoding the next contig's reference.
+        governor::checkpoint()?;
         // Decode straight into the Arc (no intermediate Vec) — one resident copy,
         // not the transient two, so the predicted-peak bound holds (same as the
         // germline whole-genome driver).

--- a/src/call/gvcf.rs
+++ b/src/call/gvcf.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::call::germline::{genotype_column_gvcf, GvcfGenotype};
 use crate::call::types::{Filter, Genotype, GermlineCall, GermlineParams};
 use crate::call::whole_genome::PerContig;
-use crate::core::{AlignedRead, ContigSet, CoreError, Locus, WorkingSet};
+use crate::core::{governor, AlignedRead, ContigSet, CoreError, Locus, WorkingSet};
 use crate::genomics::ReferenceView;
 use crate::pileup::{PileupEngine, PileupParams, ReadSource, SkipCounts};
 
@@ -225,6 +225,7 @@ fn stream_gvcf_region<S: ReadSource, W: Write>(
     let mut max_ws = WorkingSet { bytes: 0 };
     while let Some(column) = engine.next() {
         let column = column?;
+        governor::checkpoint()?;
         let ws = engine.current_working_set();
         if ws.bytes > max_ws.bytes {
             max_ws = ws;
@@ -257,6 +258,9 @@ pub fn stream_gvcf_whole_genome<S: ReadSource, W: Write>(
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
+        // Cooperative budget check (no-op unless an --enforce governor is armed):
+        // catch a breach before decoding the next contig's reference.
+        governor::checkpoint()?;
         let start = c.global_offset as usize;
         let end = c.global_offset as usize + c.length as usize;
         let reference: Arc<[u8]> = ref_view.decode_window_arc(start, end);

--- a/src/call/pipeline.rs
+++ b/src/call/pipeline.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::call::{
     call_germline, call_somatic, GermlineCall, GermlineParams, SomaticCall, SomaticParams,
 };
-use crate::core::{CoreError, Locus, WorkingSet};
+use crate::core::{governor, CoreError, Locus, WorkingSet};
 use crate::pileup::{PileupColumn, PileupEngine, PileupParams, ReadSource, SkipCounts};
 
 /// Stream germline calls over `region` of `contig` to a sink, returning the
@@ -30,6 +30,7 @@ pub fn call_germline_region_streaming<S: ReadSource>(
     let mut max_ws = WorkingSet { bytes: 0 };
     while let Some(column) = engine.next() {
         let column = column?;
+        governor::checkpoint()?;
         let ws = engine.current_working_set();
         if ws.bytes > max_ws.bytes {
             max_ws = ws;

--- a/src/call/whole_genome.rs
+++ b/src/call/whole_genome.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use crate::call::{call_germline_region_streaming, GermlineCall, GermlineParams};
-use crate::core::{AlignedRead, ContigSet, CoreError, Locus, WorkingSet};
+use crate::core::{governor, AlignedRead, ContigSet, CoreError, Locus, WorkingSet};
 use crate::genomics::ReferenceView;
 use crate::pileup::{PileupParams, ReadSource, SkipCounts};
 
@@ -59,6 +59,9 @@ pub fn call_germline_whole_genome<S: ReadSource>(
     let mut peeked: Option<AlignedRead> = None;
 
     for c in contigs.iter() {
+        // Cooperative budget check (no-op unless an --enforce governor is armed):
+        // catch a breach before decoding the next contig's reference.
+        governor::checkpoint()?;
         // Decode this contig's reference straight into the Arc — no intermediate
         // Vec, so peak resident reference memory is ONE copy, not the transient
         // two that `Arc::from(decoded)` (a reallocation) would briefly hold. Peak

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -21,6 +21,14 @@ pub const PILEUP_ENGINE_OVERHEAD: u64 = 256;
 /// than a steady-state live-bytes count. The reference-decode transient is
 /// eliminated at the source (`decode_window_arc`), so this margin covers only
 /// fixed I/O buffers + slack, not a per-contig reference copy.
+///
+/// Reframe (Sprint 1.1): this margin's correctness is no longer load-bearing for
+/// *safety*. Under `--enforce` a runtime [`MemoryGovernor`](crate::core::MemoryGovernor)
+/// fails the run loud (exit 4, output + receipt written) the moment realized peak
+/// RSS crosses the budget, so an under-prediction here is caught live rather than
+/// silently OOM-killed. The realized residual (`peak − working_set − baseline`) is
+/// now recorded in every receipt (`rss_residual_bytes`) so a future, evidence-based
+/// re-tuning of this constant is possible — it stays fixed and conservative for now.
 pub const PILEUP_IO_RSS_OVERHEAD: u64 = 8 * 1024 * 1024;
 
 /// A declared cap on a streaming stage's working set.

--- a/src/core/governor.rs
+++ b/src/core/governor.rs
@@ -1,0 +1,143 @@
+//! Process-global runtime memory governor.
+//!
+//! Closes the window between the pre-run refuse (exit 3) and the post-run check
+//! where an `--enforce`'d run that mispredicts its peak could be silently
+//! OOM-killed by the kernel. While a [`MemoryGovernor`] is alive, a background
+//! thread polls process RSS; the first sample above the declared budget arms a
+//! process-global breach flag that the bounded streaming drivers observe via
+//! [`checkpoint`] and turn into a loud `Err(CoreError::BudgetExceeded)`.
+//!
+//! The state is process-global because RSS *is* a process-global resource — the
+//! budget is on the whole process, not one call. This keeps the public streaming
+//! API (the ColumnKit SDK) signature-stable: a driver checks the budget with a
+//! one-line [`checkpoint`] call, not a threaded parameter.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::core::error::CoreError;
+
+/// Is a governor active in this process? Guards against two concurrent governors.
+static ARMED: AtomicBool = AtomicBool::new(false);
+/// Has the active governor observed a breach?
+static TRIPPED: AtomicBool = AtomicBool::new(false);
+/// Realized peak RSS (bytes) at the breach — carried into the error + receipt.
+static PEAK_AT_TRIP: AtomicU64 = AtomicU64::new(0);
+/// Declared budget (bytes) of the active governor — carried into the error.
+static BUDGET: AtomicU64 = AtomicU64::new(0);
+
+/// A cooperative cancellation point for the bounded streaming drivers. Returns
+/// `Err(CoreError::BudgetExceeded)` once the active governor has observed a breach,
+/// else `Ok(())`. A single relaxed atomic load on the hot path; a no-op (always
+/// `Ok`) when no governor is armed (library callers, record-only runs).
+pub fn checkpoint() -> Result<(), CoreError> {
+    if TRIPPED.load(Ordering::Relaxed) {
+        Err(CoreError::BudgetExceeded {
+            needed: PEAK_AT_TRIP.load(Ordering::Acquire),
+            budget: BUDGET.load(Ordering::Acquire),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Failure starting a [`MemoryGovernor`].
+#[derive(Debug)]
+pub enum GovernorError {
+    /// A governor is already active in this process (the CLI is one-job-per-process).
+    AlreadyActive,
+}
+
+impl std::fmt::Display for GovernorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GovernorError::AlreadyActive => write!(f, "a memory governor is already active"),
+        }
+    }
+}
+
+impl std::error::Error for GovernorError {}
+
+/// An RAII runtime memory governor. While alive, a background thread polls
+/// `rss_source` every `poll`; the first sample above `budget_bytes` arms the
+/// process-global breach state [`checkpoint`] observes. Dropping it stops the
+/// thread and disarms the state.
+#[derive(Debug)]
+pub struct MemoryGovernor {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MemoryGovernor {
+    /// Start a governor for `budget_bytes`, polling `rss_source` every `poll`.
+    /// Performs one synchronous check before spawning (so an already-breached
+    /// source trips deterministically, before the first `checkpoint`). Errors if a
+    /// governor is already active in this process.
+    pub fn start<F>(budget_bytes: u64, poll: Duration, rss_source: F) -> Result<Self, GovernorError>
+    where
+        F: Fn() -> u64 + Send + 'static,
+    {
+        if ARMED.swap(true, Ordering::AcqRel) {
+            return Err(GovernorError::AlreadyActive);
+        }
+        TRIPPED.store(false, Ordering::Release);
+        PEAK_AT_TRIP.store(0, Ordering::Release);
+        BUDGET.store(budget_bytes, Ordering::Release);
+
+        // Synchronous initial check: a source already above budget trips now, so
+        // the very first driver checkpoint fails (no race with the poll thread).
+        let initial = rss_source();
+        if initial > budget_bytes {
+            PEAK_AT_TRIP.store(initial, Ordering::Release);
+            TRIPPED.store(true, Ordering::Release);
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || loop {
+            let rss = rss_source();
+            if rss > budget_bytes {
+                PEAK_AT_TRIP.store(rss, Ordering::Release);
+                TRIPPED.store(true, Ordering::Release);
+                break;
+            }
+            if stop_thread.load(Ordering::Acquire) {
+                break;
+            }
+            std::thread::sleep(poll);
+        });
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for MemoryGovernor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        TRIPPED.store(false, Ordering::Release);
+        PEAK_AT_TRIP.store(0, Ordering::Release);
+        ARMED.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Non-arming check only (arming tests live in tests/governor.rs, a separate
+    // process, so they cannot trip the global flag during in-process unit tests).
+    #[test]
+    fn checkpoint_ok_when_unarmed_and_governor_error_displays() {
+        assert!(checkpoint().is_ok());
+        assert!(GovernorError::AlreadyActive
+            .to_string()
+            .contains("already active"));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod budget;
 pub mod error;
+pub mod governor;
 pub mod locus;
 pub mod record;
 pub mod sequence;
@@ -15,5 +16,6 @@ pub use budget::{
     PILEUP_MAP_BYTES_PER_BASE, PILEUP_PER_READ_OVERHEAD, PILEUP_SEQQUAL_BYTES_PER_BASE,
 };
 pub use error::CoreError;
+pub use governor::{checkpoint, GovernorError, MemoryGovernor};
 pub use locus::{Contig, ContigSet, Locus, Position};
 pub use record::{AlignedRead, CigarOp, CigarOpKind, RefBase, SamFlags};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1566,6 +1566,8 @@ fn run_features(
     manifest_out: Option<PathBuf>,
 ) -> Result<()> {
     use rosalind::call::run_bounded_whole_genome;
+    use rosalind::core::governor::MemoryGovernor;
+    use rosalind::core::PILEUP_IO_RSS_OVERHEAD;
     use rosalind::genomics::IndexReader;
     use rosalind::io::bam::StreamingBamSource;
     use rosalind::pileup::PileupParams;
@@ -1636,6 +1638,33 @@ fn run_features(
         }
     }
 
+    // Live RSS source for the governor (test seam ROSALIND_FORCE_LIVE_RSS_BYTES, else
+    // the real high-water). Under --enforce the governor fails the run LOUD the moment
+    // live RSS crosses the budget — never a silent kernel OOM.
+    let live_rss = || {
+        std::env::var("ROSALIND_FORCE_LIVE_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let poll_ms = std::env::var("ROSALIND_GOVERNOR_POLL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    let _governor_guard = if enforce {
+        let mb = memory_budget_mb.expect("--enforce requires --memory-budget-mb (checked above)");
+        Some(
+            MemoryGovernor::start(
+                MemoryBudget::from_mb(mb).bytes,
+                std::time::Duration::from_millis(poll_ms),
+                live_rss,
+            )
+            .map_err(|e| anyhow!("failed to start memory governor: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     // Stream feature rows straight to the writer (header once, one row per callable
     // locus) — no genome-wide buffer accumulates.
     // `features` is the first ColumnKit analyzer: the FeatureAnalyzer drives the
@@ -1643,7 +1672,13 @@ fn run_features(
     // shipped path and the SDK are one and the same (not parallel). Byte-identical
     // output is pinned by the golden feature test.
     let mut analyzer = rosalind::call::FeatureAnalyzer::default();
-    let (max_ws, skips) = match &output {
+    // Inline both arms (match arms are exclusive, so moving source/pileup_params in
+    // each is fine). Flush on BOTH paths so partial output survives a governed abort;
+    // inspect the Result rather than `?`-propagating it.
+    let drive_result: Result<
+        (rosalind::core::WorkingSet, rosalind::pileup::SkipCounts),
+        rosalind::core::CoreError,
+    > = match &output {
         Some(path) => {
             let file = File::create(path)
                 .with_context(|| format!("failed to create features file {}", path.display()))?;
@@ -1655,9 +1690,12 @@ fn run_features(
                 contigs,
                 pileup_params,
                 &mut writer,
-            )
-            .map_err(|e| anyhow!("feature streaming failed: {e}"))?;
-            writer.flush()?;
+            );
+            if r.is_ok() {
+                writer.flush()?;
+            } else {
+                let _ = writer.flush();
+            }
             r
         }
         None => {
@@ -1670,23 +1708,51 @@ fn run_features(
                 contigs,
                 pileup_params,
                 &mut handle,
-            )
-            .map_err(|e| anyhow!("feature streaming failed: {e}"))?;
-            handle.flush()?;
+            );
+            if r.is_ok() {
+                handle.flush()?;
+            } else {
+                let _ = handle.flush();
+            }
             r
         }
     };
+    let (max_ws, skips, breached, breach_peak) = match drive_result {
+        Ok((ws, sk)) => (ws, sk, false, 0u64),
+        Err(rosalind::core::CoreError::BudgetExceeded { needed, .. }) => (
+            rosalind::core::WorkingSet { bytes: 0 },
+            rosalind::pileup::SkipCounts::default(),
+            true,
+            needed,
+        ),
+        Err(e) => return Err(anyhow!("feature streaming failed: {e}")),
+    };
     let feature_rows = analyzer.rows();
 
-    let peak_rss = std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or_else(peak_rss_bytes);
+    let peak_rss = if breached {
+        breach_peak
+    } else {
+        std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
     let verdict = match memory_budget_mb.map(|mb| MemoryBudget::from_mb(mb).admits(peak_rss)) {
         None => "unset",
         Some(true) => "within",
         Some(false) => "over",
     };
+    let governor_state = if breached {
+        "tripped"
+    } else if enforce {
+        "enforced"
+    } else {
+        "record-only"
+    };
+    let baseline_rss_bytes = baseline;
+    let rss_residual_bytes = peak_rss
+        .saturating_sub(max_ws.bytes)
+        .saturating_sub(baseline_rss_bytes);
 
     let receipt_dest: Option<PathBuf> = match (&manifest_out, &output) {
         (Some(m), _) => Some(m.clone()),
@@ -1735,6 +1801,21 @@ fn run_features(
         manifest.params.insert(
             "max_working_set_bytes".to_string(),
             max_ws.bytes.to_string(),
+        );
+        manifest
+            .params
+            .insert("governor".to_string(), governor_state.to_string());
+        manifest.params.insert(
+            "baseline_rss_bytes".to_string(),
+            baseline_rss_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "rss_residual_bytes".to_string(),
+            rss_residual_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "io_rss_overhead_assumed_bytes".to_string(),
+            PILEUP_IO_RSS_OVERHEAD.to_string(),
         );
         manifest
             .params

--- a/src/main.rs
+++ b/src/main.rs
@@ -1812,6 +1812,7 @@ fn run_variants_index(
         call_germline_whole_genome, stream_gvcf_whole_genome, write_gvcf_header, GermlineParams,
     };
     use rosalind::core::governor::MemoryGovernor;
+    use rosalind::core::PILEUP_IO_RSS_OVERHEAD;
     use rosalind::genomics::IndexReader;
     use rosalind::io::bam::StreamingBamSource;
     use rosalind::io::vcf::{write_germline_header, write_germline_row, GermlineRow};
@@ -2039,6 +2040,13 @@ fn run_variants_index(
     } else {
         "record-only"
     };
+    // Measured RSS residual telemetry: the real I/O + allocator slack this run
+    // incurred above the modeled working set, recorded so the fixed 8 MiB
+    // prediction margin can later be re-tuned with evidence (Sprint 1.1).
+    let baseline_rss_bytes = baseline;
+    let rss_residual_bytes = peak_rss
+        .saturating_sub(max_ws.bytes)
+        .saturating_sub(baseline_rss_bytes);
 
     // Reproducibility + memory receipt. Written when there is a destination — an
     // explicit --manifest path, or a sidecar next to a `-o` VCF. A stdout run
@@ -2099,6 +2107,18 @@ fn run_variants_index(
         manifest
             .params
             .insert("governor".to_string(), governor_state.to_string());
+        manifest.params.insert(
+            "baseline_rss_bytes".to_string(),
+            baseline_rss_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "rss_residual_bytes".to_string(),
+            rss_residual_bytes.to_string(),
+        );
+        manifest.params.insert(
+            "io_rss_overhead_assumed_bytes".to_string(),
+            PILEUP_IO_RSS_OVERHEAD.to_string(),
+        );
         manifest.params.insert(
             "over_max_depth".to_string(),
             skips.over_max_depth.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1811,6 +1811,7 @@ fn run_variants_index(
     use rosalind::call::{
         call_germline_whole_genome, stream_gvcf_whole_genome, write_gvcf_header, GermlineParams,
     };
+    use rosalind::core::governor::MemoryGovernor;
     use rosalind::genomics::IndexReader;
     use rosalind::io::bam::StreamingBamSource;
     use rosalind::io::vcf::{write_germline_header, write_germline_row, GermlineRow};
@@ -1901,6 +1902,36 @@ fn run_variants_index(
         }
     }
 
+    // Live RSS source for the governor: a test seam (ROSALIND_FORCE_LIVE_RSS_BYTES)
+    // standing in for live RSS, else the real getrusage high-water mark. Distinct
+    // from ROSALIND_FORCE_PEAK_RSS_BYTES, which overrides only the POST-run peak.
+    let live_rss = || {
+        std::env::var("ROSALIND_FORCE_LIVE_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
+    let poll_ms = std::env::var("ROSALIND_GOVERNOR_POLL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    // Under --enforce, the governor fails the run LOUD the moment live RSS crosses
+    // the budget (exit 4 with output + receipt) — never a silent kernel OOM. Held
+    // for the duration of the calling pass; dropped (thread stopped) at scope end.
+    let _governor_guard = if enforce {
+        let mb = memory_budget_mb.expect("--enforce requires --memory-budget-mb (checked above)");
+        Some(
+            MemoryGovernor::start(
+                MemoryBudget::from_mb(mb).bytes,
+                std::time::Duration::from_millis(poll_ms),
+                live_rss,
+            )
+            .map_err(|e| anyhow!("failed to start memory governor: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     // Stream straight to the writer (header once, then one record per callable
     // locus in gVCF mode, or per variant otherwise) so no genome-wide row buffer
     // accumulates. The returned WorkingSet is the high-water (reference + active
@@ -1941,13 +1972,21 @@ fn run_variants_index(
                         .map_err(rosalind::core::CoreError::from)
                     },
                 )
+            };
+            // Flush even on a governed abort so partial output survives; surface a
+            // genuine flush failure only when the calling pass itself succeeded.
+            if r.is_ok() {
+                w.flush()?;
+            } else {
+                let _ = w.flush();
             }
-            .map_err(|e| anyhow!("variant calling failed: {e}"))?;
-            w.flush()?;
             r
         }};
     }
-    let (max_ws, skips) = match &output {
+    let drive_result: Result<
+        (rosalind::core::WorkingSet, rosalind::pileup::SkipCounts),
+        rosalind::core::CoreError,
+    > = match &output {
         Some(path) => {
             let file = File::create(path)
                 .with_context(|| format!("failed to create VCF file {}", path.display()))?;
@@ -1960,20 +1999,45 @@ fn run_variants_index(
             drive!(&mut handle)
         }
     };
-    // Realized peak (monotonic high-water mark) captured after the calling pass.
-    // Test-only seam: ROSALIND_FORCE_PEAK_RSS_BYTES overrides ONLY this post-run
-    // realized peak (never the pre-run baseline at the --enforce gate), so the
-    // exit-4 breach branch can be exercised deterministically without allocating.
-    let peak_rss = std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or_else(peak_rss_bytes);
+    // A governor trip is the one error we do NOT bail on: we still write the proof
+    // receipt (verdict=over, governor=tripped) and exit 4 via the existing post-run
+    // check. Any other error is a genuine failure.
+    let (max_ws, skips, breached, breach_peak) = match drive_result {
+        Ok((ws, sk)) => (ws, sk, false, 0u64),
+        Err(rosalind::core::CoreError::BudgetExceeded { needed, .. }) => (
+            rosalind::core::WorkingSet { bytes: 0 },
+            rosalind::pileup::SkipCounts::default(),
+            true,
+            needed,
+        ),
+        Err(e) => return Err(anyhow!("variant calling failed: {e}")),
+    };
+    // Realized peak: the governor's tripping peak on a live breach, else the
+    // post-run high-water (monotonic). Test-only seam: ROSALIND_FORCE_PEAK_RSS_BYTES
+    // overrides ONLY this post-run realized peak (never the pre-run baseline at the
+    // --enforce gate), so the exit-4 backstop can be exercised without allocating.
+    let peak_rss = if breached {
+        breach_peak
+    } else {
+        std::env::var("ROSALIND_FORCE_PEAK_RSS_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or_else(peak_rss_bytes)
+    };
 
     // Compute the contract verdict before writing the receipt (so it records it).
     let verdict = match memory_budget_mb.map(|mb| MemoryBudget::from_mb(mb).admits(peak_rss)) {
         None => "unset",
         Some(true) => "within",
         Some(false) => "over",
+    };
+    // Distinguish a live-governed abort from a post-run-detected overrun in the receipt.
+    let governor_state = if breached {
+        "tripped"
+    } else if enforce {
+        "enforced"
+    } else {
+        "record-only"
     };
 
     // Reproducibility + memory receipt. Written when there is a destination — an
@@ -2032,6 +2096,9 @@ fn run_variants_index(
             "max_working_set_bytes".to_string(),
             max_ws.bytes.to_string(),
         );
+        manifest
+            .params
+            .insert("governor".to_string(), governor_state.to_string());
         manifest.params.insert(
             "over_max_depth".to_string(),
             skips.over_max_depth.to_string(),

--- a/tests/governor.rs
+++ b/tests/governor.rs
@@ -1,0 +1,79 @@
+//! Library-API tests for the process-global memory governor. These run in their
+//! OWN test binary (separate process) so arming the global breach state cannot
+//! contaminate the in-process streaming unit tests; a module-local lock serializes
+//! the (process-global) governor tests against each other.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rosalind::core::governor::{checkpoint, GovernorError, MemoryGovernor};
+use rosalind::core::CoreError;
+
+// The governor state is process-global; serialize these tests against each other.
+static LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn checkpoint_is_ok_when_no_governor_is_armed() {
+    let _l = LOCK.lock().unwrap();
+    assert!(checkpoint().is_ok());
+}
+
+#[test]
+fn governor_trips_when_rss_crosses_budget_and_disarms_on_drop() {
+    let _l = LOCK.lock().unwrap();
+    // rss rises 100 bytes per call; budget 250 -> trips on the 3rd sample (300).
+    let counter = Arc::new(AtomicU64::new(0));
+    let c = Arc::clone(&counter);
+    let gov = MemoryGovernor::start(250, Duration::from_millis(1), move || {
+        c.fetch_add(100, Ordering::SeqCst) + 100
+    })
+    .expect("start");
+
+    // Spin (bounded) until checkpoint observes the breach.
+    let mut tripped = false;
+    for _ in 0..2000 {
+        if checkpoint().is_err() {
+            tripped = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(tripped, "checkpoint should observe the breach");
+    match checkpoint() {
+        Err(CoreError::BudgetExceeded { needed, budget }) => {
+            assert!(needed > 250, "needed {needed} should exceed the budget");
+            assert_eq!(budget, 250);
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    drop(gov);
+    // Disarmed on drop -> checkpoint is Ok again, and a fresh governor can start.
+    assert!(checkpoint().is_ok(), "drop must disarm the global state");
+    let again = MemoryGovernor::start(1000, Duration::from_millis(1), || 0).expect("re-start");
+    drop(again);
+}
+
+#[test]
+fn a_below_budget_source_never_trips() {
+    let _l = LOCK.lock().unwrap();
+    let gov = MemoryGovernor::start(1_000_000, Duration::from_millis(1), || 100).expect("start");
+    std::thread::sleep(Duration::from_millis(20));
+    assert!(
+        checkpoint().is_ok(),
+        "a source below budget must never trip"
+    );
+    drop(gov);
+}
+
+#[test]
+fn a_second_governor_while_one_is_active_is_rejected() {
+    let _l = LOCK.lock().unwrap();
+    let first = MemoryGovernor::start(1_000_000, Duration::from_millis(50), || 0).expect("first");
+    match MemoryGovernor::start(1_000_000, Duration::from_millis(50), || 0) {
+        Err(GovernorError::AlreadyActive) => {}
+        _ => panic!("a second concurrent governor must be rejected"),
+    }
+    drop(first);
+}

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -575,3 +575,35 @@ fn verify_rejects_an_internally_inconsistent_manifest() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn governor_aborts_loud_when_live_rss_exceeds_budget() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    // 4096 MiB passes the pre-run exit-3 gate, but the live-RSS seam reports
+    // 5000 MiB > budget, so the governor trips mid-run -> exit 4.
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .env(
+            "ROSALIND_FORCE_LIVE_RSS_BYTES",
+            (5_000u64 * 1024 * 1024).to_string(),
+        )
+        .env("ROSALIND_GOVERNOR_POLL_MS", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "governor breach must exit 4: {out:?}"
+    );
+    let m = std::fs::read_to_string(&manifest).expect("manifest written on breach");
+    assert!(m.contains("\"governor\":\"tripped\""), "manifest: {m}");
+    assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -607,3 +607,37 @@ fn governor_aborts_loud_when_live_rss_exceeds_budget() {
     assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn receipt_records_residual_and_governor_fields_on_a_fitting_run() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "a fitting run should exit 0: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).expect("manifest");
+    for key in [
+        "\"baseline_rss_bytes\":",
+        "\"rss_residual_bytes\":",
+        "\"io_rss_overhead_assumed_bytes\":",
+        "\"governor\":\"enforced\"",
+    ] {
+        assert!(text.contains(key), "manifest missing {key}: {text}");
+    }
+    // The receipt round-trips through the canonical parser.
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&text).expect("parse");
+    assert_eq!(
+        m.params.get("governor").map(String::as_str),
+        Some("enforced")
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -671,3 +671,56 @@ fn features_governor_aborts_loud_and_records_residual() {
     assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn near_saturation_margin_holds_on_a_larger_contig() {
+    // Soundness of the 8 MiB prediction margin at a bigger scale than the 4 MiB
+    // sibling test: on an ~8 MB contig (reference-decode dominates), the predicted
+    // peak must still upper-bound the realized peak — the fixed I/O+slack margin
+    // covers the real residual — AND the recorded residual is within that margin.
+    // (Governor no-false-fire on fitting runs is covered by the existing --enforce
+    // tests, which now run with the governor armed and still exit 0.)
+    let (dir, idx, bam) = build_big_contig_fixture(8 * 1024 * 1024);
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--max-depth", "1000", "--max-read-len", "250", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let m = rosalind::provenance::RunManifest::from_canonical_json(
+        &std::fs::read_to_string(&manifest).unwrap(),
+    )
+    .unwrap();
+    let predicted: u64 = m
+        .params
+        .get("predicted_peak_rss_bytes")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
+    let residual: u64 = m.params.get("rss_residual_bytes").unwrap().parse().unwrap();
+    let assumed: u64 = m
+        .params
+        .get("io_rss_overhead_assumed_bytes")
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(
+        predicted >= realized,
+        "8 MB contig: predicted {predicted} must be >= realized {realized}"
+    );
+    assert!(
+        residual <= assumed,
+        "recorded residual {residual} should be within the assumed margin {assumed} \
+         (if not, the 8 MiB constant is too small for this workload — a REAL finding, \
+          not a test to silence)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -641,3 +641,33 @@ fn receipt_records_residual_and_governor_fields_on_a_fitting_run() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn features_governor_aborts_loud_and_records_residual() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let tsv = dir.join("feats.tsv");
+    let manifest = dir.join("feats.tsv.manifest.json");
+    let out = Command::new(bin())
+        .args(["features", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&tsv)
+        .env(
+            "ROSALIND_FORCE_LIVE_RSS_BYTES",
+            (5_000u64 * 1024 * 1024).to_string(),
+        )
+        .env("ROSALIND_GOVERNOR_POLL_MS", "1")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "features breach must exit 4: {out:?}"
+    );
+    let m = std::fs::read_to_string(&manifest).expect("manifest on breach");
+    assert!(m.contains("\"governor\":\"tripped\""), "manifest: {m}");
+    assert!(m.contains("\"contract_verdict\":\"over\""), "manifest: {m}");
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Turns *"never a silent OOM"* from a claim resting on an 8 MiB guess into an **enforced, receipt-proven property** — the single highest-ROI hardening of the memory-contract moat.

- **Runtime governor** (`src/core/governor.rs`): under `--enforce`, a background thread polls process RSS and, the moment the realized peak crosses the budget, fails the run **loud** — exit 4 with the partial output + a `governor=tripped`, `contract_verdict=over` receipt — instead of letting the kernel OOM-killer fire first. Closes the window between the pre-run refuse (exit 3) and the post-run check.
- **Process-global, zero-API-churn**: RSS *is* a process-global resource, so cancellation is observed via a one-line `governor::checkpoint()?` at the 6 bounded-driver hot-loop sites (germline + features + **gVCF**, per-contig pre-decode + per-column). **No public signature changes** — the ColumnKit SDK (`run_bounded_whole_genome`) and every crate re-export are byte-for-byte unchanged.
- **Measured residual telemetry**: every `variants`/`features` receipt now records `baseline_rss_bytes`, `rss_residual_bytes` (`peak − working_set − baseline`), and `io_rss_overhead_assumed_bytes`, so the fixed 8 MiB prediction margin can be re-tuned with **evidence** later. The constant's value is unchanged; its correctness is just no longer load-bearing for *safety*.
- **Determinism preserved**: the guard only reads RSS; a fitting run never fires it and stays byte-identical. A breach is a non-deterministic *failure* (exits non-zero), not a reproducible artifact.

Reviewed design + plan: `docs/superpowers/specs/2026-06-02-sprint1-unbreakable-bound-design.md`, `docs/superpowers/plans/2026-06-02-sprint1-unbreakable-bound.md`. Part of the receipt-first engineering roadmap (`docs/ROADMAP.md`, Sprint 1).

## Test Plan

- [x] `core::governor` unit + library tests (`tests/governor.rs`, separate binary so arming the global flag can't contaminate the in-process streaming tests): trips on breach, disarms on drop, rejects a second concurrent governor.
- [x] Governor aborts loud (exit 4, `governor=tripped`, `verdict=over`) for both `variants --index` and `features --index` (via the `ROSALIND_FORCE_LIVE_RSS_BYTES` seam).
- [x] Residual fields recorded + round-trip through the canonical-JSON parser on a fitting run.
- [x] Near-saturation soundness on an 8 MB contig: `predicted ≥ realized` **and** recorded residual `≤` the assumed margin.
- [x] Full suite green (25 sections), 0 warnings (debug+release+examples), `cargo fmt --check` clean, clippy-clean additions.
- [x] End-to-end smoke on the bundled fixture: `contract: OK`, the 4 new receipt fields present, `verify: OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)