### PR TITLE
docs: forkability hygiene — doc-drift fixes, CONTRIBUTING/ARCHITECTURE, ROADMAP (Sprint 1.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: A reproducible bug (Rosalind's determinism makes most bugs exactly reproducible)
+title: ""
+labels: bug
+---
+
+**What happened vs. what you expected**
+
+**Exact command**
+
+```sh
+rosalind ...
+```
+
+**Inputs** (sizes + how to obtain them; a tiny fixture that reproduces it is ideal)
+
+**Receipt** — paste the run's `manifest_blake3` (and `contract_verdict`) from the `.manifest.json`, or
+attach the manifest.
+
+**Environment**
+- `rosalind --version`:
+- OS / arch:
+- Installed via (release tarball / `cargo build` / Action):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - uses: actions-rs/toolchain@v1
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - uses: actions/setup-python@v4

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Rosalind Architecture
+
+A map of the codebase, so you know where a change belongs. Companion to
+[`docs/ROADMAP.md`](docs/ROADMAP.md) (where we're going) and
+[`docs/OPEN_PROBLEMS.md`](docs/OPEN_PROBLEMS.md) (the research thesis).
+
+## The kernel
+
+Rosalind's spine is a **bounded, deterministic `PileupColumn` stream**. Variant calling, gVCF, the
+feature substrate, and any ColumnKit analyzer all consume that one stream, so they inherit the same
+memory contract and byte-reproducibility.
+
+## Modules (`src/`)
+
+| Module | Responsibility |
+|---|---|
+| `core/` | Shared types: `Locus`/`ContigSet`/`AlignedRead`, the memory `budget` + `WorkingSet`, the runtime `governor`, the typed `CoreError`. |
+| `io/` | Streaming FASTA/FASTQ (gzip/bgzf auto-detect), BAM/VCF read+write (via rust-htslib), decompression. |
+| `genomics/` | The FM-index: `suffix_array` (SA-IS), `fm_index`/`fm_backing`, `rank_select`, the persisted `index/` (format, mmap `view`), `compressed_dna`, the `bwt_aligner`, deterministic `sort`, and `eval/` (truth-set comparison). |
+| `pileup/` | The streaming pileup `engine` + `column` + read `source` — the bounded kernel. |
+| `call/` | Consumers of the kernel: `germline`/`somatic`/`gvcf` calling, the `features` egress, the `columnkit` SDK, the `plan` estimator, fleet `pack`, the `pipeline`/`whole_genome` drivers. |
+| `provenance/` | The canonical-JSON, self-hashing BLAKE3 run receipt (`RunManifest`). |
+| `util/` | Process RSS (`getrusage`), mmap helpers. |
+
+## Roadmap phases → code
+
+- **A** (streaming pileup + calling): `pileup/`, `call/{germline,somatic,gvcf,pipeline}`.
+- **B** (genome-scale index): `genomics/{suffix_array,fm_index,index}`, `io/bam`.
+- **C** (the memory contract): `core/{budget,governor}`, `call/plan`, `provenance/`, `verify` in `main.rs`.
+- **D** (sublinear-space index *build* — research): `genomics/suffix_array` + a future external-memory constructor. See `docs/OPEN_PROBLEMS.md`.
+- **E** (reach + ML substrate): `call/{features,columnkit}`, `python/`, `genomics/eval`.
+
+## CLI
+
+`src/main.rs` is the CLI surface (`index`, `align`, `sort`, `variants`, `somatic`, `features`, `plan`,
+`pack`, `verify`, `locate`, `eval-*`), thin over the library.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Rosalind
+
+Thanks for building on Rosalind. This guide gets you productive fast and explains the two
+guarantees every change must preserve.
+
+## Build, test, format
+
+```bash
+cargo build --release          # the rosalind binary + library
+cargo test                     # full unit + integration suite
+cargo fmt --check              # formatting (run `cargo fmt` to fix)
+```
+
+## Two invariants you must not break
+
+1. **Determinism.** Primary artifacts (VCF, gVCF, feature TSV) are byte-identical across repeated runs
+   on identical inputs. See [`docs/determinism.md`](docs/determinism.md). If you touch the calling or
+   egress path, add or keep a repeat-run byte-equality test.
+2. **The memory contract.** `rosalind plan` predicts a peak that must upper-bound the realized peak;
+   `--enforce` honors it (refuse exit 3, or the runtime governor exits 4); the receipt is self-hashing.
+   See [`CONTRACT.md`](CONTRACT.md). A streaming stage's working set must stay bounded by coverage, not
+   input size.
+
+## How we work: brainstorm → spec → plan → TDD
+
+Non-trivial changes go through a short design loop. Specs live in `docs/superpowers/specs/`, plans in
+`docs/superpowers/plans/`. Write a failing test first; keep commits small; one branch per increment;
+open a PR for review (CI must be green before merge).
+
+## Extending the engine
+
+The fastest way to add your own per-locus analytic is the **ColumnKit SDK**: implement one
+`ColumnAnalyzer` method and run it through `run_bounded_whole_genome` to inherit bounded memory,
+determinism, and a verifiable receipt — no contract code to re-derive. See
+[`examples/columnkit_coverage.rs`](examples/columnkit_coverage.rs) and [`CONTRACT.md`](CONTRACT.md).
+
+## Reporting bugs
+
+Use the bug-report template. Include the exact command, the inputs, and the receipt hash
+(`manifest_blake3`) + `rosalind --version` — Rosalind's determinism makes most bugs exactly
+reproducible.

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Rosalind's kernel is a **bounded, deterministic `PileupColumn` stream** — buil
 cargo test                          # full unit + integration suite
 cargo test --test variants_index    # bounded whole-genome `variants --index` gates
 cargo test --test determinism       # byte-identical outputs across repeated runs
-cargo test --test space_bounds      # working-set scaling checks for the streaming evaluator
+cargo test --test plan_enforce      # the memory contract: plan / --enforce / verify / governor
 cargo test --test fm_index_props    # property tests: FM-index rank/total invariants vs. naive counts
 cargo test --test golden_vcf        # snapshot test for stable VCF rendering
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,195 @@
+# Rosalind — Engineering Roadmap
+
+**Status:** Living engineering-direction document — 2026-06-02. Companion to
+[`docs/OPEN_PROBLEMS.md`](OPEN_PROBLEMS.md) (the research thesis) and [`CONTRACT.md`](../CONTRACT.md)
+(the shipped memory contract). Audience: builders deciding what to build *on* Rosalind, and
+contributors deciding where to help.
+
+This document is a *direction*, not a promise of dates. It records **what we will build next and
+why**, in priority order, grounded in the actual codebase.
+
+---
+
+## 1. The organizing principle
+
+Rosalind has exactly one moat, and it is not the caller, the aligner, or the `~√t` framing. It is
+the **receipt**: a bounded, deterministic run that emits a content-addressed proof of *what it did*
+and *what it cost*.
+
+> **The receipt is the product. The caller is the demo.**
+
+Every prioritization decision flows from a single test. A change is worth doing if and only if it
+does one of three things to the receipt:
+
+1. **Hardens it** — makes the receipt *unforgeable* and the memory bound it attests *unbreakable*.
+2. **Widens it** — makes more lifecycle stages and more artifact types emit a receipt, extending a
+   verifiable provenance graph that a non-deterministic tool structurally cannot produce.
+3. **Deepens it** — pairs every receipt with a *measured trust number* (accuracy / correctness), so
+   an artifact is reproducible **and** right.
+
+Work that does not touch the receipt — raw throughput, structural-variant/CNV tracks, accuracy-parity
+races against GATK/DeepVariant, a mismatch-tolerant aligner — is deliberately deprioritized. Those
+compete on dimensions Rosalind has declared **non-goals** (see §6), and, more importantly, they do
+not *compound*. The receipt does.
+
+---
+
+## 2. Current state (what's real, what's not)
+
+**Shipped and well-tested.** Bounded whole-genome germline *SNV* calling over a sorted BAM (peak
+independent of BAM size); a build-once, memory-mapped, byte-reproducible FM-index (`index` / `locate`);
+deterministic external-merge `sort` (output provably independent of the chunk boundary); banded gVCF;
+region-bounded somatic; the reproducible per-locus feature substrate with BLAKE3 receipts; the
+ColumnKit SDK (`ColumnAnalyzer` + `run_bounded_whole_genome`, with `features` as its first impl);
+`plan` / `--enforce` / `verify` / `pack`; a self-testing GitHub Action and cross-platform release
+tarballs. The historical reference-decode undercount is fixed (`decode_window_arc`), and the
+`predicted ≥ realized` working-set inequality is tested.
+
+**Stubbed or simulated — stated plainly.** Accuracy is 100% simulated (no GIAB run yet); the germline
+model has none of the standard FP filters (FS/SOR/MQRankSum/ReadPosRankSum). MAPQ is a hardcoded
+placeholder the likelihood ignores, so Rosalind's *own* aligner cannot yet be in an accuracy story.
+Germline is SNV-only (indels are structurally absent from `Obs`, not merely uncalled). The feature
+substrate egresses as TSV through a fully-materializing Python loader — the bounded story currently
+breaks at the Python boundary. Published to zero package registries.
+
+**The one structural gap.** Index **build** is `O(reference)` RAM — a single in-RAM SA-IS call peaking
+at ~45 B/base. "Declare your RAM" is honored for *calling* and silently false for the *build*, which
+is exactly where builders hit the wall first. Closing this is the headline research bet (§5, Sprint 4).
+
+**A quieter, load-bearing gap.** The entire "verifiable upper bound" currently rests on a hardcoded
+`PILEUP_IO_RSS_OVERHEAD = 8 MiB` slack constant, with no proof it holds across platforms/allocators,
+and **no runtime governor** — so a misprediction could be OOM-killed by the kernel *before* the
+post-run exit-4 check fires. That is the exact silent-OOM the thesis forbids. Closing it is the single
+highest-ROI item in the repo (Sprint 1).
+
+---
+
+## 3. The asymmetric bets (ranked by ROI, not effort)
+
+| # | Bet | What it does to the receipt | Effort | Why it's asymmetric |
+|---|-----|------------------------------|--------|---------------------|
+| 1 | Unbreakable bound | Hardens | S–M | Days of work insure the entire thesis against a brand-inversion event. |
+| 2 | Unforgeable receipt | Hardens | S | "Reproducible" → "tamper-evident" = the actual clinical/audit bar; schema-version is free now, costly later. |
+| 3 | One real GIAB number | Deepens | M | You don't need to *win* GIAB — a number *paired with a memory receipt* is an artifact no one else publishes. |
+| 4 | Content-addressed dataset engine | Widens | M | The substrate already emits the bytes; determinism makes "bit-reproducible training data" a category incumbents are locked out of. |
+| 5 | Somatic + sort into the envelope | Widens | M | Lifecycle width on existing primitives; closes the "your thesis holds for 2 of 7 stages" gap. |
+| 6 | D1a: the build that refuses to OOM | Widens (the last stage) | XL | Category-defining and the literal realization of the √t framing — but high cost, so it runs in parallel, not first. |
+
+---
+
+## 4. The roadmap (sequenced)
+
+Four increments. The **spine** (Sprints 1–3) is certain value that compounds the receipt; the
+**headline bet** (D1a) runs in parallel once its cheap prereqs land. Each to-do is shippable as its
+own PR via the project's `brainstorm → spec → plan → TDD` flow. Effort: **S** = days, **M** = 1–3
+weeks, **L** = a quarter, **XL** = 1–2 quarters.
+
+### Sprint 1 — Harden the receipt (insurance + hygiene)
+
+- **1.1 — Unbreakable bound.** Replace the fixed `PILEUP_IO_RSS_OVERHEAD` with a **measured residual**
+  (sample `peak_rss − working_set − baseline`, record p99 in the receipt). Add a `setrlimit(RLIMIT_AS,
+  budget)` guard under `--enforce` (Linux) plus a periodic RSS-poll abort fallback (portable), so a
+  breach **fails loud at the allocation site (exit 4)** before the kernel OOM-killer can fire. Add an
+  upper-bound test at **near-saturation on a chr20-scale fixture**, not the 4 MiB toy.
+  *Surfaces:* `core/budget.rs`, `pileup/engine.rs`, `main.rs`, `tests/plan_enforce.rs`. *Effort: S–M.*
+- **1.2 — Unforgeable receipt + schema version.** BLAKE3 self-hash over the canonical JSON (digest
+  field zeroed); `verify` re-derives it. Remove the verify-budget-from-manifest fallback. Stamp a
+  `SCHEMA_VERSION` into `FEATURE_HEADER` + the manifest **now**, before any columnar schema freezes.
+  *Surfaces:* `provenance/mod.rs`, `call/features.rs`, `main.rs`. *Effort: S.*
+- **1.3 — Forkability hygiene.** `cargo publish`; clippy `-D warnings` + MSRV + `rust-version`; fix the
+  known doc-drift defects; run the README quickstart verbatim in CI; add `CONTRIBUTING.md`,
+  `ARCHITECTURE.md`, and a deterministic-repro issue template. (Not PyPI/bioconda — the htslib linking
+  wall is real work, deferred.) *Effort: S.*
+
+### Sprint 2 — Earn caller trust (∥ de-risk the build bet)
+
+- **2.1 — Genotype-aware GIAB.** Upgrade the comparator: GT/zygosity scoring, multi-allelic
+  decomposition (stop skipping comma-containing ALTs), golden left-align cases. Run HG002 chr20
+  high-confidence **+ CMRG** through `eval-germline` on an externally-mapped BAM; publish an accuracy
+  card *alongside* the memory receipt. Fold MAPQ into the germline likelihood. Frame honestly:
+  *"accuracy is now measured, not assumed; the contract is the contribution."*
+  *Surfaces:* `genomics/eval/{vcf,compare,normalize}.rs`, `call/germline.rs`. *Effort: M.*
+- **2.2 — D1a prereqs (start early; cheap; independent).** Property/adversarial-fuzz `sais_u32` vs a
+  naive SA. Swap the coarse 12 B/base build estimate for the code-grounded ~45 B/base
+  `BuildMemoryModel` as the `plan --reference` basis, so the build inequality is sound *before*
+  enforcement. *Surfaces:* `genomics/suffix_array.rs`, `genomics/index/report.rs`, `call/plan.rs`.
+  *Effort: S–M.*
+
+### Sprint 3 — Widen the contract + open the ML surface
+
+- **3.1 — Somatic + sort into the envelope.** `stream_somatic_whole_genome`: two `StreamingBamSource`
+  + two depth-capped engines in lockstep, reusing the existing merge-join with **lazy** engines; wire
+  `plan`/`--enforce`/`verify`. Give `sort` an enforced (refuse / fail-loud) chunk bound + a build
+  receipt. *Surfaces:* `call/{somatic,pipeline}.rs`, `genomics/sort.rs`. *Effort: M.*
+- **3.2 — Arrow/Parquet egress + zero-copy bindings.** An `ArrowFeatureAnalyzer` (`ColumnAnalyzer`)
+  that flushes bounded 64k-locus Parquet row-groups behind a cargo feature (keep the lean static-musl
+  default); add the row-group term to the plan estimator so `predicted ≥ realized` still holds.
+  Replace the Python `str.split` loader with `pyarrow → .to_torch()/.to_jax()/__dlpack__`.
+  *Surfaces:* `call/{features,columnkit,plan}.rs`, `python/rosalind.py`. *Effort: M.*
+
+### Sprint 4 — The dataset engine + the headline build bet
+
+- **4.1 — Supervised in one command + content-addressed dataset cards.** A `LabeledFeatureAnalyzer`:
+  `features --truth truth.vcf --confident-regions conf.bed --emit-label` → bounded `(X, y)`.
+  Region-disjoint, content-addressed train/val/test split descriptors; `rosalind dataset-card`;
+  `verify` re-checks split-disjointness. The "prove this quarter's model saw exactly last quarter's
+  data" artifact. *Surfaces:* `call/features.rs`, `genomics/eval/{normalize,bed}.rs`,
+  `provenance/mod.rs`. *Effort: M.*
+- **4.2 — D1a: budget-tunable external-memory build (the headline).** Blocked SA-IS (budget-sized
+  blocks → spill → deterministic disk merge reusing `sort.rs`'s heap-merge); wire
+  `index --memory-budget-mb` into refuse/honor/verify + a build receipt; byte-identical `.idx` oracle
+  on RAM-sized genomes, plus an independent FM-roundtrip / `locate`-vs-brute-force check for genomes
+  too large to build at `b = n`. Market as *"build a human index on a 2 GB box, or refuse."* Pangenome
+  scale (u64 / format-v2, past the current `u32::MAX` ceiling) is **D1b**, a separate deferred epic.
+  *Surfaces:* `genomics/{suffix_array,fm_index,genome_index}.rs`, `genomics/index/io.rs`,
+  `genomics/sort.rs`. *Effort: XL.*
+
+---
+
+## 5. The single big bet
+
+**D1a — close the build hole, scoped to "human/T2T on a small box," run in parallel with the spine.**
+
+It is the only item that resolves the thesis's defining contradiction: today "declare your RAM" is
+honored for calling and silently false for the build — the most memory-hungry stage, and where
+builders hit the wall first. No production indexer (bwa, minimap2, samtools) offers a declared-budget,
+degrade-to-disk build with a verifiable receipt; they OOM-kill on an emergent peak. Rosalind already
+owns every surrounding piece (SA-IS over an integer alphabet, the deterministic external merge in
+`sort.rs`, the streamable on-disk block format, and the D0 measurement proving the build is
+intermediate-state-bound). It comes with a cheap, powerful oracle — a blocked build must produce a
+**byte-identical `.idx`** to the full-RAM build.
+
+Three honest constraints govern it: (1) market it as **human-on-a-laptop, not pangenome** — the
+`u32::MAX` ceiling means wheat/conifers/pangenomes cannot even be *represented* until the separate
+u64 epic (D1b); (2) the prereqs (SA-IS fuzz, estimator swap) are **gating, not concurrent**; (3) it is
+the long pole (XL) and the disk-backed block-boundary SA merge is the genuinely hard part — so it runs
+alongside the cheap reach-and-credibility spine, which touches disjoint subsystems.
+
+---
+
+## 6. Non-goals (what we deliberately do not build, and why)
+
+- **No "time/wall-clock curve" as a contract dimension.** A throughput regression fit from past
+  receipts has no soundness property, and it is not the √t framing (which is about *space*). Keep
+  wall-time as a logged telemetry field only.
+- **No SV/CNV evidence track yet.** A read-depth bedgraph + discordant/split-read counts is commodity
+  (mosdepth/samtools); "bounded" adds little where depth tracking is already trivially streaming.
+- **No full local-assembly haplotype indel calling.** It breaks the bounded contract and is a
+  multi-year fight against entrenched, well-validated tools. Bounded-*pileup* indels may ship later as
+  a **capability** demonstration, explicitly not accuracy parity, and only after GIAB.
+- **No `--threads` as a performance play.** Byte-identical-across-thread-count is a hard *correctness*
+  property (SA-merge tie-break, allocator-arena RSS interactions); if pursued, only ever as a
+  determinism property with a byte-identity CI gate, and only after the spine and the build bet land.
+- **Do not anchor the pitch on `pack` co-location.** It is real but thin — schedulers already pack by
+  *requested* memory. It rides on the contract; it is not the headline.
+
+---
+
+## 7. How to build on Rosalind
+
+The fastest path from "I want my own per-locus metric" to "I inherit a machine-checkable memory budget
++ a hash-verifiable receipt" is the **ColumnKit SDK**: implement one `ColumnAnalyzer` method and run it
+through `run_bounded_whole_genome`. See [`CONTRACT.md`](../CONTRACT.md) and
+[`examples/columnkit_coverage.rs`](../examples/columnkit_coverage.rs). The shipped `features` egress is
+itself the first `ColumnAnalyzer`, so a third-party analyzer is a first-class citizen, not a
+second-class plugin.

--- a/docs/superpowers/plans/2026-06-02-sprint1-3-forkability-hygiene.md
+++ b/docs/superpowers/plans/2026-06-02-sprint1-3-forkability-hygiene.md
@@ -63,9 +63,15 @@ git commit -m "fix(docs): repair day-one doc-drift (space_bounds test, ft.array-
 
 ---
 
-### Task 2: MSRV — declare + enforce
+### Task 2: MSRV — DEFERRED to 1.3b (execution finding 2026-06-02)
 
-**Files:** `Cargo.toml`, `.github/workflows/ci.yml`
+**Skip this task.** The documented 1.72 MSRV is not buildable: `Cargo.lock` is format v4 (≥1.78) and the
+pinned transitive deps climb to ≥1.83 (`proptest` ICU chain, `icu_properties_data`). Supporting a low
+MSRV needs deliberate `cargo update --precise` dep-pinning — the same decision as the deferred
+`div_ceil`/clippy work — so MSRV moves to **1.3b** (see the spec §3.1/§6). No `rust-version` or MSRV CI
+job ships in 1.3. The pip-cache-key fix from Task 1 already covers the only `ci.yml` change in 1.3.
+
+**Files:** none (deferred).
 
 - [ ] **Step 1: Add `rust-version` to `Cargo.toml`**
 

--- a/docs/superpowers/plans/2026-06-02-sprint1-3-forkability-hygiene.md
+++ b/docs/superpowers/plans/2026-06-02-sprint1-3-forkability-hygiene.md
@@ -1,0 +1,299 @@
+# Sprint 1.3 — Forkability Hygiene: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the verified day-one forkability defects: broken doc commands, an unenforced MSRV, and missing contribution scaffolding; confirm crates.io packaging.
+
+**Architecture:** Config + docs only (no production code). Verification is "the fixed command actually runs" + "CI green incl. a new MSRV job" + "`cargo publish --dry-run` packages."
+
+**Tech Stack:** Cargo metadata, GitHub Actions YAML, Markdown.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md`
+
+---
+
+### Task 1: Doc-drift fixes (3 verified defects)
+
+**Files:** `README.md`, `python/README.md`, `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Fix the README `space_bounds` line**
+
+In `README.md` (~line 387), replace:
+
+```
+cargo test --test space_bounds      # working-set scaling checks for the streaming evaluator
+```
+
+with:
+
+```
+cargo test --test plan_enforce      # the memory contract: plan / --enforce / verify / governor
+```
+
+- [ ] **Step 2: Fix the python README field name**
+
+In `python/README.md` (~line 19), replace `print(ft.array.shape)` with `print(ft.data.shape)`.
+
+- [ ] **Step 3: Repoint the CI pip-cache keys**
+
+In `.github/workflows/ci.yml`, replace BOTH occurrences (lines ~55 and ~96) of:
+
+```
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+```
+
+with:
+
+```
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
+```
+
+- [ ] **Step 4: Verify the fixed commands are real**
+
+Run: `cargo test --test plan_enforce 2>&1 | grep "test result"` → PASS (the README command resolves).
+Run: `grep -n "ft.data" python/rosalind.py` → the `data` field exists on `FeatureTable`.
+Run: `grep -rn "space_bounds\|pyproject.toml\|ft.array" README.md python/README.md .github/workflows/ci.yml` → no matches (all fixed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md python/README.md .github/workflows/ci.yml
+git commit -m "fix(docs): repair day-one doc-drift (space_bounds test, ft.array->ft.data, pip-cache key)"
+```
+
+---
+
+### Task 2: MSRV — declare + enforce
+
+**Files:** `Cargo.toml`, `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add `rust-version` to `Cargo.toml`**
+
+In `Cargo.toml` `[package]`, add after the `edition = "2021"` line:
+
+```toml
+rust-version = "1.72"
+```
+
+- [ ] **Step 2: Verify the crate actually builds on 1.72 locally**
+
+Run: `rustup install 1.72.0 && cargo +1.72.0 check --all-targets 2>&1 | tail -5`
+Expected: PASS. **If it fails to compile on 1.72**, bump `rust-version` in `Cargo.toml` to the lowest
+version that compiles (try `1.74.0`, then `1.75.0`) and re-run — do NOT weaken the check. Record the
+chosen version.
+
+- [ ] **Step 3: Add the MSRV CI job**
+
+In `.github/workflows/ci.yml`, add a new job (mirror the existing job structure — `runs-on:
+ubuntu-latest`, an `actions/checkout@v4` step, then a pinned toolchain). Append this job under `jobs:`
+(use the SAME `rust-version` value chosen in Step 2):
+
+```yaml
+  msrv:
+    name: MSRV (1.72)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.72.0
+          profile: minimal
+          override: true
+      - name: cargo check on the declared MSRV
+        run: cargo check --all-targets
+```
+
+(If the repo's other jobs use `dtolnay/rust-toolchain` instead of `actions-rs/toolchain`, match that
+action for consistency — check the existing `rust`/`python` jobs and copy their toolchain step.)
+
+- [ ] **Step 4: Verify YAML + the full suite still build**
+
+Run: `cargo build --release 2>&1 | grep -i warning || echo "no warnings"` → no warnings.
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "yaml ok"` (or
+`ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml')"` if no python yaml) → parses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock .github/workflows/ci.yml
+git commit -m "ci(msrv): declare rust-version and enforce it with a 1.72 build job"
+```
+
+---
+
+### Task 3: Contribution scaffolding
+
+**Files:** `CONTRIBUTING.md` (new), `ARCHITECTURE.md` (new), `.github/ISSUE_TEMPLATE/bug_report.md` (new)
+
+- [ ] **Step 1: Write `CONTRIBUTING.md`**
+
+Create `CONTRIBUTING.md`:
+
+```markdown
+# Contributing to Rosalind
+
+Thanks for building on Rosalind. This guide gets you productive fast and explains the two
+guarantees every change must preserve.
+
+## Build, test, format
+
+```bash
+cargo build --release          # the rosalind binary + library
+cargo test                     # full unit + integration suite
+cargo fmt --check              # formatting (run `cargo fmt` to fix)
+```
+
+The MSRV is **Rust 1.72** (`rust-version` in `Cargo.toml`); CI enforces it.
+
+## Two invariants you must not break
+
+1. **Determinism.** Primary artifacts (VCF, gVCF, feature TSV) are byte-identical across repeated runs
+   on identical inputs. See [`docs/determinism.md`](docs/determinism.md). If you touch the calling or
+   egress path, add/keep a repeat-run byte-equality test.
+2. **The memory contract.** `rosalind plan` predicts a peak that must upper-bound the realized peak;
+   `--enforce` honors it (refuse exit 3 / governor exit 4); the receipt is self-hashing. See
+   [`CONTRACT.md`](CONTRACT.md). A streaming stage's working set must stay bounded by coverage, not
+   input size.
+
+## How we work: brainstorm → spec → plan → TDD
+
+Non-trivial changes go through a short design loop. Specs live in `docs/superpowers/specs/`, plans in
+`docs/superpowers/plans/`. Write a failing test first; keep commits small; one branch per increment;
+open a PR for review (CI must be green before merge).
+
+## Extending the engine
+
+The fastest way to add your own per-locus analytic is the **ColumnKit SDK**: implement one
+`ColumnAnalyzer` method and run it through `run_bounded_whole_genome` to inherit bounded memory,
+determinism, and a verifiable receipt — no contract code to re-derive. See
+[`examples/columnkit_coverage.rs`](examples/columnkit_coverage.rs) and [`CONTRACT.md`](CONTRACT.md).
+
+## Reporting bugs
+
+Use the bug-report template. Include the exact command, the inputs, and the receipt hash
+(`manifest_blake3`) + `rosalind --version` — Rosalind's determinism makes most bugs exactly
+reproducible.
+```
+
+- [ ] **Step 2: Write `ARCHITECTURE.md`**
+
+Create `ARCHITECTURE.md`:
+
+```markdown
+# Rosalind Architecture
+
+A map of the codebase, so you know where a change belongs. Companion to
+[`docs/ROADMAP.md`](docs/ROADMAP.md) (where we're going) and
+[`docs/OPEN_PROBLEMS.md`](docs/OPEN_PROBLEMS.md) (the research thesis).
+
+## The kernel
+
+Rosalind's spine is a **bounded, deterministic `PileupColumn` stream**. Variant calling, gVCF, the
+feature substrate, and any ColumnKit analyzer all consume that one stream, so they inherit the same
+memory contract and byte-reproducibility.
+
+## Modules (`src/`)
+
+| Module | Responsibility |
+|---|---|
+| `core/` | Shared types: `Locus`/`ContigSet`/`AlignedRead`, the memory `budget` + `WorkingSet`, the runtime `governor`, the typed `CoreError`. |
+| `io/` | Streaming FASTA/FASTQ (gzip/bgzf auto-detect), BAM/VCF read+write (via rust-htslib), decompression. |
+| `genomics/` | The FM-index: `suffix_array` (SA-IS), `fm_index`/`fm_backing`, `rank_select`, the persisted `index/` (format, mmap `view`), `compressed_dna`, the `bwt_aligner`, deterministic `sort`, and `eval/` (truth-set comparison). |
+| `pileup/` | The streaming pileup `engine` + `column` + read `source` — the bounded kernel. |
+| `call/` | Consumers of the kernel: `germline`/`somatic`/`gvcf` calling, the `features` egress, the `columnkit` SDK, the `plan` estimator, fleet `pack`, the `pipeline`/`whole_genome` drivers. |
+| `provenance/` | The canonical-JSON, self-hashing BLAKE3 run receipt (`RunManifest`). |
+| `util/` | Process RSS (`getrusage`), mmap helpers. |
+
+## Roadmap phases → code
+
+- **A** (streaming pileup + calling): `pileup/`, `call/{germline,somatic,gvcf,pipeline}`.
+- **B** (genome-scale index): `genomics/{suffix_array,fm_index,index}`, `io/bam`.
+- **C** (the memory contract): `core/{budget,governor}`, `call/plan`, `provenance/`, `verify` in `main.rs`.
+- **D** (sublinear-space index *build* — research): `genomics/suffix_array` + a future external-memory constructor. See `docs/OPEN_PROBLEMS.md`.
+- **E** (reach + ML substrate): `call/{features,columnkit}`, `python/`, `genomics/eval`.
+
+## CLI
+
+`src/main.rs` is the CLI surface (`index`, `align`, `sort`, `variants`, `somatic`, `features`, `plan`,
+`pack`, `verify`, `locate`, `eval-*`), thin over the library.
+```
+
+- [ ] **Step 3: Write the bug-report issue template**
+
+Create `.github/ISSUE_TEMPLATE/bug_report.md`:
+
+```markdown
+---
+name: Bug report
+about: A reproducible bug (Rosalind's determinism makes most bugs exactly reproducible)
+title: ""
+labels: bug
+---
+
+**What happened vs. what you expected**
+
+**Exact command**
+```sh
+rosalind ...
+```
+
+**Inputs** (sizes + how to obtain them; a tiny fixture that reproduces it is ideal)
+
+**Receipt** — paste the run's `manifest_blake3` (and `contract_verdict`) from the `.manifest.json`, or
+attach the manifest.
+
+**Environment**
+- `rosalind --version`:
+- OS / arch:
+- Installed via (release tarball / `cargo build` / Action):
+```
+
+- [ ] **Step 4: Verify the docs render + links resolve**
+
+Run: `ls CONTRIBUTING.md ARCHITECTURE.md .github/ISSUE_TEMPLATE/bug_report.md` → all exist.
+Run: `grep -oE "\[.*\]\(([^)]+)\)" CONTRIBUTING.md ARCHITECTURE.md | grep -oE "\(([^)]+)\)" | tr -d '()' | grep -vE "^https?:" | while read p; do [ -e "$p" ] || echo "BROKEN LINK: $p"; done; echo "link check done"`
+Expected: no `BROKEN LINK` lines (relative links resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CONTRIBUTING.md ARCHITECTURE.md .github/ISSUE_TEMPLATE/bug_report.md
+git commit -m "docs: add CONTRIBUTING, ARCHITECTURE, and a deterministic-repro issue template"
+```
+
+---
+
+### Task 4: Publish readiness (dry-run only)
+
+**Files:** none (verification), or small `Cargo.toml` metadata fix if blocked.
+
+- [ ] **Step 1: Dry-run the crates.io package**
+
+Run: `cargo publish --dry-run --allow-dirty 2>&1 | tail -20`
+Expected: `Packaged …` / `Verifying …` with no error. (`--allow-dirty` only because the working tree
+may have uncommitted plan edits; the real publish is NOT run.)
+
+- [ ] **Step 2: If it fails, fix the blocker (only if needed)**
+
+Common blockers + fixes (apply ONLY the one that fires; otherwise skip):
+- "X files … large" or unwanted files in the package → add an `exclude = ["results/", "target/", ".venv/", "tests/golden/", "tests/snapshots/"]` (or the specific dirs named) to `[package]` in `Cargo.toml`.
+- A missing required field → it is already present (`description`/`license`/`repository`); only act on the exact message.
+
+Re-run Step 1 until it packages. **Do NOT run `cargo publish` without `--dry-run`.**
+
+- [ ] **Step 3: Commit (only if Cargo.toml changed)**
+
+```bash
+git add Cargo.toml
+git commit -m "chore(publish): make the crate package cleanly for crates.io (dry-run verified)"
+```
+
+---
+
+## Final verification
+
+- [ ] `cargo test` green; `cargo build --release` no warnings; `cargo fmt --check` clean.
+- [ ] `cargo +<msrv>.0 check --all-targets` passes (MSRV honored).
+- [ ] `cargo publish --dry-run --allow-dirty` packages cleanly.
+- [ ] `grep -rn "space_bounds\|pyproject.toml\|ft.array" README.md python/README.md .github/workflows/ci.yml` → no matches.
+- [ ] CI green on GitHub (incl. the new `msrv` job).

--- a/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
@@ -79,10 +79,15 @@ as-is (it records what was true then).
 
 ### 3.4 Publish readiness
 
-Run `cargo publish --dry-run` and fix anything that blocks packaging (e.g. excluded files, metadata).
-**Do not publish.** The crate metadata is already complete (`description`, `license`, `keywords`,
-`categories`, `repository` in `Cargo.toml`); this step confirms the tarball builds and is a no-op if it
-already passes. The real `cargo publish` stays a maintainer-gated, irreversible action.
+Run `cargo publish --dry-run` to confirm the crate packages cleanly. **Do not publish.**
+
+**Result (2026-06-02):** ✅ packages + verifies cleanly — `Packaged 173 files, 1.8 MiB`, the packaged
+tarball compiles. BUT a **blocking finding**: the crate name **`rosalind` is already taken on
+crates.io** — by an unrelated crate (`github.com/antklim/rosalind`, "solutions of problems published on
+Rosalind.info", currently v0.10.0). So `cargo publish` as `rosalind` is **not possible**; publishing to
+crates.io requires **renaming the published crate** (e.g. `rosalind-genomics`, `rosalind-engine`) in
+`Cargo.toml` `[package].name` — a product/naming decision for the maintainer, deferred out of this
+increment. The GitHub-release + `install.sh` + Action distribution path (already shipped) is unaffected.
 
 ## 4. File-by-file change list
 

--- a/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
@@ -26,27 +26,31 @@ Verified defects (2026-06-02):
 
 **Goals**
 - Fix the three verified doc-drift defects.
-- Declare + **enforce** the MSRV (`rust-version` + a CI job that builds on it).
 - Add `CONTRIBUTING.md`, `ARCHITECTURE.md`, and a deterministic-repro issue template.
 - Confirm the crate **packages** cleanly for crates.io (`cargo publish --dry-run`).
 
 **Non-goals (explicitly deferred — see §6)**
-- The `clippy -D warnings` CI gate (82 pre-existing lints + an MSRV/`div_ceil` tension → its own
-  "1.3b clippy cleanup" increment).
+- The MSRV declaration + CI gate — moved to **1.3b** after the execution finding in §3.1 (the documented
+  1.72 is not buildable; the dep ecosystem forces ≥1.83). It is the same decision as `div_ceil`/clippy.
+- The `clippy -D warnings` CI gate (82 pre-existing lints + the MSRV/`div_ceil` tension → **1.3b**).
 - Actually running `cargo publish` (irreversible; a gated step for the maintainer).
 - PyPI / bioconda / Docker channels (the htslib-linking wall — a separate, later effort).
 - Running the README quickstart verbatim in CI (`release.yml` already smoke-tests `install.sh` on tag).
 
 ## 3. Design
 
-### 3.1 MSRV — declare + enforce
+### 3.1 MSRV — DEFERRED to 1.3b (finding during execution, 2026-06-02)
 
-- `Cargo.toml`: add `rust-version = "1.72"` to `[package]` (the documented MSRV).
-- `.github/workflows/ci.yml`: add an `msrv` job that installs Rust **1.72** and runs `cargo check
-  --all-targets`. This catches any accidental use of a newer-than-1.72 API (the codebase already
-  avoids `u64::div_ceil`, a 1.73 API, via manual arithmetic — consistent with 1.72).
-- Pre-push local check: `rustup install 1.72.0 && cargo +1.72.0 check --all-targets`. If it does not
-  compile on 1.72, **bump `rust-version` to the true minimum** rather than weaken the gate.
+**Original plan:** declare `rust-version = "1.72"` + a CI job enforcing it.
+
+**Finding:** the documented "1.72" MSRV is stale and not buildable. The committed `Cargo.lock` is
+format **v4** (Rust ≥1.78 to parse), and its pinned transitive deps demand an even higher floor that
+*climbs* as you test (`proptest 1.9` + its ICU chain → 1.82; `icu_properties_data 2.1.1` → 1.83; …).
+Supporting a low MSRV would require pinning many transitive deps via `cargo update --precise` — a
+fragile, high-maintenance choice that is a *deliberate dependency policy*, not hygiene. It is also the
+**same decision** as the deferred `div_ceil`/clippy item (`div_ceil` needs 1.73). So MSRV moves to the
+**1.3b** increment (§6), where the dep-pinning-vs-high-MSRV tradeoff is decided on purpose. No
+`rust-version` or MSRV CI job ships in 1.3.
 
 ### 3.2 Doc-drift fixes
 
@@ -84,8 +88,7 @@ already passes. The real `cargo publish` stays a maintainer-gated, irreversible 
 
 | File | Change |
 |---|---|
-| `Cargo.toml` | `rust-version = "1.72"`. |
-| `.github/workflows/ci.yml` | New `msrv` job (Rust 1.72 `cargo check`); repoint the 2 pip-cache keys off `pyproject.toml`. |
+| `.github/workflows/ci.yml` | Repoint the 2 pip-cache keys off `pyproject.toml`. (MSRV job deferred to 1.3b.) |
 | `README.md` | Replace the `space_bounds` test line. |
 | `python/README.md` | `ft.array` → `ft.data`. |
 | `CONTRIBUTING.md` (new) | Contribution guide. |
@@ -94,9 +97,7 @@ already passes. The real `cargo publish` stays a maintainer-gated, irreversible 
 
 ## 5. Testing / verification
 
-- `cargo build --release` + `cargo test` stay green; `cargo fmt --check` clean (no code changes, but
-  `Cargo.toml` edits must not break the build).
-- `cargo +1.72.0 check --all-targets` passes locally (or `rust-version` is bumped to the true min).
+- `cargo build --release` + `cargo test` stay green; `cargo fmt --check` clean.
 - `cargo publish --dry-run` succeeds.
 - The fixed doc commands actually run: `cargo test --test plan_enforce` passes; the python snippet
   field (`ft.data`) matches `python/rosalind.py`.
@@ -104,11 +105,14 @@ already passes. The real `cargo publish` stays a maintainer-gated, irreversible 
 
 ## 6. Deferred follow-up (noted, not in this increment)
 
-**1.3b — clippy cleanup + `-D warnings` gate.** Clear all 82 pre-existing `clippy --all-targets` lints
-(needless-borrow ×17, `manual_div_ceil` ×10, manual-`for` loops, `repeat().take()`, etc.) and add a
-CI clippy gate. The `manual_div_ceil` lints force an MSRV decision: either bump MSRV to **1.73** to use
-`u64::div_ceil` (and replace the manual arithmetic, including in `tests/plan_enforce.rs`), or
-`#[allow(clippy::manual_div_ceil)]` to stay at 1.72. Resolve there, not here.
+**1.3b — MSRV policy + clippy cleanup + `-D warnings` gate.** One increment, because MSRV, `div_ceil`,
+and the clippy lints are the same decision. Scope: (1) pick a real MSRV policy — either accept a recent
+MSRV that the current deps build on (verify by install + `cargo check`), or pin the bleeding-edge
+transitive deps down via `cargo update --precise` to support a lower floor — then declare `rust-version`
+and add an MSRV CI job that actually passes; (2) clear all 82 `clippy --all-targets` lints (needless-borrow
+×17, `manual_div_ceil` ×10 — resolved by the MSRV choice, manual-`for` loops, `repeat().take()`, etc.) and
+add the `-D warnings` CI gate. The `Cargo.lock` is format v4 (≥1.78) and dep MSRVs climb to ≥1.83 — that
+constraint is the starting point.
 
 ## 7. References
 

--- a/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md
@@ -1,0 +1,117 @@
+# Sprint 1.3 — Forkability Hygiene (design)
+
+**Status:** Approved design — 2026-06-02. Increment 1.3 of the engineering roadmap
+([`docs/ROADMAP.md`](../../ROADMAP.md), Sprint 1).
+
+---
+
+## 1. Problem
+
+Rosalind's whole value proposition is forkability (~249 stars, 10+ forks), but a new builder hits
+verified day-one friction: broken commands in the docs, an unenforced MSRV claim, and no contribution
+scaffolding. Cheapest credibility-per-hour in the roadmap.
+
+Verified defects (2026-06-02):
+- `README.md:387` tells you to run `cargo test --test space_bounds` — that test was **deleted** in the
+  dead-code prune. The very first thing a curious forker copy-pastes errors out.
+- `python/README.md:19` prints `ft.array.shape`, but the `FeatureTable` field is **`data`** (`ft.data`)
+  — the documented Python example throws `AttributeError`.
+- `.github/workflows/ci.yml:55,96` key the pip cache on `hashFiles('pyproject.toml')`, but that file
+  was **removed** — `hashFiles` of a missing path is empty, so the key never varies (a silently broken,
+  always-cold cache).
+- `Cargo.toml` has **no `rust-version`** — the MSRV is asserted in prose but not declared or enforced.
+- No `CONTRIBUTING.md`, `ARCHITECTURE.md`, or issue template — a contributor has no paved road.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Fix the three verified doc-drift defects.
+- Declare + **enforce** the MSRV (`rust-version` + a CI job that builds on it).
+- Add `CONTRIBUTING.md`, `ARCHITECTURE.md`, and a deterministic-repro issue template.
+- Confirm the crate **packages** cleanly for crates.io (`cargo publish --dry-run`).
+
+**Non-goals (explicitly deferred — see §6)**
+- The `clippy -D warnings` CI gate (82 pre-existing lints + an MSRV/`div_ceil` tension → its own
+  "1.3b clippy cleanup" increment).
+- Actually running `cargo publish` (irreversible; a gated step for the maintainer).
+- PyPI / bioconda / Docker channels (the htslib-linking wall — a separate, later effort).
+- Running the README quickstart verbatim in CI (`release.yml` already smoke-tests `install.sh` on tag).
+
+## 3. Design
+
+### 3.1 MSRV — declare + enforce
+
+- `Cargo.toml`: add `rust-version = "1.72"` to `[package]` (the documented MSRV).
+- `.github/workflows/ci.yml`: add an `msrv` job that installs Rust **1.72** and runs `cargo check
+  --all-targets`. This catches any accidental use of a newer-than-1.72 API (the codebase already
+  avoids `u64::div_ceil`, a 1.73 API, via manual arithmetic — consistent with 1.72).
+- Pre-push local check: `rustup install 1.72.0 && cargo +1.72.0 check --all-targets`. If it does not
+  compile on 1.72, **bump `rust-version` to the true minimum** rather than weaken the gate.
+
+### 3.2 Doc-drift fixes
+
+| File:line | Now | Fix |
+|---|---|---|
+| `README.md:387` | `cargo test --test space_bounds … streaming evaluator` | `cargo test --test plan_enforce      # the memory contract: plan / --enforce / verify / governor` |
+| `python/README.md:19` | `print(ft.array.shape)` | `print(ft.data.shape)` |
+| `ci.yml:55,96` | `hashFiles('pyproject.toml')` | `hashFiles('.github/workflows/ci.yml')` (busts the cache when the install step changes; an existing path) |
+
+The historical reference in `docs/superpowers/plans/2026-06-01-phase-c1-…md` is an archived plan — left
+as-is (it records what was true then).
+
+### 3.3 Forkability scaffolding
+
+- **`CONTRIBUTING.md`** — build/test/fmt commands; the project's `brainstorm → spec → plan → TDD`
+  increment flow (with pointers to `docs/superpowers/`); the **two load-bearing invariants** a change
+  must preserve (byte-identical determinism per `docs/determinism.md`; the memory contract per
+  `CONTRACT.md` — `predicted ≥ realized`, the governor, the self-hashing receipt); the "implement one
+  `ColumnAnalyzer`" extension path; branch/PR conventions (a branch per increment, PR for review).
+- **`ARCHITECTURE.md`** — a one-screen map of `src/` modules to responsibilities (`core`, `io`,
+  `genomics`, `pileup`, `call`, `provenance`, `util`) and the roadmap phases (A–E) to where they live,
+  so a contributor knows where a change belongs. Links `docs/ROADMAP.md` + `docs/OPEN_PROBLEMS.md`.
+- **`.github/ISSUE_TEMPLATE/bug_report.md`** — a deterministic-repro template: exact command + inputs,
+  expected vs actual, the **receipt hash** (`manifest_blake3`) + `rosalind --version`, OS/arch. Steers
+  reports toward the reproducible artifacts the engine already produces.
+
+### 3.4 Publish readiness
+
+Run `cargo publish --dry-run` and fix anything that blocks packaging (e.g. excluded files, metadata).
+**Do not publish.** The crate metadata is already complete (`description`, `license`, `keywords`,
+`categories`, `repository` in `Cargo.toml`); this step confirms the tarball builds and is a no-op if it
+already passes. The real `cargo publish` stays a maintainer-gated, irreversible action.
+
+## 4. File-by-file change list
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | `rust-version = "1.72"`. |
+| `.github/workflows/ci.yml` | New `msrv` job (Rust 1.72 `cargo check`); repoint the 2 pip-cache keys off `pyproject.toml`. |
+| `README.md` | Replace the `space_bounds` test line. |
+| `python/README.md` | `ft.array` → `ft.data`. |
+| `CONTRIBUTING.md` (new) | Contribution guide. |
+| `ARCHITECTURE.md` (new) | Module + phase map. |
+| `.github/ISSUE_TEMPLATE/bug_report.md` (new) | Deterministic-repro bug template. |
+
+## 5. Testing / verification
+
+- `cargo build --release` + `cargo test` stay green; `cargo fmt --check` clean (no code changes, but
+  `Cargo.toml` edits must not break the build).
+- `cargo +1.72.0 check --all-targets` passes locally (or `rust-version` is bumped to the true min).
+- `cargo publish --dry-run` succeeds.
+- The fixed doc commands actually run: `cargo test --test plan_enforce` passes; the python snippet
+  field (`ft.data`) matches `python/rosalind.py`.
+- CI green on GitHub (incl. the new `msrv` job).
+
+## 6. Deferred follow-up (noted, not in this increment)
+
+**1.3b — clippy cleanup + `-D warnings` gate.** Clear all 82 pre-existing `clippy --all-targets` lints
+(needless-borrow ×17, `manual_div_ceil` ×10, manual-`for` loops, `repeat().take()`, etc.) and add a
+CI clippy gate. The `manual_div_ceil` lints force an MSRV decision: either bump MSRV to **1.73** to use
+`u64::div_ceil` (and replace the manual arithmetic, including in `tests/plan_enforce.rs`), or
+`#[allow(clippy::manual_div_ceil)]` to stay at 1.72. Resolve there, not here.
+
+## 7. References
+
+- `README.md:387`, `python/README.md:19`, `.github/workflows/ci.yml:55,96` — the verified defects.
+- `Cargo.toml` — metadata (publish-ready) + the missing `rust-version`.
+- `docs/ROADMAP.md` Sprint 1 (QW-1) — this increment.

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ from rosalind import features
 # Streams the whole-genome feature table to disk in bounded memory, then loads it.
 ft = features("ref.idx", "sorted.bam", binary="target/release/rosalind")
 print(ft.columns)            # contig, pos, ref, depth, A/C/G/T counts, strand, mean bq/mapq, …
-print(ft.array.shape)        # one row per callable locus
+print(ft.data.shape)         # one row per callable locus
 ```
 
 Because `rosalind features` is byte-identical run-to-run with a BLAKE3 receipt, the loaded


### PR DESCRIPTION
## Summary

Repairs the verified day-one friction a new forker hits, and adds the contribution scaffolding. Two roadmap items (MSRV, crates.io publish) surfaced real blockers during execution and are **honestly deferred with documented findings** rather than shipped wrong.

**Delivered:**
- **Doc-drift fixes (3, all verified to still exist):** `README.md` referenced the deleted `cargo test --test space_bounds` → repointed to `plan_enforce`; `python/README.md` printed `ft.array.shape` → `ft.data.shape` (the real `FeatureTable` field); CI pip-cache keyed on the removed `pyproject.toml` → repointed to an existing path.
- **Forkability scaffolding:** `CONTRIBUTING.md` (build/test, the two load-bearing invariants — determinism + the memory contract, the brainstorm→spec→plan→TDD flow, the ColumnKit extension path), `ARCHITECTURE.md` (a `src/` module + roadmap-phase map), and a deterministic-repro bug-report template.
- **Landed `docs/ROADMAP.md`** (previously stranded on an unmerged branch) — `ARCHITECTURE.md` and the already-merged 1.1/1.2 specs reference it, so this resolves those dangling links.

**Deferred with findings (see the spec):**
- **MSRV → 1.3b.** The documented "1.72" is stale/unbuildable: `Cargo.lock` is format **v4** (needs rustc ≥1.78) and the pinned transitive deps climb the floor to **≥1.83** (proptest's ICU chain, `icu_properties_data`). A low MSRV needs deliberate `cargo update --precise` dep-pinning — the same decision as the deferred `div_ceil`/clippy work, so they merge into one **1.3b** increment.
- **crates.io publish → maintainer decision.** `cargo publish --dry-run` packages cleanly (173 files, verifies), but the name **`rosalind` is already taken** on crates.io (unrelated `antklim/rosalind`, v0.10.0). Publishing needs a crate rename (e.g. `rosalind-genomics`) — a naming call. The GitHub-release/`install.sh`/Action distribution path is unaffected.

Reviewed design + plan: `docs/superpowers/specs/2026-06-02-sprint1-3-forkability-hygiene-design.md`, `docs/superpowers/plans/2026-06-02-sprint1-3-forkability-hygiene.md`. Roadmap Sprint 1, QW-1.

## Test Plan

- [x] The fixed doc commands resolve: `cargo test --test plan_enforce` passes; `ft.data` exists on `FeatureTable`; no stale `space_bounds`/`pyproject.toml`/`ft.array` refs remain.
- [x] All relative links in CONTRIBUTING/ARCHITECTURE resolve (incl. `docs/ROADMAP.md`, now in-tree).
- [x] Full suite green (25 sections), 0 warnings, `cargo fmt --check` clean (no production code changed).
- [x] `cargo publish --dry-run` packages cleanly.

> Note: this PR makes `docs/ROADMAP.md` live on main, so the separate `rosalind/docs-roadmap` branch becomes redundant and can be deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)