### PR TITLE
ci: MSRV 1.83 + clear 82 clippy lints + -D warnings gate (Sprint 1.3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,50 @@ jobs:
           budget-mb: 4096
           binary-path: target/release/rosalind
           output: examples/data/illumina_toy/action.vcf
+
+  msrv:
+    name: MSRV (1.83)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.83.0
+          profile: minimal
+          override: true
+      - name: cargo check on the declared MSRV
+        run: cargo check --all-targets
+
+  clippy:
+    name: Clippy (-D warnings)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+          override: true
+      - name: Clippy as a gate
+        run: cargo clippy --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rosalind"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.83"
 authors = ["Logan Nye <logannye@users.noreply.github.com>"]
 description = "Deterministic, low-memory genomics engine: memory as a verifiable contract (declare → predict → honor → verify) for alignment and variant calling"
 repository = "https://github.com/logannye/rosalind"

--- a/docs/superpowers/plans/2026-06-02-sprint1-3b-msrv-clippy.md
+++ b/docs/superpowers/plans/2026-06-02-sprint1-3b-msrv-clippy.md
@@ -1,0 +1,163 @@
+# Sprint 1.3b — MSRV + Clippy Gate: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax. Run INLINE — never delegate `cargo clippy --fix` / mutating git to a subagent (shared-tree hazard).
+
+**Goal:** Declare + enforce the real MSRV (1.83) and clear all 82 `clippy --all-targets` lints behind a `-D warnings` CI gate — behavior-preserving.
+
+**Architecture:** Mechanical lint cleanup (tool-assisted) + two CI jobs. The full test suite staying green is the proof that every fix is a semantic no-op.
+
+**Tech Stack:** `cargo clippy`/`clippy --fix`, Cargo metadata, GitHub Actions YAML, Rust 1.83 (`u64::div_ceil` / `is_multiple_of` now available).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-sprint1-3b-msrv-clippy-design.md`
+
+---
+
+### Task 1: Clear the 82 clippy lints (behavior-preserving)
+
+**Files:** `src/**`, `tests/**`, `examples/**` (small mechanical edits across many files)
+
+- [ ] **Step 1: Snapshot the baseline**
+
+Run: `cargo clippy --all-targets 2>&1 | grep -cE "^warning:"`
+Expected: `82` (the baseline to drive to 0).
+
+- [ ] **Step 2: Auto-fix the mechanically-fixable lints**
+
+Run: `cargo clippy --fix --all-targets --allow-dirty --allow-staged 2>&1 | tail -5`
+This resolves the machine-applicable lints (needless_borrow, useless_vec, bool_assert_comparison,
+unnecessary_lazy_evaluations, ptr_arg, unused_enumerate_index, manual_contains, many of the loop/repeat
+ones, and — at MSRV 1.83 — `manual_div_ceil` and `manual_is_multiple_of`).
+
+- [ ] **Step 3: Verify behavior is unchanged after auto-fix**
+
+Run: `cargo test 2>&1 | grep -iE "FAILED" || echo "no failures"`
+Expected: `no failures`. **If any test fails, the auto-fix changed behavior — `git diff` the offending
+file, revert that specific hunk, and resolve that lint by hand instead.**
+
+- [ ] **Step 4: List the remaining lints**
+
+Run: `cargo clippy --all-targets 2>&1 | grep -E "^warning:" | sort | uniq -c | sort -rn`
+These are the ones `--fix` could not apply automatically — expected to be the two `too_many_arguments`
+and the one `type_complexity`, plus any loop/repeat rewrites clippy declined.
+
+- [ ] **Step 5: Resolve the `too_many_arguments` lints with a scoped allow**
+
+For each function clippy flags (streaming drivers — a bounded source + region + params + sinks
+legitimately need the arity), add directly above the `fn`:
+
+```rust
+#[allow(clippy::too_many_arguments)] // a bounded streaming driver: source + region + params + sinks
+```
+
+(`gvcf.rs::stream_gvcf_region` already uses this pattern — match it.)
+
+- [ ] **Step 6: Resolve `type_complexity`**
+
+For the flagged complex type (a `Result<(WorkingSet, SkipCounts), CoreError>`-style return), prefer a
+local `type` alias near the function if it reads well, e.g.:
+
+```rust
+/// (max working set, skip counts) — the bounded-run telemetry a driver returns.
+type DriveOutcome = (crate::core::WorkingSet, crate::pileup::SkipCounts);
+```
+
+…and use it in the signature. If the alias hurts readability at the single call site, instead add a
+scoped `#[allow(clippy::type_complexity)]` above the function with a one-line rationale. Pick one.
+
+- [ ] **Step 7: Resolve any remaining hand-fixable lints**
+
+For each still-listed lint, apply the idiomatic fix clippy suggests (it prints the exact `help:`
+rewrite). Common remainders: `needless_range_loop` → iterate the slice / `enumerate`; `manual_repeat_n`
+→ `std::iter::repeat_n(x, n)`; manual `str::repeat` → `"x".repeat(n)`. Keep each edit behavior-identical.
+
+- [ ] **Step 8: Drive to zero + verify green**
+
+Run: `cargo clippy --all-targets 2>&1 | grep -cE "^warning:"` → `0`.
+Run: `cargo test 2>&1 | grep -iE "FAILED" || echo "no failures"` → `no failures`.
+Run: `cargo build --release 2>&1 | grep -i warning || echo "no warnings"` → `no warnings`.
+Run: `cargo fmt && cargo fmt --check && echo "fmt clean"` → `fmt clean`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "style(clippy): clear all 82 clippy lints (behavior-preserving; div_ceil/is_multiple_of via MSRV 1.83)"
+```
+
+---
+
+### Task 2: Declare the MSRV + add the CI gates
+
+**Files:** `Cargo.toml`, `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Declare the MSRV**
+
+In `Cargo.toml` `[package]`, add after `edition = "2021"`:
+
+```toml
+rust-version = "1.83"
+```
+
+- [ ] **Step 2: Verify the crate builds on the declared MSRV**
+
+Run: `cargo +1.83.0 check --all-targets 2>&1 | tail -3`
+Expected: `Finished` (no errors). If a clippy fix in Task 1 used a >1.83 API, this catches it — fix to
+a 1.83-compatible form (do NOT bump the MSRV to paper over it).
+
+- [ ] **Step 3: Add the `msrv` + `clippy` CI jobs**
+
+In `.github/workflows/ci.yml`, append under `jobs:` (match the existing jobs' `actions-rs/toolchain@v1`
+structure):
+
+```yaml
+  msrv:
+    name: MSRV (1.83)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.83.0
+          profile: minimal
+          override: true
+      - name: cargo check on the declared MSRV
+        run: cargo check --all-targets
+
+  clippy:
+    name: Clippy (-D warnings)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+          override: true
+      - name: clippy as a gate
+        run: cargo clippy --all-targets -- -D warnings
+```
+
+- [ ] **Step 4: Verify the gate command passes locally + YAML parses**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -3`
+Expected: `Finished` (the gate passes — 0 warnings became 0 errors).
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock .github/workflows/ci.yml
+git commit -m "ci: declare MSRV 1.83 + enforce it and a clippy -D warnings gate"
+```
+
+---
+
+## Final verification
+
+- [ ] `cargo clippy --all-targets -- -D warnings` → clean.
+- [ ] `cargo test` → all sections green; `cargo build --release` (+ `--examples`) → 0 warnings; `cargo fmt --check` clean.
+- [ ] `cargo +1.83.0 check --all-targets` → builds.
+- [ ] CI green on GitHub incl. the new `msrv` + `clippy` jobs.
+- [ ] Public API unchanged (the lint fixes are internal; confirm no exported signature changed — `git diff main -- src/lib.rs src/call/mod.rs` is empty or only internal).

--- a/docs/superpowers/specs/2026-06-02-sprint1-3b-msrv-clippy-design.md
+++ b/docs/superpowers/specs/2026-06-02-sprint1-3b-msrv-clippy-design.md
@@ -1,0 +1,94 @@
+# Sprint 1.3b — MSRV + Clippy Gate (design)
+
+**Status:** Approved design — 2026-06-02. Increment 1.3b of the engineering roadmap
+([`docs/ROADMAP.md`](../../ROADMAP.md), Sprint 1). Picks up the MSRV + clippy items deferred from 1.3.
+
+---
+
+## 1. Problem
+
+Two forkability defects deferred from 1.3, resolved together because they are one decision:
+
+1. **No enforced MSRV.** `Cargo.toml` has no `rust-version`; the prose "1.72" claim is false (the
+   committed `Cargo.lock` is format v4 and the dep tree — `url`→`rust-htslib` ICU chain, `proptest` —
+   requires rustc **1.83**). A forker on an older toolchain gets an inscrutable failure.
+2. **82 pre-existing `clippy --all-targets` lints** and no clippy CI gate, so the backlog grows
+   unchecked and a contributor's PR can add more.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Declare the **real, verified MSRV (1.83)** and enforce it with a CI job.
+- Clear **all 82** `clippy --all-targets` lints — behavior-preserving.
+- Add a `clippy … -D warnings` CI gate so the backlog cannot regrow.
+
+**Non-goals**
+- Any behavior change. Every lint fix is a semantic no-op; the full test suite staying byte-green is
+  the guard (a clippy fix that changes a test result is reverted, not forced).
+- Pinning deps down for a lower MSRV (decided: accept 1.83 — zero-maintenance vs a fragile
+  `cargo update --precise` treadmill for an audience that runs recent Rust).
+- Bumping the crate version or touching the public API.
+
+## 3. Design
+
+### 3.1 MSRV = 1.83
+
+- `Cargo.toml`: `rust-version = "1.83"` in `[package]`. **Verified**: `cargo +1.83.0 check
+  --all-targets` builds the lib, bin, and tests against the committed v4 lock.
+- `.github/workflows/ci.yml`: a new `msrv` job — `actions-rs/toolchain@v1` pinned to `1.83.0`, then
+  `cargo check --all-targets` (matches the existing jobs' toolchain action). Catches any future use of
+  a post-1.83 API.
+
+### 3.2 Clearing the 82 clippy lints
+
+Resolved by category (counts from `cargo clippy --all-targets`):
+
+| Lint | × | Resolution |
+|---|---|---|
+| `manual_div_ceil` | 10 | Replace `(x + n - 1) / n` with `x.div_ceil(n)` — now available at MSRV 1.83 (was the blocker at 1.72). |
+| `needless_borrow` | 17 | Drop the redundant `&` (`cargo clippy --fix`). |
+| `needless_range_loop` (manual `for`) | 6 | Iterate directly / `enumerate` (`--fix` where safe, else manual). |
+| `manual_repeat_n` / `repeat().take()` / manual `str::repeat` | 8 | `std::iter::repeat_n` / `"x".repeat(n)`. |
+| `useless_vec` | 2 | `[…]` array instead of `vec![…]`. |
+| `bool_assert_comparison` | 2 | `assert!(x)` instead of `assert_eq!(x, true)`. |
+| `unnecessary_lazy_evaluations` (`unwrap_or_else(\|\| None-ish)`) | 2 | `unwrap_or(…)`. |
+| `manual_is_multiple_of` | 2 | `x.is_multiple_of(n)` (available at 1.83). |
+| `ptr_arg` (`&PathBuf`→`&Path`) | 1 | Take `&Path`. |
+| `unused_enumerate_index` | 1 | Drop `.enumerate()`. |
+| `manual_contains` (`iter().any` vs `contains`) | 1 | `contains`. |
+| `too_many_arguments` (8/7, 11/7) | 2 | `#[allow(clippy::too_many_arguments)]` + rationale on the two **streaming-driver** fns (a bounded source + region + params + sinks legitimately needs them; already the pattern in `gvcf.rs`). |
+| `type_complexity` | 1 | A `type` alias for the complex `Result<…>`, or a scoped `#[allow]` if the alias hurts readability. |
+
+**Method:** run `cargo clippy --fix --all-targets --allow-dirty` for the mechanically-fixable lints,
+then hand-resolve the remainder (the `div_ceil`/`is_multiple_of` rewrites, the two `#[allow]`s, the type
+alias). After each pass: `cargo test` (behavior unchanged) + `cargo clippy --all-targets` (0 warnings) +
+`cargo fmt`. (Run inline — `cargo clippy --fix` mutating a shared tree is fine for the maintainer, but
+must never be delegated to a subagent per the shared-tree hazard.)
+
+### 3.3 The `-D warnings` CI gate
+
+Add a `clippy` job to `ci.yml`: `actions-rs/toolchain@v1` (stable, `components: clippy`), then
+`cargo clippy --all-targets --all-features -- -D warnings`. Once the 82 are cleared this stays green and
+fails any PR that introduces a new lint.
+
+## 4. File-by-file change list
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | `rust-version = "1.83"`. |
+| `.github/workflows/ci.yml` | New `msrv` job (1.83 `cargo check`); new `clippy` job (`-D warnings`). |
+| `src/**`, `tests/**`, `examples/**` | The behavior-preserving lint fixes (many files, small mechanical edits; the test suite is the guard). |
+
+## 5. Testing / verification
+
+- `cargo clippy --all-targets -- -D warnings` → **clean** (the exit criterion).
+- `cargo test` → all sections green (behavior preserved by every fix).
+- `cargo build --release` (+ examples) → 0 warnings; `cargo fmt --check` clean.
+- `cargo +1.83.0 check --all-targets` → builds (MSRV honored).
+- CI green on GitHub incl. the new `msrv` + `clippy` jobs.
+
+## 6. References
+
+- The 1.3 spec §3.1/§6 — where MSRV + clippy were deferred, with the dep-floor finding.
+- `cargo clippy --all-targets` (2026-06-02) — the 82-lint inventory in §3.2.
+- `cargo +1.83.0 check --all-targets` — the verified MSRV.

--- a/examples/basic_alignment.rs
+++ b/examples/basic_alignment.rs
@@ -6,7 +6,7 @@ fn main() -> anyhow::Result<()> {
     // Minimal reference contig (re-used in README quick start).
     let reference = include_bytes!("data/ref.fa")
         .split(|&b| b == b'\n')
-        .filter(|line| !line.starts_with(&[b'>']))
+        .filter(|line| !line.starts_with(b">"))
         .flatten()
         .copied()
         .collect::<Vec<u8>>();

--- a/examples/verify_installation.rs
+++ b/examples/verify_installation.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn ensure_data_exists(dir: &PathBuf) -> Result<()> {
+fn ensure_data_exists(dir: &Path) -> Result<()> {
     for name in ["ref.fa", "reads.fastq"] {
         let path = dir.join(name);
         if !path.exists() {

--- a/src/call/pipeline.rs
+++ b/src/call/pipeline.rs
@@ -45,6 +45,7 @@ pub fn call_germline_region_streaming<S: ReadSource>(
 /// Like [`call_germline_region`], but also returns the maximum pileup-engine
 /// working set observed during the pass. Collects sites into a `Vec` via
 /// [`call_germline_region_streaming`].
+#[allow(clippy::type_complexity)] // (emitted sites, working set) — a clear ad-hoc pair, not worth a named type
 pub fn call_germline_region_tracked<S: ReadSource>(
     source: S,
     reference: Arc<[u8]>,

--- a/src/call/whole_genome.rs
+++ b/src/call/whole_genome.rs
@@ -231,7 +231,7 @@ mod tests {
         let run = |n: usize| -> u64 {
             // n reads, each 100bp, all starting at pos 0 (depth would be n without
             // the cap; capped at 8).
-            let reads: Vec<AlignedRead> = (0..n).map(|_| read_at(0, 0, &vec![b'C'; 100])).collect();
+            let reads: Vec<AlignedRead> = (0..n).map(|_| read_at(0, 0, &[b'C'; 100])).collect();
             call_germline_whole_genome(
                 SliceSource::new(reads),
                 &rv,

--- a/src/genomics/block_alignment.rs
+++ b/src/genomics/block_alignment.rs
@@ -136,7 +136,7 @@ pub fn align_within_block(
     let mut processed = 0usize;
     let mut exhausted = false;
 
-    for (_offset, &symbol) in workspace.iter().take(read_segment.len()).enumerate() {
+    for &symbol in workspace.iter().take(read_segment.len()) {
         let base_code = match BaseCode::from_ascii(symbol) {
             Some(code) => code,
             None => {

--- a/src/genomics/bwt_aligner.rs
+++ b/src/genomics/bwt_aligner.rs
@@ -134,7 +134,7 @@ impl BWTAligner {
         if read_upper.len() >= self.seed_cfg.k {
             for read_pos in (0..=read_upper.len() - self.seed_cfg.k).step_by(self.seed_cfg.stride) {
                 let kmer = &read_upper[read_pos..read_pos + self.seed_cfg.k];
-                if kmer.iter().any(|&b| b == b'N') {
+                if kmer.contains(&b'N') {
                     continue;
                 }
                 let k_interval = self.fm_index.backward_search(kmer);

--- a/src/genomics/compressed_dna.rs
+++ b/src/genomics/compressed_dna.rs
@@ -45,6 +45,11 @@ impl AmbiguityMask {
         self.len
     }
 
+    /// Whether the mask tracks no positions.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Access the underlying bit words (useful for serialization).
     pub fn bits(&self) -> &[u64] {
         &self.bits
@@ -80,8 +85,8 @@ impl CompressedDNA {
         let mut ambiguity = AmbiguityMask::new(len);
 
         for (idx, &base) in sequence.iter().enumerate() {
-            let (code, is_ambiguous) = encode_base(base)
-                .ok_or_else(|| CompressedDNAError::UnsupportedBase(base as char, idx))?;
+            let (code, is_ambiguous) =
+                encode_base(base).ok_or(CompressedDNAError::UnsupportedBase(base as char, idx))?;
 
             if is_ambiguous {
                 ambiguity.set(idx);
@@ -168,8 +173,8 @@ impl CompressedDNA {
             self.len
         );
 
-        for idx in 0..self.len {
-            out[idx] = if self.ambiguity.test(idx) {
+        for (idx, slot) in out.iter_mut().take(self.len).enumerate() {
+            *slot = if self.ambiguity.test(idx) {
                 b'N'
             } else {
                 let (word_idx, bit_shift) = word_position(idx);
@@ -182,8 +187,8 @@ impl CompressedDNA {
     /// Append a single base to the compressed sequence.
     pub fn push(&mut self, base: u8) -> Result<(), CompressedDNAError> {
         let idx = self.len;
-        let (code, is_ambiguous) = encode_base(base)
-            .ok_or_else(|| CompressedDNAError::UnsupportedBase(base as char, idx))?;
+        let (code, is_ambiguous) =
+            encode_base(base).ok_or(CompressedDNAError::UnsupportedBase(base as char, idx))?;
 
         let (word_idx, bit_shift) = word_position(idx);
         if word_idx >= self.data.len() {
@@ -274,7 +279,7 @@ fn words_for_len(len: usize) -> usize {
     if len == 0 {
         0
     } else {
-        (len + BASES_PER_WORD - 1) / BASES_PER_WORD
+        len.div_ceil(BASES_PER_WORD)
     }
 }
 

--- a/src/genomics/eval/bed.rs
+++ b/src/genomics/eval/bed.rs
@@ -33,6 +33,7 @@ impl BedIndex {
     }
 
     /// Parse and index a BED file given as a string.
+    #[allow(clippy::should_implement_trait)] // inherent parser; a `FromStr` impl would force callers to import the trait
     pub fn from_str(contents: &str) -> Result<Self, BedParseError> {
         let mut per_chrom: BTreeMap<String, Vec<Range<u32>>> = BTreeMap::new();
 

--- a/src/genomics/fm_index.rs
+++ b/src/genomics/fm_index.rs
@@ -505,13 +505,13 @@ fn build_bwt_and_sa_samples(
     }
 
     let rate = sa_sample_rate.max(1);
+    // `% == 0` (not `usize::is_multiple_of`, stable only in 1.87) to hold MSRV 1.83.
+    #[allow(clippy::manual_is_multiple_of)]
     let sampled = SampledSuffixArray::from_sorted_samples(
         text.len(),
         rate,
         sa.iter().enumerate().filter_map(|(bwt_idx, &sa_idx)| {
-            (sa_idx as usize)
-                .is_multiple_of(rate)
-                .then_some((bwt_idx, sa_idx))
+            ((sa_idx as usize) % rate == 0).then_some((bwt_idx, sa_idx))
         }),
     );
 

--- a/src/genomics/fm_index.rs
+++ b/src/genomics/fm_index.rs
@@ -283,6 +283,11 @@ impl BlockedFMIndex {
         self.bwt_len
     }
 
+    /// Whether the BWT is empty (no bases indexed).
+    pub fn is_empty(&self) -> bool {
+        self.bwt_len == 0
+    }
+
     /// Block size used for the FM-index partitioning.
     pub fn block_size(&self) -> usize {
         self.block_size
@@ -504,7 +509,9 @@ fn build_bwt_and_sa_samples(
         text.len(),
         rate,
         sa.iter().enumerate().filter_map(|(bwt_idx, &sa_idx)| {
-            ((sa_idx as usize) % rate == 0).then_some((bwt_idx, sa_idx))
+            (sa_idx as usize)
+                .is_multiple_of(rate)
+                .then_some((bwt_idx, sa_idx))
         }),
     );
 
@@ -696,12 +703,12 @@ mod tests {
             assert_eq!(block.end() - block.start(), block.bwt().len());
             // Each of the 5 occ rank bitvectors has ceil(n/64) words.
             let n = block.bwt().len();
-            let expected_words = (n + 63) / 64;
+            let expected_words = n.div_ceil(64);
             for bv in block.occ().bitvectors() {
                 assert_eq!(bv.len(), expected_words);
             }
             // Each of the 5 occ superblock arrays has ceil(n/stride) + 1 entries.
-            let expected_sb = (n + block.occ().stride() - 1) / block.occ().stride() + 1;
+            let expected_sb = n.div_ceil(block.occ().stride()) + 1;
             for sb in block.occ().superblocks() {
                 assert_eq!(sb.len(), expected_sb);
             }
@@ -710,7 +717,7 @@ mod tests {
 
         // The sampled SA exposes marks/superblocks/values.
         let s = index.sampled();
-        assert_eq!(s.marks().len(), (s.len() + 63) / 64);
+        assert_eq!(s.marks().len(), s.len().div_ceil(64));
         assert_eq!(s.values().len(), s.num_samples());
         assert!(!s.superblocks().is_empty());
     }

--- a/src/genomics/index/io.rs
+++ b/src/genomics/index/io.rs
@@ -319,7 +319,7 @@ fn block_record_len(block: &crate::genomics::BWTBlock) -> u64 {
         + 4 * 5; // totals[5]
                  // Round up to a multiple of 8. `(body + 7) / 8 * 8`, not `body.div_ceil(8) * 8`
                  // (div_ceil is Rust 1.73+; MSRV is 1.72).
-    (body + 7) / 8 * 8
+    body.div_ceil(8) * 8
 }
 
 /// Write one block record: 8 header fields (`start,end,sentinel_offset,stride,
@@ -369,7 +369,7 @@ fn write_block_record(
         + 4 * 5 * occ_superblock_len
         + 4 * 5;
     // Pad to a multiple of 8. `(body + 7) / 8 * 8`, not `div_ceil` (Rust 1.73+; MSRV 1.72).
-    let pad = ((body + 7) / 8 * 8 - body) as usize;
+    let pad = (body.div_ceil(8) * 8 - body) as usize;
     if pad != 0 {
         w.write_all(&[0u8; 8][..pad])?;
     }
@@ -856,8 +856,8 @@ mod tests {
 
         assert_eq!(rv.len(), reference.len());
         assert!(!rv.is_empty());
-        for i in 0..rv.len() {
-            assert_eq!(rv.base_at(i), reference[i], "base_at mismatch @ {i}");
+        for (i, &expected) in reference.iter().enumerate() {
+            assert_eq!(rv.base_at(i), expected, "base_at mismatch @ {i}");
         }
 
         let mut buf = Vec::new();

--- a/src/genomics/index/view.rs
+++ b/src/genomics/index/view.rs
@@ -425,7 +425,7 @@ fn validate_block_records(blocks: &[u8], block_dir: &[u64]) -> Result<(), IndexI
         // corrupt non-aligned offset here at `open` rather than letting `block()`
         // hit `.expect("aligned")` at query time (the integrity contract: a corrupt
         // index is rejected up front, never crashed-on later).
-        if rec % 8 != 0 {
+        if !rec.is_multiple_of(8) {
             return Err(IndexIoError::Invalid(
                 "block record offset is not 8-aligned".to_string(),
             ));

--- a/src/genomics/index/view.rs
+++ b/src/genomics/index/view.rs
@@ -425,7 +425,9 @@ fn validate_block_records(blocks: &[u8], block_dir: &[u64]) -> Result<(), IndexI
         // corrupt non-aligned offset here at `open` rather than letting `block()`
         // hit `.expect("aligned")` at query time (the integrity contract: a corrupt
         // index is rejected up front, never crashed-on later).
-        if !rec.is_multiple_of(8) {
+        // `% != 0` (not `usize::is_multiple_of`, stable only in 1.87) to hold MSRV 1.83.
+        #[allow(clippy::manual_is_multiple_of)]
+        if rec % 8 != 0 {
             return Err(IndexIoError::Invalid(
                 "block record offset is not 8-aligned".to_string(),
             ));

--- a/src/genomics/io.rs
+++ b/src/genomics/io.rs
@@ -13,19 +13,19 @@ pub fn create_bam_writer<P: AsRef<Path>>(
     let mut header = Header::new();
 
     let mut hd = HeaderRecord::new(b"HD");
-    hd.push_tag(b"VN", &"1.6");
-    hd.push_tag(b"SO", &"unknown");
+    hd.push_tag(b"VN", "1.6");
+    hd.push_tag(b"SO", "unknown");
     header.push_record(&hd);
 
     let mut sq = HeaderRecord::new(b"SQ");
     sq.push_tag(b"SN", reference_name);
-    sq.push_tag(b"LN", &(reference_length as i64));
+    sq.push_tag(b"LN", reference_length as i64);
     header.push_record(&sq);
 
     let mut pg = HeaderRecord::new(b"PG");
-    pg.push_tag(b"ID", &"rosalind");
-    pg.push_tag(b"PN", &"rosalind");
-    pg.push_tag(b"VN", &env!("CARGO_PKG_VERSION"));
+    pg.push_tag(b"ID", "rosalind");
+    pg.push_tag(b"PN", "rosalind");
+    pg.push_tag(b"VN", env!("CARGO_PKG_VERSION"));
     header.push_record(&pg);
 
     let writer = bam::Writer::from_path(output_path, &header, bam::Format::Bam)?;

--- a/src/genomics/rank_select.rs
+++ b/src/genomics/rank_select.rs
@@ -103,11 +103,11 @@ impl RankSelectIndex {
         }
 
         // Build superblock prefix sums for each base.
-        let num_superblocks = (len + stride - 1) / stride;
+        let num_superblocks = len.div_ceil(stride);
         let mut superblocks: [Vec<u32>; ALPHABET_SIZE] =
             std::array::from_fn(|_| Vec::with_capacity(num_superblocks + 1));
-        for b in 0..ALPHABET_SIZE {
-            superblocks[b].push(0);
+        for sb_prefix in superblocks.iter_mut() {
+            sb_prefix.push(0);
         }
 
         for sb in 0..num_superblocks {
@@ -182,10 +182,10 @@ impl RankSelectIndex {
         let within_start = sb * self.stride;
 
         let mut out = [0u32; ALPHABET_SIZE];
-        for b in 0..ALPHABET_SIZE {
+        for (b, slot) in out.iter_mut().enumerate() {
             let prefix = self.superblocks[b][sb];
             let within = popcount_range(&self.bitvectors[b], within_start, bounded);
-            out[b] = prefix + within;
+            *slot = prefix + within;
         }
         out
     }
@@ -196,7 +196,7 @@ fn words_for_bits(bits: usize) -> usize {
     if bits == 0 {
         0
     } else {
-        (bits + 63) / 64
+        bits.div_ceil(64)
     }
 }
 

--- a/src/genomics/sampled_sa.rs
+++ b/src/genomics/sampled_sa.rs
@@ -32,7 +32,7 @@ impl SampledSuffixArray {
         samples: impl Iterator<Item = (usize, u32)>,
     ) -> Self {
         // `(n + 63) / 64`, not `n.div_ceil(64)` (which is Rust 1.73+; MSRV is 1.72).
-        let words = (bwt_len + 63) / 64;
+        let words = bwt_len.div_ceil(64);
         let mut marks = vec![0u64; words];
         let mut values = Vec::new();
         // The strictly-ascending contract is load-bearing: `values` is pushed in
@@ -45,7 +45,7 @@ impl SampledSuffixArray {
             #[cfg(debug_assertions)]
             {
                 debug_assert!(
-                    prev.map_or(true, |p| pos > p),
+                    prev.is_none_or(|p| pos > p),
                     "samples must be yielded in strictly ascending BWT-position order"
                 );
                 prev = Some(pos);
@@ -148,7 +148,7 @@ fn popcount_prefix(words: &[u64], start: usize, end: usize) -> u32 {
 /// Prefix popcounts of `marks` at each `stride` boundary (entry `k` = set bits in
 /// `[0, k*stride)`); length `ceil(bwt_len/stride) + 1`.
 fn build_superblocks(marks: &[u64], bwt_len: usize, stride: usize) -> Vec<u32> {
-    let num = (bwt_len + stride - 1) / stride;
+    let num = bwt_len.div_ceil(stride);
     let mut sb = Vec::with_capacity(num + 1);
     sb.push(0u32);
     let mut acc = 0u32;

--- a/src/genomics/sort.rs
+++ b/src/genomics/sort.rs
@@ -77,7 +77,7 @@ fn spill_chunk(
     idx: usize,
     chunk: &mut Vec<Record>,
 ) -> Result<PathBuf> {
-    chunk.sort_by(|a, b| sort_key_cmp(a, b));
+    chunk.sort_by(sort_key_cmp);
 
     let path = dir.join(format!("{idx:05}.bam"));
     let mut writer = bam::Writer::from_path(&path, header, bam::Format::Bam)

--- a/src/genomics/types.rs
+++ b/src/genomics/types.rs
@@ -77,6 +77,11 @@ impl AlignedRead {
         self.sequence.len()
     }
 
+    /// Whether the read has no bases.
+    pub fn is_empty(&self) -> bool {
+        self.sequence.is_empty()
+    }
+
     /// End position (half-open) on the reference assuming contiguous match.
     pub fn end(&self) -> u32 {
         self.pos + self.len() as u32

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -257,7 +257,7 @@ mod tests {
         for (name, len) in contigs {
             let mut rec = bam::header::HeaderRecord::new(b"SQ");
             rec.push_tag(b"SN", name);
-            rec.push_tag(b"LN", &(*len as i64));
+            rec.push_tag(b"LN", *len as i64);
             header.push_record(&rec);
         }
         header
@@ -414,8 +414,8 @@ mod tests {
         let mut header = bam::Header::new();
         header.push_record(
             bam::header::HeaderRecord::new(b"SQ")
-                .push_tag(b"SN", &"chr1")
-                .push_tag(b"LN", &1000),
+                .push_tag(b"SN", "chr1")
+                .push_tag(b"LN", 1000),
         );
         {
             let mut w = bam::Writer::from_path(&path, &header, bam::Format::Bam).unwrap();
@@ -477,8 +477,8 @@ mod tests {
         let mut header = bam::Header::new();
         header.push_record(
             bam::header::HeaderRecord::new(b"SQ")
-                .push_tag(b"SN", &"chrX")
-                .push_tag(b"LN", &1000),
+                .push_tag(b"SN", "chrX")
+                .push_tag(b"LN", 1000),
         );
         {
             let mut w = bam::Writer::from_path(&path, &header, bam::Format::Bam).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,6 +1019,7 @@ fn run_locate(index: PathBuf, pattern: String, max_hits: usize) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)] // a CLI entry point: each flag is a parameter
 fn run_somatic(
     reference_path: PathBuf,
     tumor_fastq: Option<PathBuf>,
@@ -1198,6 +1199,7 @@ fn run_somatic(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)] // a CLI entry point: each flag is a parameter
 fn run_align(
     reference_path: PathBuf,
     reads_path: Option<PathBuf>,
@@ -1427,6 +1429,7 @@ fn align_pairs(
     Ok(out)
 }
 
+#[allow(clippy::too_many_arguments)] // a CLI entry point: each flag is a parameter
 fn run_variants(
     reference_path: PathBuf,
     alignments_path: PathBuf,
@@ -1891,6 +1894,7 @@ fn run_features(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)] // a CLI entry point: each flag is a parameter
 fn run_variants_index(
     index_path: PathBuf,
     alignments_path: PathBuf,

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -445,9 +445,9 @@ mod tests {
         )
     }
 
-    fn columns(mut e: PileupEngine<SliceSource>) -> Vec<PileupColumn> {
+    fn columns(e: PileupEngine<SliceSource>) -> Vec<PileupColumn> {
         let mut out = Vec::new();
-        while let Some(c) = e.next() {
+        for c in e {
             out.push(c.expect("pileup column"));
         }
         out
@@ -533,7 +533,7 @@ mod tests {
             max_depth: Some(cap),
             ..PileupParams::default()
         };
-        let mut e = PileupEngine::new(
+        let e = PileupEngine::new(
             SliceSource::new(reads),
             Arc::from(reference.into_boxed_slice()),
             0,
@@ -541,7 +541,7 @@ mod tests {
             params,
         );
         let mut at_v = None;
-        while let Some(c) = e.next() {
+        for c in e {
             let col = c.unwrap();
             if col.locus.pos.0 == v {
                 at_v = Some(col);
@@ -751,7 +751,7 @@ mod tests {
         ];
         let mut e = engine(reads, reference);
         let mut cols = Vec::new();
-        while let Some(c) = e.next() {
+        for c in e.by_ref() {
             cols.push(c.unwrap());
         }
         // Only the kept read's 'C' (allele 1) appears at every position.
@@ -778,7 +778,7 @@ mod tests {
             params,
         );
         let mut cols = Vec::new();
-        while let Some(c) = e.next() {
+        for c in e.by_ref() {
             cols.push(c.unwrap());
         }
         assert!(cols.iter().all(|c| c.allele_counts() == [0, 1, 0, 0]));
@@ -857,8 +857,8 @@ mod tests {
         let reference = b"AAAAAAAA";
         let reads = vec![mread(0, b"CCCC", false), mread(2, b"CCCC", false)];
         let mut coverage = Vec::new();
-        let mut e = engine(reads, reference);
-        while let Some(c) = e.next() {
+        let e = engine(reads, reference);
+        for c in e {
             let col = c.unwrap();
             coverage.push((col.locus.pos.0, col.depth()));
         }
@@ -932,7 +932,7 @@ mod tests {
                 params.clone(),
             );
             let mut depths = Vec::new();
-            while let Some(c) = e.next() {
+            for c in e.by_ref() {
                 depths.push(c.unwrap().raw_depth);
             }
             (depths, e.skip_counts().over_max_depth)

--- a/src/util/mmap.rs
+++ b/src/util/mmap.rs
@@ -45,9 +45,8 @@ impl MmapReadOnly {
             if addr == libc::MAP_FAILED {
                 return Err(io::Error::last_os_error());
             }
-            let ptr = NonNull::new(addr as *mut u8).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::Other, "mmap returned null pointer")
-            })?;
+            let ptr = NonNull::new(addr as *mut u8)
+                .ok_or_else(|| io::Error::other("mmap returned null pointer"))?;
             Ok(Self { ptr, len })
         }
     }

--- a/tests/alignment_pipeline.rs
+++ b/tests/alignment_pipeline.rs
@@ -4,7 +4,7 @@ use rosalind::genomics::BWTAligner;
 fn align_batch_produces_results() {
     let reference = b"ACGTACGTACGT";
     let mut aligner = BWTAligner::new(reference).expect("aligner should initialize");
-    let reads = vec![b"ACGT".as_slice(), b"CGTA".as_slice(), b"GTAC".as_slice()];
+    let reads = [b"ACGT".as_slice(), b"CGTA".as_slice(), b"GTAC".as_slice()];
     let results = aligner
         .align_batch(reads.iter().copied())
         .expect("batch alignment should succeed");

--- a/tests/bam_sort.rs
+++ b/tests/bam_sort.rs
@@ -24,8 +24,8 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
     let mut header = bam::Header::new();
     header.push_record(
         bam::header::HeaderRecord::new(b"SQ")
-            .push_tag(b"SN", &"chr1")
-            .push_tag(b"LN", &1000),
+            .push_tag(b"SN", "chr1")
+            .push_tag(b"LN", 1000),
     );
 
     // Write unsorted records: positions 10, 5, 10 (different qnames).
@@ -88,9 +88,9 @@ fn deterministic_bam_sort_orders_by_tid_pos_strand_qname() {
     assert_eq!(qnames, vec!["readA", "readB", "readC"]);
     assert_eq!(keys[0].1, 5);
     assert_eq!(keys[1].1, 10);
-    assert_eq!(keys[1].2, false);
+    assert!(!keys[1].2);
     assert_eq!(keys[2].1, 10);
-    assert_eq!(keys[2].2, true);
+    assert!(keys[2].2);
 
     let _ = std::fs::remove_file(input);
     let _ = std::fs::remove_file(output);

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -38,7 +38,7 @@ fn build_sorted_bam_fixture() -> (PathBuf, PathBuf, PathBuf) {
     let mut s = String::new();
     for (i, &start) in [0usize, 0, 4, 4, 8].iter().enumerate() {
         let read = &seq[start..start + 16];
-        let qual: String = std::iter::repeat('I').take(16).collect();
+        let qual: String = std::iter::repeat_n('I', 16).collect();
         s.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
     }
     std::fs::write(&fq, s).unwrap();

--- a/tests/germline_accuracy.rs
+++ b/tests/germline_accuracy.rs
@@ -137,8 +137,8 @@ fn run_accuracy(coverage: usize, error_rate: f64, cap: u32, seed: u64) -> Accura
     let mut header = bam::Header::new();
     {
         let mut sq = bam::header::HeaderRecord::new(b"SQ");
-        sq.push_tag(b"SN", &"chr1");
-        sq.push_tag(b"LN", &(N as i64));
+        sq.push_tag(b"SN", "chr1");
+        sq.push_tag(b"LN", N as i64);
         header.push_record(&sq);
     }
     let raw_bam = dir.join("reads.bam");

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -105,7 +105,7 @@ fn build_sorted_bam_fixture() -> (PathBuf, PathBuf, PathBuf) {
     let mut s = String::new();
     for (i, &start) in [0usize, 0, 4, 4, 8].iter().enumerate() {
         let read = &seq[start..start + 16];
-        let qual: String = std::iter::repeat('I').take(16).collect();
+        let qual: String = std::iter::repeat_n('I', 16).collect();
         s.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
     }
     std::fs::write(&fq, s).unwrap();
@@ -443,7 +443,7 @@ fn build_big_contig_fixture(ref_len: usize) -> (PathBuf, PathBuf, PathBuf) {
         .enumerate()
     {
         let read = std::str::from_utf8(&seq[off..off + 60]).unwrap();
-        let qual: String = std::iter::repeat('I').take(60).collect();
+        let qual: String = std::iter::repeat_n('I', 60).collect();
         fastq.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
     }
     std::fs::write(&fq, fastq).unwrap();

--- a/tests/truthset_validation.rs
+++ b/tests/truthset_validation.rs
@@ -26,8 +26,8 @@ fn somatic_snv_truth_mixture_simple() {
     let mut header = bam::Header::new();
     header.push_record(
         bam::header::HeaderRecord::new(b"SQ")
-            .push_tag(b"SN", &"chr1")
-            .push_tag(b"LN", &1000),
+            .push_tag(b"SN", "chr1")
+            .push_tag(b"LN", 1000),
     );
 
     // Reference is all 'A'.

--- a/tests/variants_index.rs
+++ b/tests/variants_index.rs
@@ -45,7 +45,7 @@ fn write_fastq(dir: &Path, seq: &str, starts: &[usize], len: usize) -> PathBuf {
     let mut s = String::new();
     for (i, &start) in starts.iter().enumerate() {
         let read = &seq[start..start + len];
-        let qual: String = std::iter::repeat('I').take(len).collect();
+        let qual: String = std::iter::repeat_n('I', len).collect();
         s.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
     }
     std::fs::write(&p, s).unwrap();


### PR DESCRIPTION
## Summary

Closes out Sprint 1: declares + enforces the **real** MSRV and clears the entire clippy backlog behind a gate, so the lint count can't regrow. Resolves the two items deferred from 1.3.

- **MSRV = 1.83**, declared (`rust-version`) and **enforced** by a new CI `msrv` job (`cargo check --all-targets` on 1.83.0). This is the *true, verified* floor: the committed `Cargo.lock` is format v4 and the dependency tree (`url`→`rust-htslib`'s ICU chain + `proptest`) requires 1.83. (The old "1.72" prose was stale; pinning lower would mean a fragile `cargo update --precise` treadmill.)
- **All 82 `clippy --all-targets` lints cleared**, behavior-preserving — two `cargo clippy --fix` passes plus manual resolution: idiomatic `div_ceil`, `iter_mut().enumerate()` index loops, `is_empty()` beside each public `len()`, `&PathBuf`→`&Path`, and scoped `#[allow]`s with rationale (`too_many_arguments` on the 4 CLI entry points; `type_complexity` on one ad-hoc pair; `should_implement_trait` on `Bed::from_str`). The full test suite stays green = every fix is a semantic no-op.
- **`clippy -D warnings` CI gate** added so any new lint fails the build.
- **MSRV hygiene catch:** a `--fix` introduced `usize::is_multiple_of` (unstable until 1.87); reverted to `% == 0` with a scoped allow rather than raise the MSRV beyond the 1.83 dependency floor for a cosmetic lint — exactly what the new `msrv` CI job exists to catch.

Public API unchanged (the `is_empty()` additions are additive; re-exports are byte-identical vs `main`).

Reviewed design + plan: `docs/superpowers/specs/2026-06-02-sprint1-3b-msrv-clippy-design.md`, `docs/superpowers/plans/2026-06-02-sprint1-3b-msrv-clippy.md`. Roadmap Sprint 1.

## Test Plan

- [x] `cargo clippy --all-targets -- -D warnings` → clean (the gate passes).
- [x] `cargo +1.83.0 check --all-targets` → builds on the declared MSRV.
- [x] `cargo test` → all 25 sections green (behavior preserved); `cargo build --release` (+ examples) → 0 warnings; `cargo fmt --check` clean.
- [x] Public re-exports unchanged vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)