### PR TITLE
feat(provenance): cross-machine-stable receipts — claim/measurement split (P0.2)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,6 +131,15 @@ Everything downstream rests on the proofs being literally correct. Two verified 
   hash/chain/sign/re-derive the **claim** (inputs, deterministic params, code-identity, output hashes);
   record + budget-check the **measurement** but exclude it from `content_hash()`. Bump
   `MANIFEST_SCHEMA_VERSION` to 2; degrade pre-v2 gracefully (the pre-1.2 self-hash skip is the pattern).
+  **DONE** (claim/measurement split shipped; the split is lossless — a second `measurement_blake3` keeps
+  the measured cost locally tamper-evident, and a hash-protected `has_measurements` claim marker catches a
+  stripped measurement block).
+- **P0.2b — Path-normalized / content-only claim.** *(S)* P0.2 removed the measured *cost* from the claim
+  hash, but recorded input/output **paths** (`FileHash.path`) are still in the claim, recorded verbatim —
+  so two machines with byte-identical data at different paths still hash differently. To make the claim
+  hash a true cross-machine content-address (the property chaining/reproduce/cohort actually need),
+  normalize paths out of the *claim* form (e.g. key the claim on the sorted `blake3` digests; keep the
+  full path in the on-disk receipt for humans). Pairs naturally with P0.3.
 - **P0.3 — Build-identity in the receipt.** *(S)* Replace the `tool_version = "0.1.0"` half-measure with
   `code_git_sha` + `code_dirty` + `rustc_version` + `target_triple` + `deps_lock_blake3` (via `build.rs`)
   and a `verify --expect-code <sha>` gate, so "exactly this code" stops being a lie and becomes a real

--- a/docs/superpowers/plans/2026-06-02-p0-2-claim-measurement-split.md
+++ b/docs/superpowers/plans/2026-06-02-p0-2-claim-measurement-split.md
@@ -1,0 +1,609 @@
+# P0.2 — Receipt claim/measurement split — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the reproducibility receipt's self-hash cross-machine stable by hashing only the
+deterministic *claim*, while preserving tamper-evidence for the machine-dependent *measurement*
+via a second, local hash.
+
+**Architecture:** Add a `measurements: BTreeMap` block to `RunManifest`. `finalize()`
+relocates the seven machine-dependent keys (`MEASUREMENT_KEYS`) out of `params` into
+`measurements`, stamps a measurement hash, then stamps the claim self-hash over the
+claim-only canonical form. The parser optionally consumes the new key; `verify` reads both
+maps for back-compat. Bump schema version 1 → 2.
+
+**Tech Stack:** Rust, BLAKE3 (`blake3` crate), hand-written canonical-JSON serializer/parser.
+
+**Reference:** spec `docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md`.
+
+---
+
+### Task 1: Provenance unit tests (RED) — the split's core properties
+
+**Files:**
+- Modify: `src/provenance/mod.rs` (append to `mod tests`)
+
+- [ ] **Step 1: Write the failing tests** — append to `mod tests`:
+
+```rust
+    #[test]
+    fn claim_hash_is_stable_across_machine_dependent_measurements() {
+        // Same logical run on two machines: identical claim, different measured cost.
+        // The claim self-hash must match; the measurement is excluded from it.
+        let mk = |peak: &str, ws: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.fa".to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.outputs.push(FileHash {
+                path: "out.vcf".to_string(),
+                blake3: "bb".to_string(),
+            });
+            m.params.insert("min_qual".to_string(), "30".to_string());
+            m.record_measurement("peak_rss_bytes", peak);
+            m.record_measurement("max_working_set_bytes", ws);
+            m.finalize();
+            m
+        };
+        let a = mk("1000000", "4096");
+        let b = mk("9999999", "8192");
+        assert_eq!(
+            a.content_hash(),
+            b.content_hash(),
+            "measured cost must not change the claim hash"
+        );
+        assert_eq!(a.self_hash_ok(), Some(true));
+        assert_eq!(b.self_hash_ok(), Some(true));
+        // Differing measurements DO change the measurement hash.
+        assert_ne!(
+            a.measurements.get("measurement_blake3"),
+            b.measurements.get("measurement_blake3")
+        );
+    }
+
+    #[test]
+    fn claim_excludes_but_full_form_includes_measurements() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.record_measurement("peak_rss_bytes", "123");
+        m.finalize();
+        assert!(
+            !m.to_canonical_claim_json().contains("peak_rss_bytes"),
+            "claim form must not carry the measurement"
+        );
+        assert!(
+            m.to_canonical_json().contains("peak_rss_bytes"),
+            "full form must record the measurement"
+        );
+    }
+
+    #[test]
+    fn editing_a_measurement_breaks_only_the_measurement_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.record_measurement("peak_rss_bytes", "123");
+        m.finalize();
+        assert_eq!(m.self_hash_ok(), Some(true));
+        assert_eq!(m.measurement_hash_ok(), Some(true));
+        // Lower the recorded peak WITHOUT re-finalizing (a tampered receipt).
+        m.measurements
+            .insert("peak_rss_bytes".to_string(), "1".to_string());
+        assert_eq!(
+            m.self_hash_ok(),
+            Some(true),
+            "claim hash is unaffected by the measurement edit"
+        );
+        assert_eq!(
+            m.measurement_hash_ok(),
+            Some(false),
+            "measurement hash must catch the edit"
+        );
+    }
+
+    #[test]
+    fn finalize_relocates_measured_keys_out_of_the_claim() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        // Insert measured fields the legacy way (into params); finalize must relocate.
+        m.params
+            .insert("peak_rss_bytes".to_string(), "555".to_string());
+        m.params
+            .insert("contract_verdict".to_string(), "within".to_string());
+        m.params.insert("min_qual".to_string(), "30".to_string());
+        m.finalize();
+        for k in ["peak_rss_bytes", "contract_verdict"] {
+            assert!(!m.params.contains_key(k), "{k} must leave the claim");
+            assert!(m.measurements.contains_key(k), "{k} must enter measurements");
+        }
+        assert!(m.params.contains_key("min_qual"), "claim params stay put");
+    }
+
+    #[test]
+    fn pre_v2_receipt_with_measurements_in_params_still_verifies() {
+        // A pre-v2 receipt: peak in params, no measurements key, schema 1, self-hash
+        // over the params-inclusive claim. It must still self-verify (graceful degrade).
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params
+            .insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.params
+            .insert("schema_version".to_string(), "1".to_string());
+        let h = m.content_hash();
+        m.params.insert("manifest_blake3".to_string(), h);
+
+        assert_eq!(m.self_hash_ok(), Some(true));
+        assert_eq!(m.measurement_hash_ok(), None, "no measurement block in v1");
+        let json = m.to_canonical_json();
+        assert!(!json.contains("\"measurements\""), "v1 emits no measurements key");
+        let parsed = RunManifest::from_canonical_json(&json).expect("parse v1");
+        assert!(parsed.measurements.is_empty());
+        assert_eq!(parsed.self_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn v2_receipt_round_trips_through_the_parser() {
+        let mut m = RunManifest::new("features");
+        m.tool_version = "9.9.9".to_string();
+        m.inputs.push(FileHash {
+            path: "a.idx".to_string(),
+            blake3: "aa".to_string(),
+        });
+        m.outputs.push(FileHash {
+            path: "out.tsv".to_string(),
+            blake3: "bb".to_string(),
+        });
+        m.params
+            .insert("feature_rows".to_string(), "42".to_string());
+        m.record_measurement("peak_rss_bytes", "1000");
+        m.record_measurement("governor", "enforced");
+        m.finalize();
+
+        let json = m.to_canonical_json();
+        let parsed = RunManifest::from_canonical_json(&json).expect("parse v2");
+        assert_eq!(parsed.to_canonical_json(), json, "round-trip is the identity");
+        assert_eq!(
+            parsed.measurements.get("peak_rss_bytes").map(String::as_str),
+            Some("1000")
+        );
+        assert_eq!(parsed.params.get("feature_rows").map(String::as_str), Some("42"));
+        assert_eq!(parsed.self_hash_ok(), Some(true));
+        assert_eq!(parsed.measurement_hash_ok(), Some(true));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cargo test -p rosalind --lib provenance 2>&1 | head -40`
+Expected: compile errors — `record_measurement`, `measurements`, `to_canonical_claim_json`,
+`measurement_hash_ok` not found.
+
+---
+
+### Task 2: Provenance implementation (GREEN)
+
+**Files:**
+- Modify: `src/provenance/mod.rs`
+
+- [ ] **Step 1: Bump the schema version + add the policy list**
+
+Replace the version const:
+
+```rust
+/// Current receipt/feature schema version. Bump on any breaking schema change.
+/// v2: the receipt is split into a deterministic *claim* and a machine-dependent
+/// *measurement* block; the self-hash (`manifest_blake3`) covers the claim only.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
+
+/// Keys whose values are machine-/run-dependent measurements, not part of the
+/// deterministic claim. `finalize` relocates these out of `params` into the
+/// `measurements` block so the claim hash is identical for the same logical run on
+/// any machine. The single audited source of truth for the claim/measurement split.
+pub const MEASUREMENT_KEYS: &[&str] = &[
+    "peak_rss_bytes",
+    "max_working_set_bytes",
+    "predicted_peak_rss_bytes",
+    "baseline_rss_bytes",
+    "rss_residual_bytes",
+    "governor",
+    "contract_verdict",
+];
+```
+
+- [ ] **Step 2: Add the `measurements` field + init in `new`**
+
+In `struct RunManifest`, after `outputs`:
+
+```rust
+    /// Machine-/run-dependent measured cost (peak RSS, working set, verdict, …),
+    /// excluded from the claim hash. Carries its own `measurement_blake3`.
+    pub measurements: BTreeMap<String, String>,
+```
+
+In `RunManifest::new`, add `measurements: BTreeMap::new(),` to the struct literal.
+
+- [ ] **Step 3: Add `record_measurement` + replace serialization with a shared helper**
+
+Add to `impl RunManifest` (near `new`):
+
+```rust
+    /// Record a machine-/run-dependent measurement (excluded from the claim hash).
+    pub fn record_measurement(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.measurements.insert(key.into(), value.into());
+    }
+```
+
+Replace `to_canonical_json` with the claim/full pair backed by one helper:
+
+```rust
+    /// Serialize to canonical JSON: keys sorted, arrays sorted by path, no
+    /// timestamps. Includes the measurement block (when non-empty). Used on disk.
+    pub fn to_canonical_json(&self) -> String {
+        self.push_canonical(true)
+    }
+
+    /// The claim-only canonical JSON: never emits the measurement block. This is the
+    /// portion the self-hash commits to, so the hash is identical for the same
+    /// logical run on any machine.
+    pub fn to_canonical_claim_json(&self) -> String {
+        self.push_canonical(false)
+    }
+
+    fn push_canonical(&self, include_measurements: bool) -> String {
+        let mut out = String::new();
+        out.push('{');
+        out.push_str("\"inputs\":");
+        push_file_hashes(&mut out, &self.inputs);
+        if include_measurements && !self.measurements.is_empty() {
+            out.push_str(",\"measurements\":");
+            push_string_map(&mut out, &self.measurements);
+        }
+        out.push_str(",\"outputs\":");
+        push_file_hashes(&mut out, &self.outputs);
+        out.push_str(",\"params\":");
+        push_string_map(&mut out, &self.params);
+        out.push_str(",\"subcommand\":\"");
+        out.push_str(&json_escape(&self.subcommand));
+        out.push_str("\",\"tool_version\":\"");
+        out.push_str(&json_escape(&self.tool_version));
+        out.push_str("\"}");
+        out
+    }
+```
+
+Add the shared string-map serializer near `push_file_hashes`:
+
+```rust
+/// Render a `{"k":"v",…}` object, entries in the map's (sorted) key order.
+fn push_string_map(out: &mut String, map: &BTreeMap<String, String>) {
+    out.push('{');
+    for (i, (k, v)) in map.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&json_escape(k));
+        out.push_str("\":\"");
+        out.push_str(&json_escape(v));
+        out.push('"');
+    }
+    out.push('}');
+}
+```
+
+- [ ] **Step 4: Claim + measurement hashing**
+
+Replace `content_hash` and add the measurement methods:
+
+```rust
+    /// BLAKE3 hex of the **claim** canonical JSON with the self-hash excluded — the
+    /// content this manifest commits to, identical on any machine. `verify` re-derives it.
+    pub fn content_hash(&self) -> String {
+        let mut m = self.clone();
+        m.params.remove("manifest_blake3");
+        blake3_hex(m.to_canonical_claim_json().as_bytes())
+    }
+
+    /// BLAKE3 hex of the measurement block with `measurement_blake3` excluded — a
+    /// LOCAL attestation of the measured cost. Not cross-machine stable by design.
+    pub fn measurement_hash(&self) -> String {
+        let mut m = self.measurements.clone();
+        m.remove("measurement_blake3");
+        let mut s = String::new();
+        push_string_map(&mut s, &m);
+        blake3_hex(s.as_bytes())
+    }
+
+    /// `Some(match)` if a measurement self-hash is recorded; `None` if absent
+    /// (no measurement block, or a pre-v2 receipt).
+    pub fn measurement_hash_ok(&self) -> Option<bool> {
+        self.measurements
+            .get("measurement_blake3")
+            .map(|recorded| *recorded == self.measurement_hash())
+    }
+
+    /// Look up a recorded value by key, checking `measurements` then `params`. Lets
+    /// `verify` read v2 receipts (measured fields in `measurements`) and pre-v2
+    /// receipts (everything in `params`) uniformly.
+    pub fn get_recorded(&self, key: &str) -> Option<&String> {
+        self.measurements.get(key).or_else(|| self.params.get(key))
+    }
+```
+
+- [ ] **Step 5: `finalize` — relocate, then stamp both hashes**
+
+Replace `finalize`:
+
+```rust
+    /// Seal the receipt: partition measured fields out of the claim, stamp the
+    /// measurement hash, the schema version, then the claim self-hash LAST (so it
+    /// covers every other claim field, including the version). Idempotent.
+    pub fn finalize(&mut self) {
+        // 1. Partition: relocate machine-dependent fields OUT of the claim.
+        for key in MEASUREMENT_KEYS {
+            if let Some(v) = self.params.remove(*key) {
+                self.measurements.insert((*key).to_string(), v);
+            }
+        }
+        // 2. Local measurement attestation (only when a measurement exists).
+        if !self.measurements.is_empty() {
+            let mh = self.measurement_hash();
+            self.measurements
+                .insert("measurement_blake3".to_string(), mh);
+        }
+        // 3. Stamp the version into the claim, then the claim self-hash last.
+        self.params.insert(
+            "schema_version".to_string(),
+            MANIFEST_SCHEMA_VERSION.to_string(),
+        );
+        let h = self.content_hash();
+        self.params.insert("manifest_blake3".to_string(), h);
+    }
+```
+
+(`self_hash_ok` is unchanged — it already compares `manifest_blake3` to `content_hash()`.)
+
+- [ ] **Step 6: Parser — optionally consume `measurements`**
+
+In `parse_manifest`, replace the `inputs → outputs` section. After parsing `inputs` and its
+trailing comma, branch on the next key:
+
+```rust
+    fn parse_manifest(&mut self) -> Result<RunManifest, ManifestError> {
+        self.expect(b'{')?;
+        self.expect_key("inputs")?;
+        let inputs = self.parse_file_array()?;
+        self.expect(b',')?;
+        // `measurements` is optional (absent in pre-v2 receipts and empty-measurement runs).
+        let key = self.parse_string()?;
+        self.expect(b':')?;
+        let (measurements, outputs) = if key == "measurements" {
+            let m = self.parse_params()?;
+            self.expect(b',')?;
+            self.expect_key("outputs")?;
+            (m, self.parse_file_array()?)
+        } else if key == "outputs" {
+            (BTreeMap::new(), self.parse_file_array()?)
+        } else {
+            return Err(self.err(&format!(
+                "expected \"measurements\" or \"outputs\", got \"{key}\""
+            )));
+        };
+        self.expect(b',')?;
+        self.expect_key("params")?;
+        let params = self.parse_params()?;
+        self.expect(b',')?;
+        self.expect_key("subcommand")?;
+        let subcommand = self.parse_string()?;
+        self.expect(b',')?;
+        self.expect_key("tool_version")?;
+        let tool_version = self.parse_string()?;
+        self.expect(b'}')?;
+        Ok(RunManifest {
+            tool_version,
+            subcommand,
+            inputs,
+            params,
+            outputs,
+            measurements,
+        })
+    }
+```
+
+- [ ] **Step 7: Update the module doc + `content_hash`/`finalize` references**
+
+Update the module header comment (top of file) to describe the claim/measurement split in one
+sentence. Update the `finalize_is_idempotent` / `tampering_*` test comments only if they
+reference "no self-hash" (they don't — leave them).
+
+- [ ] **Step 8: Run the provenance tests**
+
+Run: `cargo test -p rosalind --lib provenance 2>&1 | tail -25`
+Expected: all green, including the new Task-1 tests and the pre-existing ones
+(`canonical_json_has_sorted_keys_and_is_exact`, `finalize_*`, `tampering_*`, `parse_*`).
+
+- [ ] **Step 9: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add src/provenance/mod.rs docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md docs/superpowers/plans/2026-06-02-p0-2-claim-measurement-split.md
+git commit -m "feat(provenance): split receipt into deterministic claim + machine-dependent measurement"
+```
+
+---
+
+### Task 3: `verify` reads both maps + checks the measurement hash
+
+**Files:**
+- Modify: `src/main.rs` (`run_verify`, ~lines 885-1006)
+
+- [ ] **Step 1: Route lookups through `get_recorded`**
+
+In `run_verify`: change the budget fallback (`manifest.params.get("memory_budget_mb")` →
+`manifest.get_recorded("memory_budget_mb")`), the peak read
+(`manifest.params.get("peak_rss_bytes")` → `manifest.get_recorded("peak_rss_bytes")`), the
+`recorded_u64` closure (`manifest.params.get(k)` → `manifest.get_recorded(k)`), and the
+verdict read (`manifest.params.get("contract_verdict")` → `manifest.get_recorded("contract_verdict")`).
+
+- [ ] **Step 2: Add the measurement-hash check + reframe the stale comment**
+
+Replace the "Internal-consistency cross-checks" comment block's stale "no self-hash yet"
+wording with the two-layer model, and after the existing `self_hash_ok()` match add:
+
+```rust
+    // Measurement attestation: catches an edit to a measured field (e.g. lowering
+    // peak_rss_bytes to fake a fit) that the claim hash cannot see by design.
+    match manifest.measurement_hash_ok() {
+        Some(true) => {}
+        Some(false) => problems.push(
+            "measurement_blake3 mismatch: a measured field was modified after the run".to_string(),
+        ),
+        None => {}
+    }
+```
+
+- [ ] **Step 3: Build + run the verify-related integration tests**
+
+Run: `cargo test -p rosalind --test plan_enforce verify 2>&1 | tail -25`
+Expected: `verify_rejects_a_self_consistent_but_tampered_receipt` and
+`verify_rejects_an_internally_inconsistent_manifest` pass; others compile.
+
+- [ ] **Step 4: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add src/main.rs
+git commit -m "feat(verify): read measurement block + check measurement_blake3 (claim/measurement split)"
+```
+
+---
+
+### Task 4: Update integration tests to the new partition
+
+**Files:**
+- Modify: `tests/plan_enforce.rs`, `tests/gvcf.rs`
+
+- [ ] **Step 1: Point measured-field reads at `.measurements`**
+
+In `tests/plan_enforce.rs`:
+- `estimator_upper_bounds_the_realized_working_set`: `m.params.get("max_working_set_bytes")`
+  → `m.measurements.get("max_working_set_bytes")`.
+- `predicted_peak_rss_upper_bounds_realized_peak`: `m.params.get("predicted_peak_rss_bytes")`
+  and `m.params.get("peak_rss_bytes")` → `m.measurements.get(...)`.
+- `receipt_records_residual_and_governor_fields_on_a_fitting_run`:
+  `m.params.get("governor")` → `m.measurements.get("governor")`.
+- the residual/assumed test (~711-721): `predicted_peak_rss_bytes`, `peak_rss_bytes`,
+  `rss_residual_bytes` → `m.measurements.get(...)`; **keep** `io_rss_overhead_assumed_bytes`
+  on `m.params` (a constant — it stays in the claim).
+
+In `tests/gvcf.rs`: `rm.params.contains_key("peak_rss_bytes")` →
+`rm.measurements.contains_key("peak_rss_bytes")`.
+
+- [ ] **Step 2: Bump the schema-version assertion + assert the measurement hash**
+
+In `tests/plan_enforce.rs::receipt_is_self_hashing_and_schema_versioned`, change
+`text.contains("\"schema_version\":\"1\"")` → `"\"schema_version\":\"2\""`, and add:
+
+```rust
+    assert!(
+        text.contains("\"measurement_blake3\":"),
+        "no measurement self-hash: {text}"
+    );
+```
+
+- [ ] **Step 3: Add the lossless-measurement-tamper end-to-end test**
+
+Append to `tests/plan_enforce.rs`:
+
+```rust
+#[test]
+fn verify_rejects_a_consistent_measurement_tamper_via_the_measurement_hash() {
+    // Lower the recorded peak while keeping the receipt internally consistent (peak
+    // still within budget, verdict still 'within'). The claim hash cannot see a
+    // measurement edit — only the measurement hash catches it.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
+    let recorded_peak = m.measurements.get("peak_rss_bytes").unwrap().clone();
+    // Replace the measured peak with a smaller, still-within-budget value.
+    let tampered = text.replace(
+        &format!("\"peak_rss_bytes\":\"{recorded_peak}\""),
+        "\"peak_rss_bytes\":\"1\"",
+    );
+    assert_ne!(text, tampered, "the replace must have changed the peak");
+    std::fs::write(&manifest, &tampered).unwrap();
+
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "a measurement tamper must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("measurement_blake3 mismatch"),
+        "expected a measurement-hash mismatch: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 4: Run the full integration suites**
+
+Run: `cargo test -p rosalind --test plan_enforce --test gvcf --test features 2>&1 | tail -30`
+Expected: all green.
+
+- [ ] **Step 5: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add tests/plan_enforce.rs tests/gvcf.rs
+git commit -m "test: adapt receipt reads to the claim/measurement split + measurement-tamper e2e"
+```
+
+---
+
+### Task 5: Full verification + clippy + MSRV
+
+- [ ] **Step 1: Whole test suite**
+
+Run: `cargo test 2>&1 | tail -30`
+Expected: all green (lib + every integration test).
+
+- [ ] **Step 2: Clippy (the CI gate)**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+- [ ] **Step 3: MSRV build (the CI gate)**
+
+Run: `cargo +1.83 build 2>&1 | tail -10` (skip if 1.83 toolchain absent — CI covers it)
+Expected: builds clean.
+
+- [ ] **Step 4: Push + open PR + watch CI**
+
+```bash
+git push -u origin rosalind/p0-2-claim-measurement-split
+gh pr create --title "feat(provenance): cross-machine-stable receipts — claim/measurement split (P0.2)" --body "<summary>"
+gh pr checks --watch
+```
+
+Merge only after all 5 CI jobs are green.

--- a/docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md
+++ b/docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md
@@ -1,0 +1,222 @@
+# P0.2 — Receipt claim/measurement split (cross-machine-stable receipts)
+
+**Status:** design
+**Date:** 2026-06-02
+**Roadmap:** `docs/ROADMAP.md` §6 Phase 0, item P0.2
+**Predecessor:** Sprint 1.2 (tamper-evident self-hashing receipt), P0.1 (sound build estimate)
+
+## The defect
+
+`RunManifest::content_hash()` (`src/provenance/mod.rs`) clones the manifest, removes only
+`manifest_blake3` from `params`, and hashes the **entire** canonical JSON — which still
+includes the machine-dependent measured fields the run records in `params`:
+
+- `peak_rss_bytes` (realized resident high-water on *this* machine)
+- `max_working_set_bytes` (realized pileup working set)
+- `predicted_peak_rss_bytes` (a prediction *anchored to this machine's measured baseline RSS*)
+- `baseline_rss_bytes` (measured process baseline at start)
+- `rss_residual_bytes` (realized peak − predicted)
+- `governor` (runtime governor status)
+- `contract_verdict` (derived from the measured peak vs the declared budget)
+
+Consequence: **the same correct run on two machines produces two different receipt hashes.**
+The receipt was supposed to be the reproducibility anchor — "running this produces an output
+with this exact hash" — but the anchor moves whenever the cost of the run moves. That makes
+`manifest_blake3` unusable as a cross-machine identity, which in turn blocks every downstream
+proof that needs a stable receipt identity: chaining (P3), `reproduce` (P3), and cohort
+receipts (P3). The hash must commit to *what was computed*, not *what it cost here*.
+
+## The lossless-split principle
+
+Partition the receipt into two parts with different reproducibility semantics:
+
+- **Claim** — deterministic, portable, identical for the same logical run on any machine:
+  `inputs`, `outputs` (content hashes), `params` (declared knobs: budget, thresholds,
+  deterministic output counts), `subcommand`, `tool_version`, `schema_version`.
+- **Measurement** — machine-/run-dependent observed cost: the seven fields above.
+
+`content_hash()` (the claim hash, recorded as `manifest_blake3`) is computed over the **claim
+only**, excluding the measurement block. Two machines that run the same logical computation
+now produce the **same** `manifest_blake3`.
+
+### Why the split must be lossless (the subtle part)
+
+Before this change, the single self-hash covered `peak_rss_bytes` (it lived in the claimed
+`params`), so the receipt was tamper-evident *against an edit to the measured peak* — e.g.
+someone lowering `peak_rss_bytes` to make a run look like it fit a budget. If we simply drop
+the measurement from the hash, **we lose that tamper-evidence** — a strict regression of the
+Sprint 1.2 guarantee.
+
+So the split adds a **second hash**: `measurement_blake3`, a BLAKE3 over the canonical
+measurement block (excluding `measurement_blake3` itself). It is **not** cross-machine stable
+(it hashes machine-dependent numbers) and therefore lives **inside** the measurement block
+(putting it in the claim would re-break claim stability). Result — two-layer integrity:
+
+| Layer | Hash | Covers | Reproducible across machines? | Catches |
+|---|---|---|---|---|
+| Claim | `manifest_blake3` (in `params`) | inputs, outputs, params, subcommand, versions | **Yes** | edits to declared inputs/outputs/params |
+| Measurement | `measurement_blake3` (in `measurements`) | the 7 measured fields | No (local attestation) | edits to the measured cost on this machine |
+
+The measurement is an **on-machine attestation**: tamper-evident locally, cross-checked for
+internal consistency by `verify`, but inherently non-portable. Cryptographic *signing* of the
+measurement by the running machine is out of scope here (a later attestation phase). This
+spec's job is the split + the portable claim hash, **without regressing** the measured-field
+tamper-evidence Sprint 1.2 shipped.
+
+## Design
+
+### Data model (`src/provenance/mod.rs`)
+
+Add a field to `RunManifest`:
+
+```rust
+pub measurements: BTreeMap<String, String>,
+```
+
+Initialized empty by `RunManifest::new`. The measurement keys are a single audited policy
+list — the source of truth for the partition:
+
+```rust
+pub const MEASUREMENT_KEYS: &[&str] = &[
+    "peak_rss_bytes",
+    "max_working_set_bytes",
+    "predicted_peak_rss_bytes",
+    "baseline_rss_bytes",
+    "rss_residual_bytes",
+    "governor",
+    "contract_verdict",
+];
+```
+
+Bump `MANIFEST_SCHEMA_VERSION` `1 → 2`.
+
+### Centralized partition (Option B — relocation in `finalize`)
+
+Callers keep inserting fields wherever is natural today; `finalize()` enforces the partition
+centrally so no call site can leave a measured field in the claim:
+
+```rust
+pub fn finalize(&mut self) {
+    // 1. Partition: relocate machine-dependent fields OUT of the claim.
+    for key in MEASUREMENT_KEYS {
+        if let Some(v) = self.params.remove(*key) {
+            self.measurements.insert((*key).to_string(), v);
+        }
+    }
+    // 2. Local measurement attestation (only when there is a measurement).
+    if !self.measurements.is_empty() {
+        let mh = self.measurement_hash();
+        self.measurements.insert("measurement_blake3".to_string(), mh);
+    }
+    // 3. Stamp the schema version into the claim, then the claim self-hash LAST.
+    self.params.insert("schema_version".to_string(), MANIFEST_SCHEMA_VERSION.to_string());
+    let h = self.content_hash();
+    self.params.insert("manifest_blake3".to_string(), h);
+}
+```
+
+This keeps the existing manifest-building sites in `main.rs` unchanged (lower diff risk); the
+policy lives in one list + one method. A `record_measurement(key, val)` helper is also exposed
+for call sites/tests that prefer to be explicit.
+
+### Serialization
+
+`measurements` is a `string → string` object, serialized identically to `params`. Canonical
+key order stays alphabetical, so `measurements` sits between `inputs` and `outputs`:
+
+```
+{"inputs":[…],"measurements":{…},"outputs":[…],"params":{…},"subcommand":"…","tool_version":"…"}
+```
+
+The `measurements` key is **emitted only when non-empty**. This keeps:
+- pre-v2 receipts (no measurements) and v2 receipts with no measurements byte-identical, and
+- the existing exact-JSON unit test (`canonical_json_has_sorted_keys_and_is_exact`, empty
+  measurements) passing unchanged.
+
+Refactor serialization into one helper parameterized by whether to include measurements:
+
+- `to_canonical_json()` — full receipt (claim + measurements). Used for `write_manifest`.
+- `to_canonical_claim_json()` — claim only (never emits measurements). Used by `content_hash`.
+
+`content_hash()` removes `manifest_blake3` from a clone's `params`, then hashes
+`to_canonical_claim_json()`. `measurement_hash()` hashes the canonical measurement object with
+`measurement_blake3` removed.
+
+### Hashing methods
+
+```rust
+pub fn content_hash(&self) -> String;        // claim hash (manifest_blake3) — cross-machine stable
+pub fn measurement_hash(&self) -> String;    // measurement block hash (measurement_blake3) — local
+pub fn self_hash_ok(&self) -> Option<bool>;          // claim: Some(match) / None if absent
+pub fn measurement_hash_ok(&self) -> Option<bool>;   // measurement: Some(match) / None if absent
+```
+
+### Parser (back-compat)
+
+`parse_manifest` accepts an **optional** `measurements` key after `inputs`: parse the next key
+string and branch — if `"measurements"`, consume the object then expect `outputs`; if
+`"outputs"`, treat measurements as empty. This parses both v1 (no key) and v2 receipts.
+
+### Backward compatibility (graceful pre-v2 degradation)
+
+A pre-v2 receipt put `peak_rss_bytes` in `params` and had no `measurements` key. On parse,
+`measurements` is empty. Because `to_canonical_claim_json()` of a parsed v1 receipt (empty
+measurements, peak still in params) is **byte-identical** to the old full canonical form,
+`content_hash()` reproduces the old v1 hash exactly — so a v1 receipt's `self_hash_ok()`
+still returns `Some(true)`. `measurement_hash_ok()` returns `None` (no measurement block);
+`verify` notes and skips it. No version branching is needed in `content_hash` — the partition
+is correct by construction for both shapes.
+
+### `verify` (`run_verify` in `src/main.rs`)
+
+- Read measured/declared fields via a new `manifest.get_recorded(key)` that checks
+  `measurements` then `params` — so `verify` reads both v2 receipts (measured fields in
+  `measurements`) and pre-v2 receipts (everything in `params`) with one call.
+- Add a `measurement_hash_ok()` check beside `self_hash_ok()`: `Some(false)` → a
+  "measurement_blake3 mismatch" problem; `None` → noted and skipped (pre-v2).
+- Keep the existing internal-consistency cross-checks (ws ≤ peak; verdict vs peak vs budget) —
+  they remain the semantic guard for the measurement and now read via `get_recorded`.
+- Update the stale "the manifest has no self-hash yet" comment to the two-layer model.
+
+## What does NOT move
+
+Deterministic counts stay in the claim (same input → same value on any machine):
+`feature_rows`, `over_max_depth`, `reads_skipped_total`, `io_rss_overhead_assumed_bytes` (a
+compile-time constant), and all declared knobs (`min_qual`, `max_depth`, `max_read_len`,
+`mapq_threshold`, `enforced`, `memory_budget_mb`, `region_start`, `somatic_snv_only`).
+
+## Testing
+
+New `provenance` unit tests:
+1. **Cross-machine claim stability** — two manifests, identical claim, different measured
+   values → identical `content_hash()`; both `self_hash_ok() == Some(true)`.
+2. **Claim excludes / full includes** — `to_canonical_claim_json()` omits `peak_rss_bytes`;
+   `to_canonical_json()` contains it.
+3. **Measurement tamper-evidence** — finalize, edit a value in `measurements` →
+   `measurement_hash_ok() == Some(false)` while `self_hash_ok()` stays `Some(true)`.
+4. **v1 back-compat** — a v1-shaped receipt (peak in params, no measurements, schema 1) still
+   `self_hash_ok() == Some(true)`; round-trips with no `measurements` key; parses to empty
+   measurements; `measurement_hash_ok() == None`.
+5. **v2 round-trip** — a finalized v2 receipt round-trips through `from_canonical_json` (the
+   optional-measurements parser), preserving both maps and both hashes.
+
+Integration-test updates (`tests/`): point measured-field reads at `.measurements`
+(`plan_enforce.rs`: `max_working_set_bytes`, `predicted_peak_rss_bytes`, `peak_rss_bytes`,
+`rss_residual_bytes`, `governor`; `gvcf.rs`: `peak_rss_bytes`); bump the `schema_version`
+assertion `"1"→"2"` and assert `measurement_blake3` is present; **add** an end-to-end test that
+tampers a measured field while keeping the receipt internally consistent and asserts
+`verify` fails with `measurement_blake3 mismatch` (the new lossless property, mirroring the
+existing claim-field tamper test). Substring assertions over raw JSON are unaffected (the
+substrings still appear, now inside `measurements`).
+
+## Out of scope
+
+Cryptographic signing/attestation of the measurement by the running machine; build-identity
+fields (`code_git_sha`, `rustc_version`, lockfile hash) — that is P0.3.
+
+## Risks
+
+- **Missing a measured key** → it stays in the claim and re-breaks cross-machine stability.
+  Mitigated by `MEASUREMENT_KEYS` being the single audited list + a unit test asserting no
+  measured key affects the claim hash.
+- **Parser regression on the optional key** → covered by the v1 and v2 round-trip tests.

--- a/docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md
+++ b/docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md
@@ -220,3 +220,40 @@ fields (`code_git_sha`, `rustc_version`, lockfile hash) — that is P0.3.
   Mitigated by `MEASUREMENT_KEYS` being the single audited list + a unit test asserting no
   measured key affects the claim hash.
 - **Parser regression on the optional key** → covered by the v1 and v2 round-trip tests.
+
+## Post-review hardening (adversarial review response)
+
+A three-way adversarial review (cross-machine stability, back-compat, silent-failure) surfaced
+issues addressed before merge:
+
+- **Deletion bypass (critical regression).** Excluding the measurement from the claim hash means
+  the claim hash no longer sees an edit *or deletion* of the measured fields. An attacker could
+  delete the entire `measurements` block: `measurement_hash_ok()` then returns `None` (read as
+  "nothing to check") and every consistency cross-check, guarded by `if let Some(...)`, silently
+  no-ops — so an over-budget receipt verifies clean. Fix: `finalize` stamps a deterministic
+  `has_measurements: "true"` marker **into the claim** (so it is covered by the cross-machine-stable
+  claim hash — unlike `measurement_blake3`, which is machine-dependent and cannot live in the
+  claim). `verify` treats `measurement_hash_ok() == None` as a problem **when the claim records
+  `has_measurements`**, catching the strip; a genuine pre-v2 / measurement-free receipt has no
+  marker and is skipped legitimately. Covered by a unit test and an end-to-end `verify` test.
+- **Honest threat model.** `measurement_blake3` is an *unkeyed self-hash*: tamper-**evidence**
+  against an accidental edit, not tamper-**resistance** against a forger who re-hashes. Wording in
+  code/`verify` states this; cryptographic signing is a later phase. (`manifest_blake3` is the same
+  kind of control — both are evidence, not authentication.)
+- **Malformed-numeric silently skipped.** `verify` parsed measured numbers with
+  `.parse().ok()`, so a *present-but-corrupt* field was indistinguishable from *absent* and silently
+  disabled the check it fed. Fix: present-but-unparseable numeric fields now push a
+  `malformed numeric field` problem; only genuine absence skips.
+- **Duplicate-key shadowing.** `parse_params` accepted duplicate keys (last wins), letting a
+  crafted receipt show one value to a reader while `verify` acted on another. Fix: the parser now
+  rejects duplicate keys.
+
+## Known remaining limitation (flagged, deferred)
+
+This change removes the measured **cost** from the claim hash. Recorded input/output **paths** are
+still part of the claim (`FileHash.path`), recorded verbatim from the CLI with no normalization — so
+two machines with byte-identical data at different paths still produce different claim hashes. Full
+cross-machine claim identity therefore requires a follow-up (path normalization, or a content-only
+claim keyed on the `blake3` digests). Tracked in the roadmap; **not** in this increment's scope. The
+unit test `claim_hash_is_stable_across_machine_dependent_measurements` is accurately scoped to
+measurement-independence (it holds paths fixed) and does not assert path-independence.

--- a/src/main.rs
+++ b/src/main.rs
@@ -907,17 +907,16 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
     }
 
     // Re-check the recorded realized peak against the budget (CLI overrides manifest).
+    // `get_recorded` reads the measurement block (v2) or params (pre-v2) uniformly.
     let budget_mb = budget_mb.or_else(|| {
         manifest
-            .params
-            .get("memory_budget_mb")
+            .get_recorded("memory_budget_mb")
             .and_then(|v| v.parse::<u64>().ok())
     });
     match (
         budget_mb,
         manifest
-            .params
-            .get("peak_rss_bytes")
+            .get_recorded("peak_rss_bytes")
             .and_then(|v| v.parse::<u64>().ok()),
     ) {
         (Some(mb), Some(peak)) => {
@@ -939,12 +938,13 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
     }
 
     // Internal-consistency cross-checks: a receipt's self-reported numbers must
-    // agree with each other. The manifest has no self-hash yet (a signed,
-    // tamper-evident receipt is a separate feature), so these cheap checks are the
-    // first line against a hand-edited or corrupt receipt — e.g. someone lowering
-    // `peak_rss_bytes` to pass `verify` but leaving the other fields behind.
+    // agree with each other. The claim self-hash (manifest_blake3) cannot see an
+    // edit to a measured field (the measurement is excluded from the claim by
+    // design), so alongside the measurement self-hash these cheap checks are the
+    // semantic guard against a hand-edited receipt — e.g. someone lowering
+    // `peak_rss_bytes` to pass `verify` but leaving the other fields inconsistent.
     let recorded_u64 =
-        |k: &str| -> Option<u64> { manifest.params.get(k).and_then(|v| v.parse::<u64>().ok()) };
+        |k: &str| -> Option<u64> { manifest.get_recorded(k).and_then(|v| v.parse::<u64>().ok()) };
     // The working set is a subset of resident memory; it cannot exceed peak RSS.
     if let (Some(ws), Some(peak)) = (
         recorded_u64("max_working_set_bytes"),
@@ -958,7 +958,9 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
     }
     // A recorded verdict must agree with the recorded peak vs the recorded budget.
     if let (Some(verdict), Some(mb), Some(peak)) = (
-        manifest.params.get("contract_verdict").map(String::as_str),
+        manifest
+            .get_recorded("contract_verdict")
+            .map(String::as_str),
         recorded_u64("memory_budget_mb"),
         recorded_u64("peak_rss_bytes"),
     ) {
@@ -979,8 +981,8 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
         }
     }
 
-    // Self-hash: catches any post-write edit (even one that keeps the other fields
-    // mutually consistent). A pre-1.2 receipt has no self-hash — note and skip.
+    // Claim self-hash: catches any post-write edit to the claim (inputs, outputs,
+    // declared params) — cross-machine stable. A pre-1.2 receipt has none — note and skip.
     match manifest.self_hash_ok() {
         Some(true) => {}
         Some(false) => problems.push(
@@ -989,6 +991,16 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
         None => {
             println!("verify: note — no manifest_blake3 (a pre-1.2 receipt); skipping self-hash")
         }
+    }
+
+    // Measurement self-hash: catches an edit to a measured field (e.g. lowering
+    // peak_rss_bytes to fake a fit) that the claim hash cannot see by design. A
+    // pre-v2 / measurement-free receipt has none — silently skip.
+    match manifest.measurement_hash_ok() {
+        Some(true) | None => {}
+        Some(false) => problems.push(
+            "measurement_blake3 mismatch: a measured field was modified after the run".to_string(),
+        ),
     }
 
     if problems.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -906,19 +906,30 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
         }
     }
 
+    // Strictly parse the numeric fields verify consults. A field that is PRESENT but
+    // unparseable is corruption, not absence — flag it rather than silently skipping
+    // the check it feeds (the closure takes `&mut problems` as an argument so it does
+    // not capture the borrow). `get_recorded` reads measurements (v2) or params
+    // (pre-v2) uniformly.
+    let parse_num = |k: &str, problems: &mut Vec<String>| -> Option<u64> {
+        match manifest.get_recorded(k) {
+            None => None,
+            Some(v) => match v.parse::<u64>() {
+                Ok(n) => Some(n),
+                Err(_) => {
+                    problems.push(format!("malformed numeric field {k}: {v:?}"));
+                    None
+                }
+            },
+        }
+    };
+    let recorded_peak = parse_num("peak_rss_bytes", &mut problems);
+    let recorded_ws = parse_num("max_working_set_bytes", &mut problems);
+    let recorded_budget = parse_num("memory_budget_mb", &mut problems);
+
     // Re-check the recorded realized peak against the budget (CLI overrides manifest).
-    // `get_recorded` reads the measurement block (v2) or params (pre-v2) uniformly.
-    let budget_mb = budget_mb.or_else(|| {
-        manifest
-            .get_recorded("memory_budget_mb")
-            .and_then(|v| v.parse::<u64>().ok())
-    });
-    match (
-        budget_mb,
-        manifest
-            .get_recorded("peak_rss_bytes")
-            .and_then(|v| v.parse::<u64>().ok()),
-    ) {
+    let budget_mb = budget_mb.or(recorded_budget);
+    match (budget_mb, recorded_peak) {
         (Some(mb), Some(peak)) => {
             let budget = rosalind::core::MemoryBudget::from_mb(mb);
             if budget.admits(peak) {
@@ -943,13 +954,9 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
     // design), so alongside the measurement self-hash these cheap checks are the
     // semantic guard against a hand-edited receipt — e.g. someone lowering
     // `peak_rss_bytes` to pass `verify` but leaving the other fields inconsistent.
-    let recorded_u64 =
-        |k: &str| -> Option<u64> { manifest.get_recorded(k).and_then(|v| v.parse::<u64>().ok()) };
+    //
     // The working set is a subset of resident memory; it cannot exceed peak RSS.
-    if let (Some(ws), Some(peak)) = (
-        recorded_u64("max_working_set_bytes"),
-        recorded_u64("peak_rss_bytes"),
-    ) {
+    if let (Some(ws), Some(peak)) = (recorded_ws, recorded_peak) {
         if ws > peak {
             problems.push(format!(
                 "internally inconsistent: max_working_set_bytes ({ws}) exceeds peak_rss_bytes ({peak})"
@@ -961,8 +968,8 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
         manifest
             .get_recorded("contract_verdict")
             .map(String::as_str),
-        recorded_u64("memory_budget_mb"),
-        recorded_u64("peak_rss_bytes"),
+        recorded_budget,
+        recorded_peak,
     ) {
         let actually_within = rosalind::core::MemoryBudget::from_mb(mb).admits(peak);
         if verdict == "within" && !actually_within {
@@ -994,13 +1001,27 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
     }
 
     // Measurement self-hash: catches an edit to a measured field (e.g. lowering
-    // peak_rss_bytes to fake a fit) that the claim hash cannot see by design. A
-    // pre-v2 / measurement-free receipt has none — silently skip.
+    // peak_rss_bytes to fake a fit) that the claim hash cannot see by design. This is
+    // an unkeyed self-hash — tamper-EVIDENCE against an accidental edit, not
+    // tamper-resistance against a forger who re-hashes; the cross-checks above are the
+    // semantic backstop.
     match manifest.measurement_hash_ok() {
-        Some(true) | None => {}
+        Some(true) => {}
         Some(false) => problems.push(
             "measurement_blake3 mismatch: a measured field was modified after the run".to_string(),
         ),
+        // No measurement block. Legitimate for a pre-v2 / measurement-free receipt —
+        // but if the (hash-protected) claim records that one must exist, its absence
+        // means the whole block was stripped to evade the budget/consistency checks.
+        None => {
+            if manifest.claims_measurements() {
+                problems.push(
+                    "measurement block missing: the claim records a measurement block but \
+                     the receipt has none (stripped after the run?)"
+                        .to_string(),
+                );
+            }
+        }
     }
 
     if problems.is_empty() {

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -6,8 +6,13 @@
 //! The receipt is split into a deterministic **claim** (inputs, outputs, params,
 //! subcommand, versions) and a machine-/run-dependent **measurement** block (peak
 //! RSS, working set, verdict, …). The self-hash (`manifest_blake3`) covers the
-//! claim only — so the same logical run hashes identically on any machine — while
-//! a second `measurement_blake3` keeps the measured cost locally tamper-evident.
+//! claim only — so the machine-dependent measured *cost* no longer perturbs it —
+//! while a second `measurement_blake3` keeps that cost locally tamper-evident.
+//!
+//! Scope note: this removes the measured *cost* from the claim hash. Recorded
+//! input/output *paths* are still part of the claim, so two machines with the same
+//! data at different paths still hash differently — a separate machine-dependent
+//! axis (path normalization / content-only claim) left to a later phase.
 
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
@@ -16,13 +21,13 @@ use std::path::{Path, PathBuf};
 /// Current receipt/feature schema version. Bump on any breaking schema change.
 /// v2: the receipt is split into a deterministic *claim* and a machine-dependent
 /// *measurement* block; the self-hash (`manifest_blake3`) covers the claim only, so
-/// the same logical run hashes identically on any machine.
+/// the measured cost no longer perturbs it.
 pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
 
 /// Keys whose values are machine-/run-dependent measurements, not part of the
 /// deterministic claim. `finalize` relocates these out of `params` into the
-/// `measurements` block so the claim hash is identical for the same logical run on
-/// any machine. The single audited source of truth for the claim/measurement split.
+/// `measurements` block so the measured cost is excluded from the claim hash. The
+/// single audited source of truth for the claim/measurement split.
 pub const MEASUREMENT_KEYS: &[&str] = &[
     "peak_rss_bytes",
     "max_working_set_bytes",
@@ -98,8 +103,8 @@ impl RunManifest {
     }
 
     /// The claim-only canonical JSON: never emits the measurement block. This is the
-    /// portion the self-hash commits to, so the hash is identical for the same
-    /// logical run on any machine.
+    /// portion the self-hash commits to, so the measured cost is excluded from the
+    /// claim hash.
     pub fn to_canonical_claim_json(&self) -> String {
         self.push_canonical(false)
     }
@@ -141,8 +146,9 @@ impl RunManifest {
     }
 
     /// BLAKE3 hex of the **claim** canonical JSON with the self-hash excluded — the
-    /// content this manifest commits to, identical on any machine (the measurement
-    /// block is excluded). Deterministic; `verify` re-derives it.
+    /// content this manifest commits to. Excludes the machine-dependent measurement
+    /// block, so the measured cost does not perturb it. Deterministic; `verify`
+    /// re-derives it. (Recorded paths remain in the claim — see the module note.)
     pub fn content_hash(&self) -> String {
         let mut m = self.clone();
         m.params.remove("manifest_blake3");
@@ -168,22 +174,40 @@ impl RunManifest {
         self.measurements.get(key).or_else(|| self.params.get(key))
     }
 
+    /// Whether the (hash-protected) claim records that a measurement block exists.
+    /// `verify` uses this to detect a measurement block stripped after the run — a
+    /// claim that says `has_measurements` paired with a receipt that has none.
+    pub fn claims_measurements(&self) -> bool {
+        self.params
+            .get("has_measurements")
+            .map(|v| v == "true")
+            .unwrap_or(false)
+    }
+
     /// Seal the receipt: partition measured fields out of the claim, stamp the
     /// measurement hash, the schema version, then the claim self-hash LAST (so it
     /// covers every other claim field, including the version). Idempotent.
     pub fn finalize(&mut self) {
         // 1. Partition: relocate machine-dependent fields OUT of the claim so the
-        //    claim hash is identical for the same logical run on any machine.
+        //    measured cost no longer perturbs the claim hash.
         for key in MEASUREMENT_KEYS {
             if let Some(v) = self.params.remove(*key) {
                 self.measurements.insert((*key).to_string(), v);
             }
         }
-        // 2. Local measurement attestation (only when a measurement exists).
+        // 2. Local measurement attestation (only when a measurement exists), plus a
+        //    DETERMINISTIC marker in the claim recording that a block exists. The
+        //    marker is covered by the claim self-hash and is identical for the same
+        //    logical run on any machine (unlike `measurement_blake3`, which hashes
+        //    machine-dependent numbers and so cannot live in the claim). It lets
+        //    `verify` catch a measurement block stripped to evade the cost checks:
+        //    dropping the block leaves the claim asserting one must exist.
         if !self.measurements.is_empty() {
             let mh = self.measurement_hash();
             self.measurements
                 .insert("measurement_blake3".to_string(), mh);
+            self.params
+                .insert("has_measurements".to_string(), "true".to_string());
         }
         // 3. Stamp the version into the claim, then the claim self-hash last.
         self.params.insert(
@@ -327,7 +351,12 @@ impl Parser<'_> {
             let k = self.parse_string()?;
             self.expect(b':')?;
             let v = self.parse_string()?;
-            map.insert(k, v);
+            // Reject duplicate keys: a crafted receipt with two values for one key
+            // could otherwise show one value to a human reader while `verify` (and
+            // `get_recorded`) act on the other.
+            if map.insert(k.clone(), v).is_some() {
+                return Err(self.err(&format!("duplicate key \"{k}\"")));
+            }
             match self.b.get(self.i) {
                 Some(b',') => self.i += 1,
                 Some(b'}') => {
@@ -809,5 +838,59 @@ mod tests {
         );
         assert_eq!(parsed.self_hash_ok(), Some(true));
         assert_eq!(parsed.measurement_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn finalize_records_a_claim_marker_only_when_a_measurement_exists() {
+        // With a measurement: the claim records has_measurements (so stripping the
+        // block is detectable), and the marker is covered by the claim self-hash.
+        let mut with = RunManifest::new("variants");
+        with.tool_version = "0.1.0".to_string();
+        with.record_measurement("peak_rss_bytes", "123");
+        with.finalize();
+        assert!(with.claims_measurements());
+        assert_eq!(
+            with.params.get("has_measurements").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(with.self_hash_ok(), Some(true));
+
+        // Without a measurement (e.g. a somatic run): no marker, nothing to strip.
+        let mut without = RunManifest::new("somatic");
+        without.tool_version = "0.1.0".to_string();
+        without.finalize();
+        assert!(!without.claims_measurements());
+        assert!(!without.params.contains_key("has_measurements"));
+    }
+
+    #[test]
+    fn stripping_the_measurement_block_leaves_the_claim_asserting_one_exists() {
+        // The deletion-bypass guard: clearing the measurement block keeps the claim
+        // self-hash valid (the claim never carried the block), but the claim still
+        // records has_measurements while measurement_hash_ok drops to None — the
+        // exact signal `verify` keys on.
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.record_measurement("peak_rss_bytes", "900000000");
+        m.finalize();
+        m.measurements.clear();
+        assert_eq!(
+            m.self_hash_ok(),
+            Some(true),
+            "claim is intact after stripping"
+        );
+        assert_eq!(m.measurement_hash_ok(), None, "no block to hash");
+        assert!(
+            m.claims_measurements(),
+            "the claim still asserts a measurement block must exist"
+        );
+    }
+
+    #[test]
+    fn parser_rejects_a_duplicate_key() {
+        // A crafted receipt cannot carry two values for one key (reader/verifier
+        // shadowing). `params` and `measurements` both go through `parse_params`.
+        let dup = r#"{"inputs":[],"outputs":[],"params":{"k":"1","k":"2"},"subcommand":"x","tool_version":"0.1.0"}"#;
+        assert!(RunManifest::from_canonical_json(dup).is_err());
     }
 }

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -1,15 +1,37 @@
 //! A minimal, deterministic reproducibility receipt for a run: tool version,
 //! subcommand, BLAKE3 content hashes of inputs + outputs, and the parameters.
 //! Serialized as canonical JSON (sorted keys, no timestamps) so two identical
-//! runs produce a byte-identical manifest. Full `rosalind verify` is a later
-//! phase; this phase emits the receipt and proves it is deterministic.
+//! runs produce a byte-identical manifest.
+//!
+//! The receipt is split into a deterministic **claim** (inputs, outputs, params,
+//! subcommand, versions) and a machine-/run-dependent **measurement** block (peak
+//! RSS, working set, verdict, …). The self-hash (`manifest_blake3`) covers the
+//! claim only — so the same logical run hashes identically on any machine — while
+//! a second `measurement_blake3` keeps the measured cost locally tamper-evident.
 
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 /// Current receipt/feature schema version. Bump on any breaking schema change.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+/// v2: the receipt is split into a deterministic *claim* and a machine-dependent
+/// *measurement* block; the self-hash (`manifest_blake3`) covers the claim only, so
+/// the same logical run hashes identically on any machine.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
+
+/// Keys whose values are machine-/run-dependent measurements, not part of the
+/// deterministic claim. `finalize` relocates these out of `params` into the
+/// `measurements` block so the claim hash is identical for the same logical run on
+/// any machine. The single audited source of truth for the claim/measurement split.
+pub const MEASUREMENT_KEYS: &[&str] = &[
+    "peak_rss_bytes",
+    "max_working_set_bytes",
+    "predicted_peak_rss_bytes",
+    "baseline_rss_bytes",
+    "rss_residual_bytes",
+    "governor",
+    "contract_verdict",
+];
 
 /// Failure parsing a canonical run manifest.
 #[derive(Debug)]
@@ -45,6 +67,9 @@ pub struct RunManifest {
     pub params: BTreeMap<String, String>,
     /// Output files and their content hashes.
     pub outputs: Vec<FileHash>,
+    /// Machine-/run-dependent measured cost (peak RSS, working set, verdict, …),
+    /// excluded from the claim hash. Carries its own `measurement_blake3`.
+    pub measurements: BTreeMap<String, String>,
 }
 
 impl RunManifest {
@@ -56,40 +81,51 @@ impl RunManifest {
             inputs: Vec::new(),
             params: BTreeMap::new(),
             outputs: Vec::new(),
+            measurements: BTreeMap::new(),
         }
     }
 
-    /// Serialize to canonical JSON: keys sorted, `inputs`/`outputs` sorted by
-    /// path, no timestamps — so identical runs hash and render identically.
+    /// Record a machine-/run-dependent measurement (excluded from the claim hash).
+    pub fn record_measurement(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.measurements.insert(key.into(), value.into());
+    }
+
+    /// Serialize to canonical JSON: keys sorted, arrays sorted by path, no
+    /// timestamps — so identical runs render identically. Includes the measurement
+    /// block (when non-empty). This is the on-disk receipt.
     pub fn to_canonical_json(&self) -> String {
+        self.push_canonical(true)
+    }
+
+    /// The claim-only canonical JSON: never emits the measurement block. This is the
+    /// portion the self-hash commits to, so the hash is identical for the same
+    /// logical run on any machine.
+    pub fn to_canonical_claim_json(&self) -> String {
+        self.push_canonical(false)
+    }
+
+    /// Render the canonical JSON, optionally including the measurement block.
+    /// Canonical key order is alphabetical, so `measurements` sits between `inputs`
+    /// and `outputs`; it is emitted only when non-empty (a pre-v2 receipt and a
+    /// measurement-free v2 receipt are byte-identical).
+    fn push_canonical(&self, include_measurements: bool) -> String {
         let mut out = String::new();
         out.push('{');
-
         out.push_str("\"inputs\":");
         push_file_hashes(&mut out, &self.inputs);
-
+        if include_measurements && !self.measurements.is_empty() {
+            out.push_str(",\"measurements\":");
+            push_string_map(&mut out, &self.measurements);
+        }
         out.push_str(",\"outputs\":");
         push_file_hashes(&mut out, &self.outputs);
-
-        out.push_str(",\"params\":{");
-        for (i, (k, v)) in self.params.iter().enumerate() {
-            if i > 0 {
-                out.push(',');
-            }
-            out.push('"');
-            out.push_str(&json_escape(k));
-            out.push_str("\":\"");
-            out.push_str(&json_escape(v));
-            out.push('"');
-        }
-        out.push('}');
-
+        out.push_str(",\"params\":");
+        push_string_map(&mut out, &self.params);
         out.push_str(",\"subcommand\":\"");
         out.push_str(&json_escape(&self.subcommand));
         out.push_str("\",\"tool_version\":\"");
         out.push_str(&json_escape(&self.tool_version));
         out.push_str("\"}");
-
         out
     }
 
@@ -104,17 +140,52 @@ impl RunManifest {
         p.parse_manifest()
     }
 
-    /// BLAKE3 hex of the canonical JSON with the self-hash field excluded — the
-    /// content this manifest commits to. Deterministic; `verify` re-derives it.
+    /// BLAKE3 hex of the **claim** canonical JSON with the self-hash excluded — the
+    /// content this manifest commits to, identical on any machine (the measurement
+    /// block is excluded). Deterministic; `verify` re-derives it.
     pub fn content_hash(&self) -> String {
         let mut m = self.clone();
         m.params.remove("manifest_blake3");
-        blake3_hex(m.to_canonical_json().as_bytes())
+        blake3_hex(m.to_canonical_claim_json().as_bytes())
     }
 
-    /// Stamp the schema version + the self-hash. Call LAST, immediately before
-    /// serialization, so the hash covers every other field (including the version).
+    /// BLAKE3 hex of the measurement block with `measurement_blake3` excluded — a
+    /// LOCAL attestation of the measured cost. Not cross-machine stable by design
+    /// (it hashes machine-dependent numbers), so it lives inside the measurement
+    /// block rather than the claim.
+    pub fn measurement_hash(&self) -> String {
+        let mut m = self.measurements.clone();
+        m.remove("measurement_blake3");
+        let mut s = String::new();
+        push_string_map(&mut s, &m);
+        blake3_hex(s.as_bytes())
+    }
+
+    /// Look up a recorded value by key, checking `measurements` then `params`. Lets
+    /// `verify` read v2 receipts (measured fields in `measurements`) and pre-v2
+    /// receipts (everything in `params`) uniformly.
+    pub fn get_recorded(&self, key: &str) -> Option<&String> {
+        self.measurements.get(key).or_else(|| self.params.get(key))
+    }
+
+    /// Seal the receipt: partition measured fields out of the claim, stamp the
+    /// measurement hash, the schema version, then the claim self-hash LAST (so it
+    /// covers every other claim field, including the version). Idempotent.
     pub fn finalize(&mut self) {
+        // 1. Partition: relocate machine-dependent fields OUT of the claim so the
+        //    claim hash is identical for the same logical run on any machine.
+        for key in MEASUREMENT_KEYS {
+            if let Some(v) = self.params.remove(*key) {
+                self.measurements.insert((*key).to_string(), v);
+            }
+        }
+        // 2. Local measurement attestation (only when a measurement exists).
+        if !self.measurements.is_empty() {
+            let mh = self.measurement_hash();
+            self.measurements
+                .insert("measurement_blake3".to_string(), mh);
+        }
+        // 3. Stamp the version into the claim, then the claim self-hash last.
         self.params.insert(
             "schema_version".to_string(),
             MANIFEST_SCHEMA_VERSION.to_string(),
@@ -123,12 +194,20 @@ impl RunManifest {
         self.params.insert("manifest_blake3".to_string(), h);
     }
 
-    /// `Some(true)`/`Some(false)` if a self-hash is recorded and matches / mismatches;
-    /// `None` if none is recorded (a pre-1.2 receipt).
+    /// `Some(true)`/`Some(false)` if a claim self-hash is recorded and matches /
+    /// mismatches; `None` if none is recorded (a pre-1.2 receipt).
     pub fn self_hash_ok(&self) -> Option<bool> {
         self.params
             .get("manifest_blake3")
             .map(|recorded| *recorded == self.content_hash())
+    }
+
+    /// `Some(true)`/`Some(false)` if a measurement self-hash is recorded and matches /
+    /// mismatches; `None` if none is recorded (no measurement block, or a pre-v2 receipt).
+    pub fn measurement_hash_ok(&self) -> Option<bool> {
+        self.measurements
+            .get("measurement_blake3")
+            .map(|recorded| *recorded == self.measurement_hash())
     }
 }
 
@@ -266,8 +345,22 @@ impl Parser<'_> {
         self.expect_key("inputs")?;
         let inputs = self.parse_file_array()?;
         self.expect(b',')?;
-        self.expect_key("outputs")?;
-        let outputs = self.parse_file_array()?;
+        // `measurements` is optional: absent in pre-v2 receipts and measurement-free
+        // runs. Read the next key and branch on whether it is the measurement block.
+        let key = self.parse_string()?;
+        self.expect(b':')?;
+        let (measurements, outputs) = if key == "measurements" {
+            let m = self.parse_params()?;
+            self.expect(b',')?;
+            self.expect_key("outputs")?;
+            (m, self.parse_file_array()?)
+        } else if key == "outputs" {
+            (BTreeMap::new(), self.parse_file_array()?)
+        } else {
+            return Err(self.err(&format!(
+                "expected \"measurements\" or \"outputs\", got \"{key}\""
+            )));
+        };
         self.expect(b',')?;
         self.expect_key("params")?;
         let params = self.parse_params()?;
@@ -284,6 +377,7 @@ impl Parser<'_> {
             inputs,
             params,
             outputs,
+            measurements,
         })
     }
 }
@@ -304,6 +398,23 @@ fn push_file_hashes(out: &mut String, files: &[FileHash]) {
         out.push_str("\"}");
     }
     out.push(']');
+}
+
+/// Render a `{"k":"v",…}` object, entries in the map's (sorted) key order. Shared by
+/// the `params` and `measurements` blocks (both are `string → string`).
+fn push_string_map(out: &mut String, map: &BTreeMap<String, String>) {
+    out.push('{');
+    for (i, (k, v)) in map.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&json_escape(k));
+        out.push_str("\":\"");
+        out.push_str(&json_escape(v));
+        out.push('"');
+    }
+    out.push('}');
 }
 
 /// Minimal RFC-8259 string escaping for the characters we can encounter.
@@ -536,5 +647,167 @@ mod tests {
         m.finalize();
         assert_eq!(m.params.get("manifest_blake3").cloned(), first);
         assert_eq!(m.self_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn claim_hash_is_stable_across_machine_dependent_measurements() {
+        // Same logical run on two machines: identical claim, different measured cost.
+        // The claim self-hash must match; the measurement is excluded from it.
+        let mk = |peak: &str, ws: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.fa".to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.outputs.push(FileHash {
+                path: "out.vcf".to_string(),
+                blake3: "bb".to_string(),
+            });
+            m.params.insert("min_qual".to_string(), "30".to_string());
+            m.record_measurement("peak_rss_bytes", peak);
+            m.record_measurement("max_working_set_bytes", ws);
+            m.finalize();
+            m
+        };
+        let a = mk("1000000", "4096");
+        let b = mk("9999999", "8192");
+        assert_eq!(
+            a.content_hash(),
+            b.content_hash(),
+            "measured cost must not change the claim hash"
+        );
+        assert_eq!(a.self_hash_ok(), Some(true));
+        assert_eq!(b.self_hash_ok(), Some(true));
+        // Differing measurements DO change the measurement hash.
+        assert_ne!(
+            a.measurements.get("measurement_blake3"),
+            b.measurements.get("measurement_blake3")
+        );
+    }
+
+    #[test]
+    fn claim_excludes_but_full_form_includes_measurements() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.record_measurement("peak_rss_bytes", "123");
+        m.finalize();
+        assert!(
+            !m.to_canonical_claim_json().contains("peak_rss_bytes"),
+            "claim form must not carry the measurement"
+        );
+        assert!(
+            m.to_canonical_json().contains("peak_rss_bytes"),
+            "full form must record the measurement"
+        );
+    }
+
+    #[test]
+    fn editing_a_measurement_breaks_only_the_measurement_hash() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.record_measurement("peak_rss_bytes", "123");
+        m.finalize();
+        assert_eq!(m.self_hash_ok(), Some(true));
+        assert_eq!(m.measurement_hash_ok(), Some(true));
+        // Lower the recorded peak WITHOUT re-finalizing (a tampered receipt).
+        m.measurements
+            .insert("peak_rss_bytes".to_string(), "1".to_string());
+        assert_eq!(
+            m.self_hash_ok(),
+            Some(true),
+            "claim hash is unaffected by the measurement edit"
+        );
+        assert_eq!(
+            m.measurement_hash_ok(),
+            Some(false),
+            "measurement hash must catch the edit"
+        );
+    }
+
+    #[test]
+    fn finalize_relocates_measured_keys_out_of_the_claim() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        // Insert measured fields the legacy way (into params); finalize must relocate.
+        m.params
+            .insert("peak_rss_bytes".to_string(), "555".to_string());
+        m.params
+            .insert("contract_verdict".to_string(), "within".to_string());
+        m.params.insert("min_qual".to_string(), "30".to_string());
+        m.finalize();
+        for k in ["peak_rss_bytes", "contract_verdict"] {
+            assert!(!m.params.contains_key(k), "{k} must leave the claim");
+            assert!(
+                m.measurements.contains_key(k),
+                "{k} must enter measurements"
+            );
+        }
+        assert!(m.params.contains_key("min_qual"), "claim params stay put");
+    }
+
+    #[test]
+    fn pre_v2_receipt_with_measurements_in_params_still_verifies() {
+        // A pre-v2 receipt: peak in params, no measurements key, schema 1, self-hash
+        // over the params-inclusive claim. It must still self-verify (graceful degrade).
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.params
+            .insert("peak_rss_bytes".to_string(), "123".to_string());
+        m.params
+            .insert("schema_version".to_string(), "1".to_string());
+        let h = m.content_hash();
+        m.params.insert("manifest_blake3".to_string(), h);
+
+        assert_eq!(m.self_hash_ok(), Some(true));
+        assert_eq!(m.measurement_hash_ok(), None, "no measurement block in v1");
+        let json = m.to_canonical_json();
+        assert!(
+            !json.contains("\"measurements\""),
+            "v1 emits no measurements key"
+        );
+        let parsed = RunManifest::from_canonical_json(&json).expect("parse v1");
+        assert!(parsed.measurements.is_empty());
+        assert_eq!(parsed.self_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn v2_receipt_round_trips_through_the_parser() {
+        let mut m = RunManifest::new("features");
+        m.tool_version = "9.9.9".to_string();
+        m.inputs.push(FileHash {
+            path: "a.idx".to_string(),
+            blake3: "aa".to_string(),
+        });
+        m.outputs.push(FileHash {
+            path: "out.tsv".to_string(),
+            blake3: "bb".to_string(),
+        });
+        m.params
+            .insert("feature_rows".to_string(), "42".to_string());
+        m.record_measurement("peak_rss_bytes", "1000");
+        m.record_measurement("governor", "enforced");
+        m.finalize();
+
+        let json = m.to_canonical_json();
+        let parsed = RunManifest::from_canonical_json(&json).expect("parse v2");
+        assert_eq!(
+            parsed.to_canonical_json(),
+            json,
+            "round-trip is the identity"
+        );
+        assert_eq!(
+            parsed
+                .measurements
+                .get("peak_rss_bytes")
+                .map(String::as_str),
+            Some("1000")
+        );
+        assert_eq!(
+            parsed.params.get("feature_rows").map(String::as_str),
+            Some("42")
+        );
+        assert_eq!(parsed.self_hash_ok(), Some(true));
+        assert_eq!(parsed.measurement_hash_ok(), Some(true));
     }
 }

--- a/tests/gvcf.rs
+++ b/tests/gvcf.rs
@@ -154,7 +154,7 @@ fn gvcf_is_banded_byte_reproducible_and_well_formed() {
     // Bounded: the receipt records a small realized peak (coverage-bounded).
     let m = std::fs::read_to_string(&manifest).unwrap();
     let rm = rosalind::provenance::RunManifest::from_canonical_json(&m).unwrap();
-    assert!(rm.params.contains_key("peak_rss_bytes"));
+    assert!(rm.measurements.contains_key("peak_rss_bytes"));
 
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -397,7 +397,7 @@ fn estimator_upper_bounds_the_realized_working_set() {
     let text = std::fs::read_to_string(&manifest).unwrap();
     let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
     let realized: u64 = m
-        .params
+        .measurements
         .get("max_working_set_bytes")
         .unwrap()
         .parse()
@@ -521,12 +521,17 @@ fn predicted_peak_rss_upper_bounds_realized_peak() {
     let text = std::fs::read_to_string(&manifest).unwrap();
     let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
     let predicted: u64 = m
-        .params
+        .measurements
         .get("predicted_peak_rss_bytes")
         .expect("receipt must record predicted_peak_rss_bytes")
         .parse()
         .unwrap();
-    let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
+    let realized: u64 = m
+        .measurements
+        .get("peak_rss_bytes")
+        .unwrap()
+        .parse()
+        .unwrap();
     assert!(
         predicted >= realized,
         "predicted peak RSS {predicted} must be >= realized peak RSS {realized} \
@@ -646,7 +651,7 @@ fn receipt_records_residual_and_governor_fields_on_a_fitting_run() {
     // The receipt round-trips through the canonical parser.
     let m = rosalind::provenance::RunManifest::from_canonical_json(&text).expect("parse");
     assert_eq!(
-        m.params.get("governor").map(String::as_str),
+        m.measurements.get("governor").map(String::as_str),
         Some("enforced")
     );
     std::fs::remove_dir_all(&dir).ok();
@@ -709,13 +714,23 @@ fn near_saturation_margin_holds_on_a_larger_contig() {
     )
     .unwrap();
     let predicted: u64 = m
-        .params
+        .measurements
         .get("predicted_peak_rss_bytes")
         .unwrap()
         .parse()
         .unwrap();
-    let realized: u64 = m.params.get("peak_rss_bytes").unwrap().parse().unwrap();
-    let residual: u64 = m.params.get("rss_residual_bytes").unwrap().parse().unwrap();
+    let realized: u64 = m
+        .measurements
+        .get("peak_rss_bytes")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let residual: u64 = m
+        .measurements
+        .get("rss_residual_bytes")
+        .unwrap()
+        .parse()
+        .unwrap();
     let assumed: u64 = m
         .params
         .get("io_rss_overhead_assumed_bytes")
@@ -753,10 +768,14 @@ fn receipt_is_self_hashing_and_schema_versioned() {
     let text = std::fs::read_to_string(&manifest).expect("manifest");
     assert!(
         text.contains("\"manifest_blake3\":"),
-        "no self-hash: {text}"
+        "no claim self-hash: {text}"
     );
     assert!(
-        text.contains("\"schema_version\":\"1\""),
+        text.contains("\"measurement_blake3\":"),
+        "no measurement self-hash: {text}"
+    );
+    assert!(
+        text.contains("\"schema_version\":\"2\""),
         "no schema_version: {text}"
     );
     // An untampered receipt verifies.
@@ -808,6 +827,54 @@ fn verify_rejects_a_self_consistent_but_tampered_receipt() {
     assert!(
         stderr.contains("manifest_blake3 mismatch"),
         "expected a self-hash mismatch: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn verify_rejects_a_consistent_measurement_tamper_via_the_measurement_hash() {
+    // Lower the recorded peak while keeping the receipt internally consistent (peak
+    // still within budget, verdict still 'within'). The claim hash cannot see a
+    // measurement edit by design — only the measurement hash catches it.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
+    let recorded_peak = m.measurements.get("peak_rss_bytes").unwrap().clone();
+    // Replace the measured peak with a smaller, still-within-budget value.
+    let tampered = text.replace(
+        &format!("\"peak_rss_bytes\":\"{recorded_peak}\""),
+        "\"peak_rss_bytes\":\"1\"",
+    );
+    assert_ne!(text, tampered, "the replace must have changed the peak");
+    std::fs::write(&manifest, &tampered).unwrap();
+
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "a measurement tamper must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("measurement_blake3 mismatch"),
+        "expected a measurement-hash mismatch: {stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -878,3 +878,51 @@ fn verify_rejects_a_consistent_measurement_tamper_via_the_measurement_hash() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn verify_rejects_a_receipt_with_its_measurement_block_stripped() {
+    // The deletion bypass: drop the WHOLE measurement block (every measured field and
+    // its measurement_blake3). The claim hash still verifies (the claim never carried
+    // the block), and naively a missing measurement hash would read as "nothing to
+    // check". The claim's has_measurements marker — covered by the claim self-hash —
+    // makes the strip detectable: verify must refuse.
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    let mut m = rosalind::provenance::RunManifest::from_canonical_json(&text).unwrap();
+    assert!(
+        m.claims_measurements() && !m.measurements.is_empty(),
+        "fixture must record a measurement block to strip"
+    );
+    m.measurements.clear();
+    std::fs::write(&manifest, m.to_canonical_json()).unwrap();
+
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "a stripped measurement block must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("measurement block missing"),
+        "expected a stripped-block error: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## What & why

`RunManifest::content_hash()` hashed the **whole** canonical JSON, including the machine-dependent measured fields a run records (`peak_rss_bytes`, `max_working_set_bytes`, `predicted/baseline/residual` RSS, `governor`, `contract_verdict`). So **the same correct run on two machines produced two different receipt hashes** — making `manifest_blake3` useless as a cross-machine identity and silently breaking everything downstream that needs a stable receipt (chain → `reproduce` → cohort).

This splits the receipt into a deterministic **claim** (inputs, outputs, params, subcommand, versions) and a machine-dependent **measurement** block. `content_hash()` now hashes the **claim only**, so the measured cost no longer perturbs it.

## The split is lossless

Before this change, the single self-hash covered `peak_rss_bytes` (it lived in the claimed `params`), so the receipt was tamper-evident against an edit to the measured peak. Simply dropping the measurement from the hash would regress that. So the split adds a second, local hash:

| Layer | Hash | Covers | Cross-machine stable? |
|---|---|---|---|
| Claim | `manifest_blake3` (in `params`) | inputs, outputs, params, subcommand, versions | **yes** |
| Measurement | `measurement_blake3` (in `measurements`) | the 7 measured fields | no (local attestation) |

## Design

- New `measurements: BTreeMap` block; canonical key sits alphabetically between `inputs` and `outputs`, emitted only when non-empty.
- `MEASUREMENT_KEYS` is the single audited policy list; `finalize()` relocates those keys out of the claim, stamps `measurement_blake3`, then the claim self-hash.
- **Backward compatible:** the parser optionally consumes the new key; a parsed v1 receipt (peak in `params`, no measurements) reproduces its old claim hash byte-for-byte and still self-verifies. `MANIFEST_SCHEMA_VERSION` 1 → 2.
- `verify` reads measured/declared fields via `get_recorded` (measurements → params) and checks `measurement_blake3` beside the claim self-hash.

## Adversarial review (ran before merge) — findings fixed

- **CRITICAL deletion bypass:** dropping the whole `measurements` block made `measurement_hash_ok()` return `None` (read as OK) while every `if let Some` consistency check no-oped → an over-budget receipt verified clean. **Fix:** `finalize()` stamps a deterministic `has_measurements` marker **into the claim** (covered by the cross-machine-stable claim hash; the measurement hash is machine-dependent and can't live there); `verify` flags a claimed-but-absent block. Unit + e2e tests.
- **Malformed-numeric silently skipped:** a present-but-corrupt measured field was indistinguishable from absent and disabled its check → now pushes a problem.
- **Duplicate-key shadowing:** `parse_params` accepted dup keys (last wins) → now rejected.
- **Honest framing:** corrected the "identical on any machine" overclaim — this removes the measured **cost**; recorded **paths** are a separate machine-dependent axis, flagged in code + spec and tracked as roadmap **P0.2b**. `measurement_blake3` documented as unkeyed tamper-*evidence*, not authentication.

## Tests

All 25 test binaries green; clippy `-D warnings` clean; MSRV 1.83 builds. New provenance unit tests (cross-machine claim stability, claim-excludes/full-includes, measurement tamper-evidence, v1 back-compat, v2 round-trip, stripped-block marker, duplicate-key rejection) + e2e `verify` tests for measurement-tamper and stripped-block.

Spec: `docs/superpowers/specs/2026-06-02-p0-2-claim-measurement-split-design.md` · Plan: `docs/superpowers/plans/2026-06-02-p0-2-claim-measurement-split.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)