### PR TITLE
feat(provenance): content-only claim hash — cross-machine content-address (P0.2b)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,12 +134,13 @@ Everything downstream rests on the proofs being literally correct. Two verified 
   **DONE** (claim/measurement split shipped; the split is lossless — a second `measurement_blake3` keeps
   the measured cost locally tamper-evident, and a hash-protected `has_measurements` claim marker catches a
   stripped measurement block).
-- **P0.2b — Path-normalized / content-only claim.** *(S)* P0.2 removed the measured *cost* from the claim
-  hash, but recorded input/output **paths** (`FileHash.path`) are still in the claim, recorded verbatim —
-  so two machines with byte-identical data at different paths still hash differently. To make the claim
-  hash a true cross-machine content-address (the property chaining/reproduce/cohort actually need),
-  normalize paths out of the *claim* form (e.g. key the claim on the sorted `blake3` digests; keep the
-  full path in the on-disk receipt for humans). Pairs naturally with P0.3.
+- **P0.2b — Path-normalized / content-only claim.** *(S)* **DONE.** P0.2 removed the measured *cost* from
+  the claim hash, but recorded input/output **paths** (`FileHash.path`) were still in the claim, recorded
+  verbatim — so two machines with byte-identical data at different paths still hashed differently. The
+  schema-3 claim now keys inputs/outputs on their sorted `blake3` digests (paths dropped from the *claim*
+  form; the on-disk receipt keeps full paths for humans and for `verify` to re-hash files), making the
+  claim hash a true cross-machine content-address. Version-gated (schema <3 reproduces the path-inclusive
+  form so pre-P0.2b receipts still self-verify). This is the property chaining/reproduce/cohort need.
 - **P0.3 — Build-identity in the receipt.** *(S)* Replace the `tool_version = "0.1.0"` half-measure with
   `code_git_sha` + `code_dirty` + `rustc_version` + `target_triple` + `deps_lock_blake3` (via `build.rs`)
   and a `verify --expect-code <sha>` gate, so "exactly this code" stops being a lie and becomes a real

--- a/docs/superpowers/plans/2026-06-02-p0-2b-content-only-claim.md
+++ b/docs/superpowers/plans/2026-06-02-p0-2b-content-only-claim.md
@@ -1,0 +1,289 @@
+# P0.2b — Content-only claim hash — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Make `manifest_blake3` a cross-machine content-address by hashing inputs/outputs as their
+sorted `blake3` digests (dropping machine-specific paths) in the claim form, version-gated for
+back-compat.
+
+**Architecture:** A `FileRender` enum threads through the canonical serializer. The on-disk form
+stays `{path, blake3}`; the claim form (for `schema_version >= 3`) becomes `["<blake3>",…]` sorted.
+`finalize` bumps schema 2→3. `verify` unchanged (re-hashes from the on-disk paths).
+
+**Reference:** spec `docs/superpowers/specs/2026-06-02-p0-2b-content-only-claim-design.md`.
+
+---
+
+### Task 1: Unit tests (RED)
+
+**Files:** Modify `src/provenance/mod.rs` (append to `mod tests`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn claim_hash_is_stable_across_machine_dependent_paths() {
+        // Same content (blake3) at DIFFERENT paths on two machines → SAME claim hash.
+        // The keystone of P0.2b: paths are dropped from the claim form.
+        let mk = |idx_path: &str, out_path: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: idx_path.to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.outputs.push(FileHash {
+                path: out_path.to_string(),
+                blake3: "bb".to_string(),
+            });
+            m.params.insert("min_qual".to_string(), "30".to_string());
+            m.finalize();
+            m
+        };
+        let a = mk("/home/alice/ref.idx", "/tmp/run-1/out.vcf");
+        let b = mk("/data/ref.idx", "out.vcf");
+        assert_eq!(
+            a.content_hash(),
+            b.content_hash(),
+            "the claim hash must not depend on recorded paths"
+        );
+        assert_eq!(a.self_hash_ok(), Some(true));
+        assert_eq!(b.self_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn claim_hash_still_tracks_content() {
+        // Different content (blake3) → different claim hash (the address is the content).
+        let mk = |digest: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.idx".to_string(),
+                blake3: digest.to_string(),
+            });
+            m.finalize();
+            m
+        };
+        assert_ne!(mk("aa").content_hash(), mk("bb").content_hash());
+    }
+
+    #[test]
+    fn claim_drops_paths_but_the_on_disk_form_keeps_them() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.inputs.push(FileHash {
+            path: "/home/alice/secret/ref.idx".to_string(),
+            blake3: "aa".to_string(),
+        });
+        m.finalize();
+        assert!(
+            !m.to_canonical_claim_json().contains("/home/alice"),
+            "the claim form must not carry the recorded path"
+        );
+        assert!(
+            m.to_canonical_json().contains("/home/alice"),
+            "the on-disk form must keep the recorded path"
+        );
+        // The content digest is present in BOTH.
+        assert!(m.to_canonical_claim_json().contains("aa"));
+    }
+
+    #[test]
+    fn pre_p0_2b_receipt_with_paths_in_the_claim_still_verifies() {
+        // A schema-2 receipt hashed paths INTO the claim. The version gate must
+        // reproduce that path-inclusive form so it still self-verifies; a schema-3
+        // receipt over the same files hashes differently (the form changed).
+        let mk = |schema: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.idx".to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.params
+                .insert("schema_version".to_string(), schema.to_string());
+            let h = m.content_hash();
+            m.params.insert("manifest_blake3".to_string(), h);
+            m
+        };
+        let v2 = mk("2");
+        assert_eq!(v2.self_hash_ok(), Some(true), "schema-2 must self-verify");
+        let v3 = mk("3");
+        assert_eq!(v3.self_hash_ok(), Some(true), "schema-3 must self-verify");
+        assert_ne!(
+            v2.params.get("manifest_blake3"),
+            v3.params.get("manifest_blake3"),
+            "the claim form genuinely differs between schema 2 and 3"
+        );
+    }
+```
+
+- [ ] **Step 2: Confirm RED**
+
+Run: `cargo test -p rosalind --lib provenance 2>&1 | tail -15`
+Expected: `claim_hash_is_stable_across_machine_dependent_paths` FAILS (paths still in the claim →
+`a` and `b` differ); `claim_drops_paths_...` FAILS; the back-compat test FAILS (no version gate yet,
+so schema-2 and schema-3 hash identically).
+
+---
+
+### Task 2: Implementation (GREEN)
+
+**Files:** Modify `src/provenance/mod.rs`.
+
+- [ ] **Step 1: Bump the schema version**
+
+```rust
+/// Current receipt/feature schema version. Bump on any breaking schema change.
+/// v2: claim/measurement split. v3: the claim hashes inputs/outputs by their sorted
+/// `blake3` digests (paths dropped) so it is a cross-machine content-address.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
+```
+
+- [ ] **Step 2: Add the `FileRender` enum + thread it through `push_canonical`**
+
+Add above `RunManifest`:
+
+```rust
+/// How input/output file entries render in a canonical form. The on-disk receipt
+/// keeps full `{path, blake3}`; the schema-3 claim drops the path and hashes only the
+/// content digest, so the claim hash does not depend on where files live.
+#[derive(Clone, Copy)]
+enum FileRender {
+    WithPath,
+    ContentOnly,
+}
+```
+
+Replace `push_canonical` to take a `FileRender` and dispatch the file arrays:
+
+```rust
+    fn push_canonical(&self, include_measurements: bool, files: FileRender) -> String {
+        let mut out = String::new();
+        out.push('{');
+        out.push_str("\"inputs\":");
+        push_files(&mut out, &self.inputs, files);
+        if include_measurements && !self.measurements.is_empty() {
+            out.push_str(",\"measurements\":");
+            push_string_map(&mut out, &self.measurements);
+        }
+        out.push_str(",\"outputs\":");
+        push_files(&mut out, &self.outputs, files);
+        out.push_str(",\"params\":");
+        push_string_map(&mut out, &self.params);
+        out.push_str(",\"subcommand\":\"");
+        out.push_str(&json_escape(&self.subcommand));
+        out.push_str("\",\"tool_version\":\"");
+        out.push_str(&json_escape(&self.tool_version));
+        out.push_str("\"}");
+        out
+    }
+```
+
+- [ ] **Step 3: Update the two public canonical methods + add the version gate**
+
+```rust
+    pub fn to_canonical_json(&self) -> String {
+        self.push_canonical(true, FileRender::WithPath)
+    }
+
+    pub fn to_canonical_claim_json(&self) -> String {
+        self.push_canonical(false, self.claim_file_render())
+    }
+
+    /// Schema >= 3 → content-only claim (paths dropped, cross-machine). Older receipts
+    /// hashed paths into the claim; reproduce their form so they still self-verify.
+    fn claim_file_render(&self) -> FileRender {
+        match self
+            .params
+            .get("schema_version")
+            .and_then(|v| v.parse::<u32>().ok())
+        {
+            Some(v) if v >= 3 => FileRender::ContentOnly,
+            _ => FileRender::WithPath,
+        }
+    }
+```
+
+- [ ] **Step 4: Add the `push_files` dispatcher + `push_blake3_list`**
+
+Next to `push_file_hashes`:
+
+```rust
+/// Render a file array in the requested form: `[{"blake3","path"}]` sorted by path
+/// (on-disk), or `["<blake3>",…]` sorted by blake3 (the content-only claim).
+fn push_files(out: &mut String, files: &[FileHash], render: FileRender) {
+    match render {
+        FileRender::WithPath => push_file_hashes(out, files),
+        FileRender::ContentOnly => push_blake3_list(out, files),
+    }
+}
+
+/// Render `["<blake3>",…]`, sorted by digest (a content multiset — duplicates kept).
+fn push_blake3_list(out: &mut String, files: &[FileHash]) {
+    let mut digests: Vec<&str> = files.iter().map(|f| f.blake3.as_str()).collect();
+    digests.sort_unstable();
+    out.push('[');
+    for (i, d) in digests.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&json_escape(d));
+        out.push('"');
+    }
+    out.push(']');
+}
+```
+
+- [ ] **Step 5: Update doc comments for the dropped-paths reality**
+
+Update the module "Scope note" and `content_hash`'s "(Recorded paths remain in the claim…)" note to
+say paths are now dropped from the schema-3 claim. Update the P0.2-era line accordingly.
+
+- [ ] **Step 6: Run provenance tests (GREEN)**
+
+Run: `cargo test -p rosalind --lib provenance 2>&1 | tail -28`
+Expected: all green (new P0.2b tests + every P0.2 test, including the v1/v2 back-compat ones).
+
+- [ ] **Step 7: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add src/provenance/mod.rs docs/superpowers/specs/2026-06-02-p0-2b-content-only-claim-design.md docs/superpowers/plans/2026-06-02-p0-2b-content-only-claim.md
+git commit -m "feat(provenance): content-only claim hash — cross-machine content-address (P0.2b)"
+```
+
+---
+
+### Task 3: Integration assertion + full verification
+
+**Files:** Modify `tests/plan_enforce.rs`.
+
+- [ ] **Step 1: Bump the schema assertion**
+
+In `receipt_is_self_hashing_and_schema_versioned`: `"\"schema_version\":\"2\""` → `"\"schema_version\":\"3\""`.
+
+- [ ] **Step 2: Full suite + clippy + MSRV**
+
+```bash
+cargo test 2>&1 | grep -E "test result: FAILED|FAILED|^error"   # expect none
+cargo clippy --all-targets -- -D warnings 2>&1 | tail -3        # clean
+cargo +1.83 build 2>&1 | tail -3                                # MSRV (CI covers if absent)
+```
+
+- [ ] **Step 3: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add tests/plan_enforce.rs
+git commit -m "test: receipt now schema 3 (content-only claim)"
+```
+
+- [ ] **Step 4: Push, PR, watch CI, merge on green**
+
+```bash
+git push -u origin rosalind/p0-2b-content-only-claim
+gh pr create --title "feat(provenance): content-only claim hash — cross-machine content-address (P0.2b)" --body "<summary>"
+gh pr checks --watch
+```

--- a/docs/superpowers/specs/2026-06-02-p0-2b-content-only-claim-design.md
+++ b/docs/superpowers/specs/2026-06-02-p0-2b-content-only-claim-design.md
@@ -1,0 +1,110 @@
+# P0.2b — Path-normalized (content-only) claim hash
+
+**Status:** design
+**Date:** 2026-06-02
+**Roadmap:** `docs/ROADMAP.md` §6 Phase 0, item P0.2b
+**Predecessor:** P0.2 (claim/measurement split) — surfaced this gap in adversarial review
+
+## The remaining defect
+
+P0.2 removed the machine-dependent measured *cost* from the claim hash. But the claim still
+serializes, for every input/output, `{path, blake3}` — and `path` is recorded verbatim from the
+CLI (`FileHash.path`, fed unmodified at the four manifest sites in `src/main.rs`). Absolute home
+dirs, per-invocation tmp dirs, relative-vs-absolute invocation — all flow straight into the hashed
+claim. So **two machines with byte-identical data at different paths still produce different
+`manifest_blake3`.** The claim hash is therefore still not a cross-machine content-address — the
+exact property chaining / `reproduce` / cohort (Phase 3) depend on.
+
+The content hashes (`blake3`) are already cross-machine stable; only the paths are not. They are
+*incidental* to the computation: the same `subcommand` + `params` consuming the same input
+*contents* and producing the same output *contents* is the same logical run, wherever the files
+live or whatever they are named.
+
+## Design: a content-only claim form (version-gated)
+
+Make the **claim** canonical form (the bytes `content_hash()` hashes) render inputs/outputs as the
+**sorted list of their `blake3` digests**, dropping `path`:
+
+```
+claim:  {"has_measurements"…,"inputs":["<blake3>",…],"outputs":["<blake3>",…],"params":{…},"subcommand":"…","tool_version":"…"}
+```
+
+The **on-disk** receipt (`to_canonical_json`, what `write_manifest` persists and `verify` re-hashes
+files from) is **unchanged** — it keeps the full `{path, blake3}` per file, because humans need to
+see which files and `verify` re-hashes each file *at its recorded path*. Only the claim form used
+for hashing changes. Roles are preserved (inputs and outputs stay separate lists); duplicates are
+kept (the sorted blake3 list is a multiset, preserving cardinality).
+
+This makes `manifest_blake3` a genuine content-address: identical input/output contents + identical
+params + subcommand + version ⇒ identical claim hash, regardless of path.
+
+### What paths still protect (and why dropping them from the claim is safe)
+
+A path edit in the receipt is still caught — by `verify`'s input/output re-hash loop, which reads
+each file *at its recorded path*: a path pointed at a missing or different-content file fails the
+re-hash. A path pointed at a same-content file passes both re-hash and claim — which is correct,
+because same content = same computation. The claim simply stops committing to the machine-specific
+*location*; the content commitment (the `blake3`) is unchanged. Paths become advisory metadata in
+the receipt, integrity-checked by re-hash rather than by the portable claim hash.
+
+### Version gating (backward compatibility)
+
+Pre-P0.2b receipts (`schema_version` 1 or 2) recorded `manifest_blake3` over a claim that **included
+paths**. Changing the claim form unconditionally would make those receipts fail self-verify. So the
+claim form is selected by `schema_version`:
+
+- `schema_version >= 3` → **content-only** claim (path-independent).
+- `schema_version < 3` or absent → **path-inclusive** claim (the pre-P0.2b form) — reproduces the
+  old hash exactly, so old receipts still `self_hash_ok() == Some(true)`.
+
+Bump `MANIFEST_SCHEMA_VERSION` `2 → 3`. `finalize()` stamps `schema_version` *before* computing the
+claim hash (unchanged ordering), so a freshly sealed receipt is schema 3 and commits to the
+content-only claim. The version gate lives in one place (`claim_file_render`, consulted by
+`content_hash` via `to_canonical_claim_json`); no other code branches on it.
+
+## Implementation (`src/provenance/mod.rs`)
+
+- `MANIFEST_SCHEMA_VERSION` `2 → 3`.
+- A `FileRender` enum (`WithPath` | `ContentOnly`) threaded through the canonical serializer.
+- `push_canonical(include_measurements, file_render)`: dispatch file arrays to `push_file_hashes`
+  (WithPath — existing `[{"blake3","path"}]` sorted by path) or a new `push_blake3_list`
+  (ContentOnly — `["<blake3>",…]` sorted by blake3).
+- `to_canonical_json()` → `push_canonical(true, WithPath)` (on-disk, unchanged bytes).
+- `to_canonical_claim_json()` → `push_canonical(false, self.claim_file_render())`.
+- `claim_file_render()` → `ContentOnly` iff `schema_version >= 3`, else `WithPath`.
+- `content_hash()` unchanged (still hashes `to_canonical_claim_json()` with `manifest_blake3`
+  removed). The parser, `measurements`, `measurement_blake3`, `has_measurements`, and `get_recorded`
+  are all unaffected.
+
+`verify` is functionally unchanged: it re-hashes files from the on-disk full form (still has paths)
+and checks `self_hash_ok()` (now content-only for schema-3 receipts) + `measurement_hash_ok()`.
+
+## Testing
+
+New `provenance` unit tests:
+1. **Path-independence (the keystone)** — two finalized manifests with the *same* input/output
+   `blake3` digests but *different* `path`s produce *equal* `content_hash()` and both
+   `self_hash_ok() == Some(true)`. (This is the test the review noted would fail before P0.2b.)
+2. **Content sensitivity** — changing a `blake3` (different content) *does* change the claim hash.
+3. **Claim drops paths, on-disk keeps them** — `to_canonical_claim_json()` does not contain a
+   recorded path string; `to_canonical_json()` does.
+4. **Pre-P0.2b back-compat** — a hand-built `schema_version = "2"` receipt with paths reproduces its
+   path-inclusive `manifest_blake3` (still `self_hash_ok() == Some(true)`), and a schema-3 receipt
+   over the same files hashes *differently* (the form genuinely changed).
+
+Integration: bump the `schema_version` assertion `"2" → "3"`
+(`tests/plan_enforce.rs::receipt_is_self_hashing_and_schema_versioned`). All existing receipts are
+freshly generated, so the rest of the suite exercises the schema-3 path end-to-end (verify still
+passes on untampered runs; tamper/strip/consistency tests still fire).
+
+## Out of scope
+
+Signing/attestation (later); build-identity fields (P0.3). The content-only claim is the unit that
+P0.3's `code_git_sha`/lockfile and Phase 3's `reproduce` will hash/chain/sign.
+
+## Risks
+
+- **A machine-dependent value other than path still in the claim** → re-breaks cross-machine
+  stability. The P0.2 review enumerated the claim fields; only paths remained, and this closes them.
+  The path-independence unit test is the guard.
+- **Old-receipt regression** → covered by the schema-2 back-compat test (version gate).

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -9,20 +9,23 @@
 //! claim only — so the machine-dependent measured *cost* no longer perturbs it —
 //! while a second `measurement_blake3` keeps that cost locally tamper-evident.
 //!
-//! Scope note: this removes the measured *cost* from the claim hash. Recorded
-//! input/output *paths* are still part of the claim, so two machines with the same
-//! data at different paths still hash differently — a separate machine-dependent
-//! axis (path normalization / content-only claim) left to a later phase.
+//! The claim hash is a cross-machine **content-address**: for schema-3 receipts the
+//! claim hashes inputs/outputs by their sorted `blake3` digests (recorded paths are
+//! dropped from the claim form, though the on-disk receipt keeps them for humans and
+//! for `verify` to re-hash files), so the same data at different paths hashes
+//! identically. Pre-3 receipts hashed paths into the claim; the version gate
+//! reproduces their form so they still self-verify.
 
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 /// Current receipt/feature schema version. Bump on any breaking schema change.
-/// v2: the receipt is split into a deterministic *claim* and a machine-dependent
-/// *measurement* block; the self-hash (`manifest_blake3`) covers the claim only, so
-/// the measured cost no longer perturbs it.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 2;
+/// v2: split into a deterministic *claim* and a machine-dependent *measurement* block;
+/// the self-hash (`manifest_blake3`) covers the claim only. v3: the claim hashes
+/// inputs/outputs by their sorted `blake3` digests (paths dropped), so it is a
+/// cross-machine content-address — the same data at different paths hashes identically.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
 
 /// Keys whose values are machine-/run-dependent measurements, not part of the
 /// deterministic claim. `finalize` relocates these out of `params` into the
@@ -57,6 +60,15 @@ pub struct FileHash {
     pub path: String,
     /// BLAKE3 hex digest of the file's contents.
     pub blake3: String,
+}
+
+/// How input/output file entries render in a canonical form. The on-disk receipt
+/// keeps full `{path, blake3}`; the schema-3 claim drops the path and hashes only the
+/// content digest, so the claim hash does not depend on where files live.
+#[derive(Clone, Copy)]
+enum FileRender {
+    WithPath,
+    ContentOnly,
 }
 
 /// A reproducibility receipt for a single run.
@@ -96,34 +108,49 @@ impl RunManifest {
     }
 
     /// Serialize to canonical JSON: keys sorted, arrays sorted by path, no
-    /// timestamps — so identical runs render identically. Includes the measurement
-    /// block (when non-empty). This is the on-disk receipt.
+    /// timestamps — so identical runs render identically. Files render as full
+    /// `{path, blake3}`; includes the measurement block (when non-empty). This is the
+    /// on-disk receipt — humans and `verify` read files from its recorded paths.
     pub fn to_canonical_json(&self) -> String {
-        self.push_canonical(true)
+        self.push_canonical(true, FileRender::WithPath)
     }
 
     /// The claim-only canonical JSON: never emits the measurement block. This is the
-    /// portion the self-hash commits to, so the measured cost is excluded from the
-    /// claim hash.
+    /// portion the self-hash commits to. For schema-3 receipts, files render as their
+    /// sorted `blake3` digests (paths dropped) so the claim hash is a cross-machine
+    /// content-address.
     pub fn to_canonical_claim_json(&self) -> String {
-        self.push_canonical(false)
+        self.push_canonical(false, self.claim_file_render())
     }
 
-    /// Render the canonical JSON, optionally including the measurement block.
-    /// Canonical key order is alphabetical, so `measurements` sits between `inputs`
-    /// and `outputs`; it is emitted only when non-empty (a pre-v2 receipt and a
-    /// measurement-free v2 receipt are byte-identical).
-    fn push_canonical(&self, include_measurements: bool) -> String {
+    /// Schema >= 3 → content-only claim (paths dropped, cross-machine). Older receipts
+    /// hashed paths into the claim; reproduce their form so they still self-verify.
+    fn claim_file_render(&self) -> FileRender {
+        match self
+            .params
+            .get("schema_version")
+            .and_then(|v| v.parse::<u32>().ok())
+        {
+            Some(v) if v >= 3 => FileRender::ContentOnly,
+            _ => FileRender::WithPath,
+        }
+    }
+
+    /// Render the canonical JSON, optionally including the measurement block, with
+    /// files in the requested form. Canonical key order is alphabetical, so
+    /// `measurements` sits between `inputs` and `outputs`; it is emitted only when
+    /// non-empty (a pre-v2 receipt and a measurement-free receipt are byte-identical).
+    fn push_canonical(&self, include_measurements: bool, files: FileRender) -> String {
         let mut out = String::new();
         out.push('{');
         out.push_str("\"inputs\":");
-        push_file_hashes(&mut out, &self.inputs);
+        push_files(&mut out, &self.inputs, files);
         if include_measurements && !self.measurements.is_empty() {
             out.push_str(",\"measurements\":");
             push_string_map(&mut out, &self.measurements);
         }
         out.push_str(",\"outputs\":");
-        push_file_hashes(&mut out, &self.outputs);
+        push_files(&mut out, &self.outputs, files);
         out.push_str(",\"params\":");
         push_string_map(&mut out, &self.params);
         out.push_str(",\"subcommand\":\"");
@@ -147,8 +174,9 @@ impl RunManifest {
 
     /// BLAKE3 hex of the **claim** canonical JSON with the self-hash excluded — the
     /// content this manifest commits to. Excludes the machine-dependent measurement
-    /// block, so the measured cost does not perturb it. Deterministic; `verify`
-    /// re-derives it. (Recorded paths remain in the claim — see the module note.)
+    /// block (so the measured cost does not perturb it) and, for schema-3 receipts,
+    /// recorded paths (so it is a cross-machine content-address). Deterministic;
+    /// `verify` re-derives it.
     pub fn content_hash(&self) -> String {
         let mut m = self.clone();
         m.params.remove("manifest_blake3");
@@ -409,6 +437,31 @@ impl Parser<'_> {
             measurements,
         })
     }
+}
+
+/// Render a file array in the requested form: `[{"blake3","path"}]` sorted by path
+/// (on-disk), or `["<blake3>",…]` sorted by blake3 (the content-only claim).
+fn push_files(out: &mut String, files: &[FileHash], render: FileRender) {
+    match render {
+        FileRender::WithPath => push_file_hashes(out, files),
+        FileRender::ContentOnly => push_blake3_list(out, files),
+    }
+}
+
+/// Render `["<blake3>",…]`, sorted by digest (a content multiset — duplicates kept).
+fn push_blake3_list(out: &mut String, files: &[FileHash]) {
+    let mut digests: Vec<&str> = files.iter().map(|f| f.blake3.as_str()).collect();
+    digests.sort_unstable();
+    out.push('[');
+    for (i, d) in digests.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&json_escape(d));
+        out.push('"');
+    }
+    out.push(']');
 }
 
 /// Render a `[{"blake3":..,"path":..}, ..]` array, entries sorted by path.
@@ -892,5 +945,101 @@ mod tests {
         // shadowing). `params` and `measurements` both go through `parse_params`.
         let dup = r#"{"inputs":[],"outputs":[],"params":{"k":"1","k":"2"},"subcommand":"x","tool_version":"0.1.0"}"#;
         assert!(RunManifest::from_canonical_json(dup).is_err());
+    }
+
+    #[test]
+    fn claim_hash_is_stable_across_machine_dependent_paths() {
+        // Same content (blake3) at DIFFERENT paths on two machines → SAME claim hash.
+        // The keystone of P0.2b: paths are dropped from the claim form.
+        let mk = |idx_path: &str, out_path: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: idx_path.to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.outputs.push(FileHash {
+                path: out_path.to_string(),
+                blake3: "bb".to_string(),
+            });
+            m.params.insert("min_qual".to_string(), "30".to_string());
+            m.finalize();
+            m
+        };
+        let a = mk("/home/alice/ref.idx", "/tmp/run-1/out.vcf");
+        let b = mk("/data/ref.idx", "out.vcf");
+        assert_eq!(
+            a.content_hash(),
+            b.content_hash(),
+            "the claim hash must not depend on recorded paths"
+        );
+        assert_eq!(a.self_hash_ok(), Some(true));
+        assert_eq!(b.self_hash_ok(), Some(true));
+    }
+
+    #[test]
+    fn claim_hash_still_tracks_content() {
+        // Different content (blake3) → different claim hash (the address is the content).
+        let mk = |digest: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.idx".to_string(),
+                blake3: digest.to_string(),
+            });
+            m.finalize();
+            m
+        };
+        assert_ne!(mk("aa").content_hash(), mk("bb").content_hash());
+    }
+
+    #[test]
+    fn claim_drops_paths_but_the_on_disk_form_keeps_them() {
+        let mut m = RunManifest::new("variants");
+        m.tool_version = "0.1.0".to_string();
+        m.inputs.push(FileHash {
+            path: "/home/alice/secret/ref.idx".to_string(),
+            blake3: "aa".to_string(),
+        });
+        m.finalize();
+        assert!(
+            !m.to_canonical_claim_json().contains("/home/alice"),
+            "the claim form must not carry the recorded path"
+        );
+        assert!(
+            m.to_canonical_json().contains("/home/alice"),
+            "the on-disk form must keep the recorded path"
+        );
+        // The content digest is present in BOTH.
+        assert!(m.to_canonical_claim_json().contains("aa"));
+    }
+
+    #[test]
+    fn pre_p0_2b_receipt_with_paths_in_the_claim_still_verifies() {
+        // A schema-2 receipt hashed paths INTO the claim. The version gate must
+        // reproduce that path-inclusive form so it still self-verifies; a schema-3
+        // receipt over the same files hashes differently (the form changed).
+        let mk = |schema: &str| {
+            let mut m = RunManifest::new("variants");
+            m.tool_version = "0.1.0".to_string();
+            m.inputs.push(FileHash {
+                path: "ref.idx".to_string(),
+                blake3: "aa".to_string(),
+            });
+            m.params
+                .insert("schema_version".to_string(), schema.to_string());
+            let h = m.content_hash();
+            m.params.insert("manifest_blake3".to_string(), h);
+            m
+        };
+        let v2 = mk("2");
+        assert_eq!(v2.self_hash_ok(), Some(true), "schema-2 must self-verify");
+        let v3 = mk("3");
+        assert_eq!(v3.self_hash_ok(), Some(true), "schema-3 must self-verify");
+        assert_ne!(
+            v2.params.get("manifest_blake3"),
+            v3.params.get("manifest_blake3"),
+            "the claim form genuinely differs between schema 2 and 3"
+        );
     }
 }

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -1015,15 +1015,13 @@ mod tests {
     }
 
     #[test]
-    fn pre_p0_2b_receipt_with_paths_in_the_claim_still_verifies() {
-        // A schema-2 receipt hashed paths INTO the claim. The version gate must
-        // reproduce that path-inclusive form so it still self-verifies; a schema-3
-        // receipt over the same files hashes differently (the form changed).
-        let mk = |schema: &str| {
+    fn the_schema_gate_keeps_v2_verifying_and_makes_only_v3_path_independent() {
+        // Seal a receipt at a given schema with a given input path.
+        let seal = |schema: &str, path: &str| {
             let mut m = RunManifest::new("variants");
             m.tool_version = "0.1.0".to_string();
             m.inputs.push(FileHash {
-                path: "ref.idx".to_string(),
+                path: path.to_string(),
                 blake3: "aa".to_string(),
             });
             m.params
@@ -1032,14 +1030,31 @@ mod tests {
             m.params.insert("manifest_blake3".to_string(), h);
             m
         };
-        let v2 = mk("2");
-        assert_eq!(v2.self_hash_ok(), Some(true), "schema-2 must self-verify");
-        let v3 = mk("3");
-        assert_eq!(v3.self_hash_ok(), Some(true), "schema-3 must self-verify");
+        // Back-compat: the gate reproduces each schema's own claim form, so both
+        // self-verify — a pre-P0.2b receipt does not break.
+        assert_eq!(
+            seal("2", "ref.idx").self_hash_ok(),
+            Some(true),
+            "schema-2 must still self-verify"
+        );
+        assert_eq!(
+            seal("3", "ref.idx").self_hash_ok(),
+            Some(true),
+            "schema-3 must self-verify"
+        );
+        // Isolate the file-render gate: hold the schema string fixed, vary ONLY the
+        // path. schema 2 hashed paths into the claim → path-SENSITIVE.
         assert_ne!(
-            v2.params.get("manifest_blake3"),
-            v3.params.get("manifest_blake3"),
-            "the claim form genuinely differs between schema 2 and 3"
+            seal("2", "/a/ref.idx").content_hash(),
+            seal("2", "/b/ref.idx").content_hash(),
+            "the pre-P0.2b claim form is path-inclusive"
+        );
+        // schema 3 drops paths → path-INDEPENDENT: the gate fired for the right reason
+        // (the render change, not the schema string sitting inside the hashed claim).
+        assert_eq!(
+            seal("3", "/a/ref.idx").content_hash(),
+            seal("3", "/b/ref.idx").content_hash(),
+            "the schema-3 claim form is content-only"
         );
     }
 }

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -775,7 +775,7 @@ fn receipt_is_self_hashing_and_schema_versioned() {
         "no measurement self-hash: {text}"
     );
     assert!(
-        text.contains("\"schema_version\":\"2\""),
+        text.contains("\"schema_version\":\"3\""),
         "no schema_version: {text}"
     );
     // An untampered receipt verifies.


### PR DESCRIPTION
## What & why

P0.2 removed the measured **cost** from the claim hash. But the claim still serialized `{path, blake3}` for every input/output, and `path` is recorded verbatim from the CLI — so **two machines with byte-identical data at different paths still produced different `manifest_blake3`**. The claim hash was not yet the cross-machine content-address that chaining / `reproduce` / cohort (Phase 3) depend on. This was the gap the P0.2 adversarial review surfaced.

## The fix

For **schema-3** receipts, the **claim** form hashes inputs/outputs as their **sorted `blake3` digests**, dropping paths:

```
claim:  …,"inputs":["<blake3>",…],"outputs":["<blake3>",…],"params":{…},…
```

The **on-disk** receipt is unchanged (`{path, blake3}` per file) — humans need to see which files, and `verify` re-hashes each file *at its recorded path*. Only the claim form used for hashing changes. Roles are preserved (inputs/outputs stay separate); duplicates are kept (the sorted digest list is a multiset). Result: identical contents + params + subcommand + version ⇒ identical claim hash, regardless of path.

A path edit is still caught — by `verify`'s re-hash loop (a path pointed at a missing/different-content file fails). The claim simply stops committing to machine-specific *locations*.

## Backward compatibility

Version-gated: `claim_file_render()` picks content-only for `schema_version >= 3` and the old path-inclusive form for `schema < 3`, so pre-P0.2b receipts still `self_hash_ok() == Some(true)`. `MANIFEST_SCHEMA_VERSION` 2 → 3. The gate lives in one place; the parser and on-disk form are untouched.

## Adversarial review (ran before merge)

A read-only review confirmed: (1) **completeness** — every machine-dependent param is in `MEASUREMENT_KEYS` and relocated; no path/abs-location/per-run value remains in the claim; (2) **back-compat intact** — `schema_version` survives `content_hash`'s clone, so genuine schema-1/2 receipts reproduce their path-inclusive hash; (3) **no collisions** — multiset-preserving, separate in/out arrays, total order; (4) on-disk form + parser unchanged and round-tripping. It flagged one test-rigor gap (a back-compat assertion passing for an incidental reason); fixed by rewriting it to hold the schema fixed and vary only the path — proving the file-render gate fires (schema 2 path-sensitive, schema 3 path-independent).

## Tests

All 25 test binaries green; clippy `-D warnings` clean; MSRV 1.83 builds. New provenance unit tests: path-independence (the keystone), content-sensitivity, claim-drops-paths/on-disk-keeps-them, and the gate-isolating back-compat test.

Spec: `docs/superpowers/specs/2026-06-02-p0-2b-content-only-claim-design.md` · Plan: `docs/superpowers/plans/2026-06-02-p0-2b-content-only-claim.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)