### PR TITLE
feat(provenance): the unforgeable receipt — self-hash + schema_version (Sprint 1.2)

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -71,6 +71,11 @@ It re-hashes the recorded inputs and outputs (BLAKE3) and re-checks the recorded
 non-zero (exit **5**) with a per-check report on any drift, missing file, or over-budget peak. This is the
 auditability story containers can't give you for a non-deterministic caller.
 
+The receipt is **self-hashing**: a `manifest_blake3` over its own canonical JSON (plus a `schema_version`)
+is stamped at write time and re-derived by `verify`, so any post-write edit — even one that keeps the other
+fields mutually consistent — is caught (exit **5**). This is tamper-*evident*; a cryptographically signed,
+tamper-*proof* receipt is a separate planned feature.
+
 ## What's bounded (honest scope)
 
 - **Germline `variants --index`** and **`features --index`** are the bounded paths: peak ≈ the largest

--- a/docs/superpowers/plans/2026-06-02-sprint1-2-unforgeable-receipt.md
+++ b/docs/superpowers/plans/2026-06-02-sprint1-2-unforgeable-receipt.md
@@ -1,0 +1,299 @@
+# Sprint 1.2 — The Unforgeable Receipt: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the run receipt tamper-evident (a `manifest_blake3` self-hash re-derived by `verify`) and schema-versioned (`schema_version`), on the existing canonical-JSON machinery.
+
+**Architecture:** Add `content_hash`/`finalize`/`self_hash_ok` + a `MANIFEST_SCHEMA_VERSION` const to `provenance::RunManifest`. `finalize()` (called once before each of the 4 receipt writes) stamps the schema version then the self-hash over the canonical JSON with the hash field excluded. `verify` re-derives and checks it; a pre-1.2 receipt (no self-hash) verifies with a note.
+
+**Tech Stack:** Rust, the existing `blake3_hex` + canonical-JSON serializer in `src/provenance/mod.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-sprint1-2-unforgeable-receipt-design.md`
+
+---
+
+### Task 1: Self-hash + schema-version primitives (`provenance::RunManifest`)
+
+**Files:**
+- Modify: `src/provenance/mod.rs`
+
+- [ ] **Step 1: Write the failing unit tests** (append to the `#[cfg(test)] mod tests` in `src/provenance/mod.rs`)
+
+```rust
+    #[test]
+    fn finalize_stamps_schema_version_and_a_matching_self_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params.insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        assert_eq!(
+            m.params.get("schema_version").map(String::as_str),
+            Some(MANIFEST_SCHEMA_VERSION.to_string().as_str())
+        );
+        assert!(m.params.contains_key("manifest_blake3"));
+        assert_eq!(m.self_hash_ok(), Some(true), "fresh finalize must verify");
+    }
+
+    #[test]
+    fn tampering_any_field_breaks_the_self_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params.insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        // Flip a field WITHOUT re-finalizing — the recorded hash no longer matches.
+        m.params
+            .insert("peak_rss_bytes".to_string(), "999".to_string());
+        assert_eq!(m.self_hash_ok(), Some(false));
+    }
+
+    #[test]
+    fn a_manifest_without_a_self_hash_returns_none() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        assert_eq!(m.self_hash_ok(), None);
+    }
+
+    #[test]
+    fn finalize_is_idempotent() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params.insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        let first = m.params.get("manifest_blake3").cloned();
+        m.finalize();
+        assert_eq!(m.params.get("manifest_blake3").cloned(), first);
+        assert_eq!(m.self_hash_ok(), Some(true));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib provenance 2>&1 | grep -E "error|test result"`
+Expected: FAIL — `MANIFEST_SCHEMA_VERSION`, `finalize`, `self_hash_ok` do not exist.
+
+- [ ] **Step 3: Add the const + methods**
+
+Add the const near the top of `src/provenance/mod.rs` (after the module doc-comment / imports, before `ManifestError`):
+
+```rust
+/// Current receipt/feature schema version. Bump on any breaking schema change.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+```
+
+Add the methods to the existing `impl RunManifest { … }` block (after `from_canonical_json`):
+
+```rust
+    /// BLAKE3 hex of the canonical JSON with the self-hash field excluded — the
+    /// content this manifest commits to. Deterministic; `verify` re-derives it.
+    pub fn content_hash(&self) -> String {
+        let mut m = self.clone();
+        m.params.remove("manifest_blake3");
+        blake3_hex(m.to_canonical_json().as_bytes())
+    }
+
+    /// Stamp the schema version + the self-hash. Call LAST, immediately before
+    /// serialization, so the hash covers every other field (including the version).
+    pub fn finalize(&mut self) {
+        self.params.insert(
+            "schema_version".to_string(),
+            MANIFEST_SCHEMA_VERSION.to_string(),
+        );
+        let h = self.content_hash();
+        self.params.insert("manifest_blake3".to_string(), h);
+    }
+
+    /// `Some(true)`/`Some(false)` if a self-hash is recorded and matches / mismatches;
+    /// `None` if none is recorded (a pre-1.2 receipt).
+    pub fn self_hash_ok(&self) -> Option<bool> {
+        self.params
+            .get("manifest_blake3")
+            .map(|recorded| *recorded == self.content_hash())
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib provenance 2>&1 | grep -E "test result"`
+Expected: PASS (the four new tests + the existing provenance tests).
+
+- [ ] **Step 5: Verify no warnings, fmt, commit**
+
+Run: `cargo build --release 2>&1 | grep -i warning || echo "no warnings"; cargo fmt && cargo fmt --check && echo "fmt clean"`
+
+```bash
+git add src/provenance/mod.rs
+git commit -m "feat(provenance): self-hash + schema_version primitives (finalize/content_hash/self_hash_ok)"
+```
+
+---
+
+### Task 2: Stamp at the 4 receipt sites + check in `verify`
+
+**Files:**
+- Modify: `src/main.rs` (4 receipt-write sites + `run_verify`)
+- Modify: `CONTRACT.md`
+- Test: `tests/plan_enforce.rs`
+
+- [ ] **Step 1: Write the failing integration tests** (append to `tests/plan_enforce.rs`)
+
+```rust
+#[test]
+fn receipt_is_self_hashing_and_schema_versioned() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    let text = std::fs::read_to_string(&manifest).expect("manifest");
+    assert!(text.contains("\"manifest_blake3\":"), "no self-hash: {text}");
+    assert!(text.contains("\"schema_version\":\"1\""), "no schema_version: {text}");
+    // An untampered receipt verifies.
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert!(v.status.success(), "untampered verify should pass: {v:?}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn verify_rejects_a_self_consistent_but_tampered_receipt() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    // Tamper a field while keeping the receipt internally CONSISTENT: raise the
+    // recorded budget (a 'within' verdict stays valid since peak << 8192 MiB), so the
+    // verdict/consistency cross-checks still pass. Only the self-hash catches this.
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let tampered =
+        text.replace("\"memory_budget_mb\":\"4096\"", "\"memory_budget_mb\":\"8192\"");
+    assert_ne!(text, tampered, "the replace must have changed something");
+    std::fs::write(&manifest, &tampered).unwrap();
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert_eq!(v.status.code(), Some(5), "tampered receipt must fail verify: {v:?}");
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("manifest_blake3 mismatch"),
+        "expected a self-hash mismatch: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --test plan_enforce receipt_is_self_hashing verify_rejects_a_self_consistent -- --nocapture 2>&1 | grep -E "test result|FAILED"`
+Expected: FAIL — no `manifest_blake3`/`schema_version` in the receipt yet, and `verify` does not check a self-hash.
+
+- [ ] **Step 3: Call `finalize()` at the 4 receipt-write sites**
+
+In `src/main.rs`, add `manifest.finalize();` immediately before the serialization at each site. The bindings are already `let mut manifest = RunManifest::new(…)`.
+
+(a) `run_somatic` — before `let manifest_path = write_manifest(&output_vcf, &manifest)?;` (~`:1168`):
+
+```rust
+    manifest.finalize();
+    let manifest_path = write_manifest(&output_vcf, &manifest)?;
+```
+
+(b) `run_variants` (`--reference`) — before `let manifest_path = write_manifest(&path, &manifest)?;` (~`:1538`):
+
+```rust
+            manifest.finalize();
+            let manifest_path = write_manifest(&path, &manifest)?;
+```
+
+(c) `run_features` — before `std::fs::write(&dest, manifest.to_canonical_json())` (~`:1838`):
+
+```rust
+        manifest.finalize();
+        std::fs::write(&dest, manifest.to_canonical_json())
+```
+
+(d) `run_variants_index` — before `std::fs::write(&dest, manifest.to_canonical_json())` (~`:2218`):
+
+```rust
+        manifest.finalize();
+        std::fs::write(&dest, manifest.to_canonical_json())
+```
+
+> If two sites share identical surrounding text and an exact-match edit is ambiguous, include the
+> distinguishing preceding line (the last `manifest.params.insert(…)` of that block) in the match.
+
+- [ ] **Step 4: Add the self-hash check in `run_verify`**
+
+In `src/main.rs` `run_verify`, after the internal-consistency cross-checks and before the
+`if problems.is_empty()` block, add:
+
+```rust
+    // Self-hash: catches any post-write edit (even one that keeps the other fields
+    // mutually consistent). A pre-1.2 receipt has no self-hash — note and skip.
+    match manifest.self_hash_ok() {
+        Some(true) => {}
+        Some(false) => problems.push(
+            "manifest_blake3 mismatch: the receipt was modified after it was written".to_string(),
+        ),
+        None => println!("verify: note — no manifest_blake3 (a pre-1.2 receipt); skipping self-hash"),
+    }
+```
+
+- [ ] **Step 5: Run the new tests + the existing verify tests**
+
+Run: `cargo test --test plan_enforce verify -- --nocapture 2>&1 | grep -E "test result|FAILED"`
+Expected: PASS — the two new tests, plus the existing `verify_passes_on_an_untampered_run…` and
+`verify_rejects_an_internally_inconsistent_manifest` (the latter now also trips the self-hash but
+still exits 5).
+
+- [ ] **Step 6: Document in CONTRACT.md**
+
+In `CONTRACT.md`, in the `### 4. Verify` section, after the sentence describing what `verify` re-checks,
+add:
+
+```markdown
+The receipt is **self-hashing**: a `manifest_blake3` over its own canonical JSON (and a `schema_version`)
+is stamped at write time and re-derived by `verify`, so any post-write edit — even one that keeps the
+other fields mutually consistent — is caught (exit 5). This is tamper-*evident*; a cryptographically
+signed, tamper-*proof* receipt is a separate planned feature.
+```
+
+- [ ] **Step 7: Full suite + warnings + fmt, then commit**
+
+Run: `cargo test 2>&1 | grep -cE "test result: ok"; cargo test 2>&1 | grep -iE "FAILED" || echo "no failures"; cargo build --release 2>&1 | grep -i warning || echo "no warnings"; cargo fmt && cargo fmt --check && echo "fmt clean"`
+Expected: all sections ok, no failures, no warnings, fmt clean.
+
+```bash
+git add src/main.rs tests/plan_enforce.rs CONTRACT.md
+git commit -m "feat(provenance): stamp the self-hash + schema_version on every receipt; verify checks it"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full suite green:** `cargo test 2>&1 | tail -5`.
+- [ ] **Zero warnings:** `cargo build --release 2>&1 | grep -i warning || echo "no warnings"` (lib + examples).
+- [ ] **Smoke:** a real `variants --index … --enforce -o calls.vcf` receipt contains `manifest_blake3` + `schema_version`; `verify` passes; editing one byte of `calls.vcf.manifest.json` then `verify` exits 5 with "manifest_blake3 mismatch".
+- [ ] CI green on GitHub before reporting done.

--- a/docs/superpowers/specs/2026-06-02-sprint1-2-unforgeable-receipt-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-2-unforgeable-receipt-design.md
@@ -1,0 +1,163 @@
+# Sprint 1.2 — The Unforgeable Receipt (design)
+
+**Status:** Approved design — 2026-06-02. Increment 1.2 of the engineering roadmap
+([`docs/ROADMAP.md`](../../ROADMAP.md), Sprint 1). Builds on Sprint 1.1 (the runtime governor).
+
+---
+
+## 1. Problem
+
+The run receipt is canonical JSON with BLAKE3 hashes of the inputs/outputs and the recorded
+memory numbers, but **the manifest itself is unauthenticated**. `run_verify` already cross-checks
+internal consistency (its own comment, `main.rs:926`, says *"The manifest has no self-hash yet"*),
+but a hand-edited receipt whose fields are mutually consistent passes. Two gaps:
+
+1. **No self-hash** — corruption or a casual edit of any field (peak, budget, verdict, a content
+   hash) is not detected as long as the edited fields stay internally consistent.
+2. **No schema version** — there is no version token on the receipt/feature schema, so a future
+   columnar (Parquet) egress or any consumer cannot tell which schema produced a given artifact.
+   Stamping one is cheap now and expensive to retrofit after a schema freezes.
+
+This increment closes both, entirely on the existing canonical-JSON machinery.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A **self-hash** (`manifest_blake3`) over the canonical JSON, re-derived and checked by `verify` —
+  upgrading the receipt from *corruption-proof* to **tamper-evident**.
+- A **`schema_version`** token stamped into every receipt.
+- Backward compatibility: a pre-1.2 receipt (no `manifest_blake3`) still verifies, with a note.
+
+**Non-goals (explicitly deferred)**
+- Cryptographic signatures / tamper-*proof* receipts (the "verify-attest" follow-up; a self-hash is
+  tamper-*evident*, not tamper-proof — a determined forger can recompute it).
+- Removing the `verify` budget-from-manifest fallback (decided: **keep it** — the self-hash makes the
+  recorded budget tamper-evident; an auditor wanting tamper-proof supplies `--budget-mb` externally).
+- Changing the `FEATURE_HEADER` TSV bytes (the schema version lives in the manifest, not the table —
+  see §3.2).
+- Arrow/Parquet egress (Sprint 3) — `schema_version` is laid down now so it is *ready* for it.
+
+## 3. Design
+
+### 3.1 Self-hash (`provenance::RunManifest`)
+
+The self-hash is a `params` entry `manifest_blake3` — no change to the canonical-JSON top-level shape
+or the hand-parser. It is computed over the canonical JSON **with that field excluded**, so `verify`
+can re-derive it deterministically.
+
+```rust
+/// Current receipt/feature schema version. Bump on any breaking schema change.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+impl RunManifest {
+    /// BLAKE3 hex of the canonical JSON with the self-hash field excluded — the
+    /// content this manifest commits to. Deterministic; `verify` re-derives it.
+    pub fn content_hash(&self) -> String {
+        let mut m = self.clone();
+        m.params.remove("manifest_blake3");
+        blake3_hex(m.to_canonical_json().as_bytes())
+    }
+
+    /// Stamp the schema version + the self-hash. Call LAST, immediately before
+    /// serialization, so the hash covers every other field (including the version).
+    pub fn finalize(&mut self) {
+        self.params
+            .insert("schema_version".to_string(), MANIFEST_SCHEMA_VERSION.to_string());
+        let h = self.content_hash();
+        self.params.insert("manifest_blake3".to_string(), h);
+    }
+
+    /// `Some(true)`/`Some(false)` if a self-hash is recorded and matches / mismatches;
+    /// `None` if none is recorded (a pre-1.2 receipt).
+    pub fn self_hash_ok(&self) -> Option<bool> {
+        self.params
+            .get("manifest_blake3")
+            .map(|recorded| *recorded == self.content_hash())
+    }
+}
+```
+
+`RunManifest` already derives `Clone`, so `content_hash` cloning is free of new bounds. The order in
+`finalize` matters: `schema_version` is inserted first so the self-hash commits to it; `content_hash`
+removes `manifest_blake3` defensively (so `finalize` is idempotent and `self_hash_ok` is symmetric).
+
+### 3.2 `schema_version` placement — manifest only
+
+`schema_version` is recorded **only in the manifest `params`**, never in the `FEATURE_HEADER` TSV
+bytes. Rationale: the feature table's byte-for-byte reproducibility is a shipped guarantee (the golden
+feature test pins the exact header); injecting a version line would break it and is itself a breaking
+feature-schema change. The provenance record is the correct, non-breaking home for a schema version —
+it is exactly where a consumer (or the future Parquet egress) reads "which schema is this".
+
+### 3.3 Wiring at the four receipt-write sites
+
+Call `manifest.finalize()` once, immediately before serialization, at each site:
+
+| Site | `main.rs` (approx) | Serialization |
+|---|---|---|
+| `run_somatic` | `:1148`/`:1168` | `write_manifest(&out, &manifest)` |
+| `run_variants` (`--reference`) | `:1515`/`:1538` | `write_manifest(&path, &manifest)` |
+| `run_features` | `:1767`/`:1838` | `std::fs::write(dest, manifest.to_canonical_json())` |
+| `run_variants_index` | `:2146`/`:2218` | `std::fs::write(dest, manifest.to_canonical_json())` |
+
+`finalize` takes `&mut self`, so each `let mut manifest = …` binding (already `mut`) calls
+`manifest.finalize();` just before the write. `write_manifest` and `to_canonical_json` are unchanged.
+
+### 3.4 `verify` (`run_verify`)
+
+After parsing, add a self-hash check to the `problems` accumulator, alongside the existing checks:
+
+```rust
+match manifest.self_hash_ok() {
+    Some(true) => {}
+    Some(false) => problems.push(
+        "manifest_blake3 mismatch: the receipt was modified after it was written".into(),
+    ),
+    None => println!("verify: note — no manifest_blake3 (a pre-1.2 receipt); skipping self-hash"),
+}
+```
+
+The budget-from-manifest fallback (`main.rs:895`) stays. The `verify: OK` / exit-5 logic is unchanged
+otherwise — a self-hash mismatch simply joins the existing `problems`, so it fails the same way.
+
+### 3.5 Determinism & compatibility
+
+- **Determinism preserved.** `schema_version` is constant; `manifest_blake3` is a deterministic hash
+  of deterministic content. On one machine, identical inputs → byte-identical manifest *including* the
+  self-hash. (Across machines the manifest already differs by `peak_rss_bytes`; the self-hash differs
+  too — it authenticates *this* receipt, not cross-machine equality, exactly as intended.)
+- **Backward compatible.** A v0.1.0 receipt has no `manifest_blake3` → `self_hash_ok()` is `None` →
+  `verify` notes it and proceeds. No existing receipt breaks.
+- **Existing tests.** `to_canonical_json` is unchanged, so the provenance unit tests that build a
+  manifest by hand (no `finalize`) are unaffected. Integration tests assert via `.contains(…)`, so the
+  two new params don't break them.
+
+## 4. File-by-file change list
+
+| File | Change |
+|---|---|
+| `src/provenance/mod.rs` | `MANIFEST_SCHEMA_VERSION` const; `content_hash`, `finalize`, `self_hash_ok` on `RunManifest`; unit tests. |
+| `src/main.rs` | `manifest.finalize();` before each of the 4 receipt writes; the self-hash check in `run_verify`. |
+| `tests/plan_enforce.rs` | Integration: a receipt carries `manifest_blake3` + `schema_version`; `verify` passes untampered; `verify` FAILS on a tampered field whose file hashes still match. |
+| `CONTRACT.md` | The "Verify" section: note the receipt is now self-hashing (tamper-evident). |
+
+## 5. Testing
+
+1. **Unit (`provenance`)** — `content_hash` is stable across re-serialization; `finalize` makes
+   `self_hash_ok() == Some(true)`; flipping any param after `finalize` makes it `Some(false)`; a
+   manifest without the field returns `None`; `finalize` is idempotent (second call re-stamps to the
+   same value).
+2. **Integration (`tests/plan_enforce.rs`)** — a real `variants --index` receipt contains
+   `manifest_blake3` + `schema_version=1`; `verify` passes; then hand-edit a *consistent* field (e.g.
+   bump `memory_budget_mb` and `peak_rss` together so the consistency checks still pass) and assert
+   `verify` now **exits 5** on the self-hash mismatch — the gap the consistency checks alone cannot
+   close.
+3. **Regression** — full suite green; the existing `verify_passes_on_an_untampered_run…` and
+   `verify_rejects_an_internally_inconsistent_manifest` tests still pass (the latter now ALSO trips the
+   self-hash, but still exits 5 — assert it stays 5).
+
+## 6. References
+
+- `src/provenance/mod.rs` — `RunManifest`, `to_canonical_json`, `from_canonical_json`, `blake3_hex`.
+- `src/main.rs:870` (`run_verify`), `:1148`/`:1515`/`:1767`/`:2146` (the four receipt-write sites).
+- `docs/ROADMAP.md` Sprint 1 (QW-3) — this increment.

--- a/src/main.rs
+++ b/src/main.rs
@@ -964,6 +964,18 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
         }
     }
 
+    // Self-hash: catches any post-write edit (even one that keeps the other fields
+    // mutually consistent). A pre-1.2 receipt has no self-hash — note and skip.
+    match manifest.self_hash_ok() {
+        Some(true) => {}
+        Some(false) => problems.push(
+            "manifest_blake3 mismatch: the receipt was modified after it was written".to_string(),
+        ),
+        None => {
+            println!("verify: note — no manifest_blake3 (a pre-1.2 receipt); skipping self-hash")
+        }
+    }
+
     if problems.is_empty() {
         println!(
             "verify: OK — {} input(s), {} output(s) match",
@@ -1165,6 +1177,7 @@ fn run_somatic(
     manifest
         .params
         .insert("somatic_snv_only".to_string(), "true".to_string());
+    manifest.finalize();
     let manifest_path = write_manifest(&output_vcf, &manifest)?;
     eprintln!("wrote reproducibility receipt: {}", manifest_path.display());
 
@@ -1535,6 +1548,7 @@ fn run_variants(
             manifest
                 .params
                 .insert("region_start".to_string(), region_start.to_string());
+            manifest.finalize();
             let manifest_path = write_manifest(&path, &manifest)?;
             eprintln!("wrote reproducibility receipt: {}", manifest_path.display());
         }
@@ -1835,6 +1849,7 @@ fn run_features(
         manifest
             .params
             .insert("contract_verdict".to_string(), verdict.to_string());
+        manifest.finalize();
         std::fs::write(&dest, manifest.to_canonical_json())
             .with_context(|| format!("failed to write manifest {}", dest.display()))?;
         eprintln!("wrote reproducibility receipt: {}", dest.display());
@@ -2215,6 +2230,7 @@ fn run_variants_index(
         manifest
             .params
             .insert("contract_verdict".to_string(), verdict.to_string());
+        manifest.finalize();
         std::fs::write(&dest, manifest.to_canonical_json())
             .with_context(|| format!("failed to write manifest {}", dest.display()))?;
         eprintln!("wrote reproducibility receipt: {}", dest.display());

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -8,6 +8,9 @@ use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+/// Current receipt/feature schema version. Bump on any breaking schema change.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
 /// Failure parsing a canonical run manifest.
 #[derive(Debug)]
 pub struct ManifestError(pub String);
@@ -99,6 +102,33 @@ impl RunManifest {
             i: 0,
         };
         p.parse_manifest()
+    }
+
+    /// BLAKE3 hex of the canonical JSON with the self-hash field excluded — the
+    /// content this manifest commits to. Deterministic; `verify` re-derives it.
+    pub fn content_hash(&self) -> String {
+        let mut m = self.clone();
+        m.params.remove("manifest_blake3");
+        blake3_hex(m.to_canonical_json().as_bytes())
+    }
+
+    /// Stamp the schema version + the self-hash. Call LAST, immediately before
+    /// serialization, so the hash covers every other field (including the version).
+    pub fn finalize(&mut self) {
+        self.params.insert(
+            "schema_version".to_string(),
+            MANIFEST_SCHEMA_VERSION.to_string(),
+        );
+        let h = self.content_hash();
+        self.params.insert("manifest_blake3".to_string(), h);
+    }
+
+    /// `Some(true)`/`Some(false)` if a self-hash is recorded and matches / mismatches;
+    /// `None` if none is recorded (a pre-1.2 receipt).
+    pub fn self_hash_ok(&self) -> Option<bool> {
+        self.params
+            .get("manifest_blake3")
+            .map(|recorded| *recorded == self.content_hash())
     }
 }
 
@@ -458,5 +488,53 @@ mod tests {
     fn parse_rejects_malformed() {
         assert!(RunManifest::from_canonical_json("not json").is_err());
         assert!(RunManifest::from_canonical_json("{\"inputs\":[}").is_err());
+    }
+
+    #[test]
+    fn finalize_stamps_schema_version_and_a_matching_self_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params
+            .insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        assert_eq!(
+            m.params.get("schema_version").map(String::as_str),
+            Some(MANIFEST_SCHEMA_VERSION.to_string().as_str())
+        );
+        assert!(m.params.contains_key("manifest_blake3"));
+        assert_eq!(m.self_hash_ok(), Some(true), "fresh finalize must verify");
+    }
+
+    #[test]
+    fn tampering_any_field_breaks_the_self_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params
+            .insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        // Flip a field WITHOUT re-finalizing — the recorded hash no longer matches.
+        m.params
+            .insert("peak_rss_bytes".to_string(), "999".to_string());
+        assert_eq!(m.self_hash_ok(), Some(false));
+    }
+
+    #[test]
+    fn a_manifest_without_a_self_hash_returns_none() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        assert_eq!(m.self_hash_ok(), None);
+    }
+
+    #[test]
+    fn finalize_is_idempotent() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params
+            .insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.finalize();
+        let first = m.params.get("manifest_blake3").cloned();
+        m.finalize();
+        assert_eq!(m.params.get("manifest_blake3").cloned(), first);
+        assert_eq!(m.self_hash_ok(), Some(true));
     }
 }

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -724,3 +724,80 @@ fn near_saturation_margin_holds_on_a_larger_contig() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn receipt_is_self_hashing_and_schema_versioned() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    let text = std::fs::read_to_string(&manifest).expect("manifest");
+    assert!(
+        text.contains("\"manifest_blake3\":"),
+        "no self-hash: {text}"
+    );
+    assert!(
+        text.contains("\"schema_version\":\"1\""),
+        "no schema_version: {text}"
+    );
+    // An untampered receipt verifies.
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert!(v.status.success(), "untampered verify should pass: {v:?}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn verify_rejects_a_self_consistent_but_tampered_receipt() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+    // Tamper a field while keeping the receipt internally CONSISTENT: raise the
+    // recorded budget (a 'within' verdict stays valid since peak << 8192 MiB), so the
+    // verdict/consistency cross-checks still pass. Only the self-hash catches this.
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let tampered = text.replace(
+        "\"memory_budget_mb\":\"4096\"",
+        "\"memory_budget_mb\":\"8192\"",
+    );
+    assert_ne!(text, tampered, "the replace must have changed something");
+    std::fs::write(&manifest, &tampered).unwrap();
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "tampered receipt must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("manifest_blake3 mismatch"),
+        "expected a self-hash mismatch: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Makes the run receipt **tamper-evident** and **schema-versioned**, on the existing canonical-JSON machinery — upgrading "verifiable" from *corruption-proof* to *tamper-evident*.

- **Self-hash** (`manifest_blake3`): `RunManifest::finalize()` stamps a `schema_version` then a BLAKE3 over the receipt's own canonical JSON (the hash field excluded), called at all 4 receipt-write sites (`somatic`, `variants --reference`, `features`, `variants --index`). `verify` re-derives and checks it: a post-write edit that keeps the other fields **mutually consistent** (e.g. raising `memory_budget_mb`) now fails (exit 5) on the self-hash mismatch — the exact gap the internal-consistency checks alone cannot close.
- **`schema_version`** stamped into every receipt — laid down now so a future Arrow/Parquet egress (Sprint 3) has a schema token to declare. Deliberately **not** in the `FEATURE_HEADER` TSV bytes (that would break the feature table's byte-reproducibility); the provenance record is its correct home.
- **Backward compatible**: a pre-1.2 receipt (no self-hash) verifies with a note.
- **Tamper-*proof*** (cryptographic signatures) is explicitly deferred to the planned "verify-attest" feature — a self-hash is tamper-*evident*, not tamper-proof.
- Decision (confirmed): the `verify` budget-from-manifest fallback **stays** — the self-hash makes the recorded budget tamper-evident; an auditor wanting tamper-proof supplies `--budget-mb` externally.

Reviewed design + plan: `docs/superpowers/specs/2026-06-02-sprint1-2-unforgeable-receipt-design.md`, `docs/superpowers/plans/2026-06-02-sprint1-2-unforgeable-receipt.md`. Roadmap Sprint 1, QW-3.

## Test Plan

- [x] Provenance unit tests: `content_hash` stable; `finalize` → `self_hash_ok() == Some(true)`; a flipped field → `Some(false)`; no-self-hash → `None`; `finalize` idempotent.
- [x] Integration: a real `variants --index` receipt carries `manifest_blake3` + `schema_version=1`; `verify` passes untampered; a **self-consistent** tamper (raise `memory_budget_mb`) → `verify` exits 5 with `manifest_blake3 mismatch`.
- [x] The existing `verify_rejects_an_internally_inconsistent_manifest` still exits 5 (now also trips the self-hash).
- [x] Full suite green (25 sections), 0 warnings, fmt clean. End-to-end smoke confirms self-hash + tamper detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)