### PR TITLE
feat(provenance): build-identity in the receipt + verify --expect-code (P0.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ rust-htslib = { version = "0.44", default-features = false, features = ["bzip2",
 [dev-dependencies]
 proptest = "1.4"
 
+[build-dependencies]
+# Same hash as the runtime receipt digests — for deps_lock_blake3 in build.rs.
+blake3 = "1.5"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,63 @@
+//! Bake build-identity into the binary so the reproducibility receipt records exactly
+//! which code, toolchain, and dependencies produced a run. Every value degrades to
+//! "unknown" (non-git build, `git` absent, …) and the script never panics, so the
+//! crate always compiles and `env!("ROSALIND_*")` always resolves.
+
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    emit_rerun_triggers();
+
+    let git_sha = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let git_dirty = match git(&["status", "--porcelain"]) {
+        Some(s) => if s.is_empty() { "false" } else { "true" }.to_string(),
+        None => "unknown".to_string(),
+    };
+    let rustc_version = rustc_version().unwrap_or_else(|| "unknown".to_string());
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    let deps_lock_blake3 = lockfile_blake3().unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=ROSALIND_GIT_SHA={git_sha}");
+    println!("cargo:rustc-env=ROSALIND_GIT_DIRTY={git_dirty}");
+    println!("cargo:rustc-env=ROSALIND_RUSTC_VERSION={rustc_version}");
+    println!("cargo:rustc-env=ROSALIND_TARGET={target}");
+    println!("cargo:rustc-env=ROSALIND_DEPS_LOCK_BLAKE3={deps_lock_blake3}");
+}
+
+/// Re-run when the commit, staged set, or lockfile changes so the baked identity stays
+/// current. Best-effort: a pure unstaged edit between builds may not re-trigger this
+/// (so `code_dirty` is accurate at commit/stage granularity).
+fn emit_rerun_triggers() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    if Path::new(".git/HEAD").exists() {
+        println!("cargo:rerun-if-changed=.git/HEAD");
+        println!("cargo:rerun-if-changed=.git/index");
+        if let Ok(head) = std::fs::read_to_string(".git/HEAD") {
+            if let Some(r) = head.strip_prefix("ref: ") {
+                println!("cargo:rerun-if-changed=.git/{}", r.trim());
+            }
+        }
+    }
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn rustc_version() -> Option<String> {
+    let rustc = std::env::var("RUSTC").ok()?;
+    let out = Command::new(rustc).arg("--version").output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn lockfile_blake3() -> Option<String> {
+    let dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let bytes = std::fs::read(Path::new(&dir).join("Cargo.lock")).ok()?;
+    Some(blake3::hash(&bytes).to_hex().to_string())
+}

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,11 @@ fn main() {
     emit_rerun_triggers();
 
     let git_sha = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    // Collapse `git status --porcelain` to a boolean. This is LOAD-BEARING for safety:
+    // its output embeds attacker-influenceable filenames (which may contain newlines),
+    // and a newline in a baked value would split into a second `cargo:` directive. Every
+    // other baked value (40-hex SHA, single-line rustc version, TARGET, blake3 hex) is
+    // newline-free, so never bake a raw git ref/branch/tag/commit message here.
     let git_dirty = match git(&["status", "--porcelain"]) {
         Some(s) => if s.is_empty() { "false" } else { "true" }.to_string(),
         None => "unknown".to_string(),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,10 +141,13 @@ Everything downstream rests on the proofs being literally correct. Two verified 
   form; the on-disk receipt keeps full paths for humans and for `verify` to re-hash files), making the
   claim hash a true cross-machine content-address. Version-gated (schema <3 reproduces the path-inclusive
   form so pre-P0.2b receipts still self-verify). This is the property chaining/reproduce/cohort need.
-- **P0.3 — Build-identity in the receipt.** *(S)* Replace the `tool_version = "0.1.0"` half-measure with
-  `code_git_sha` + `code_dirty` + `rustc_version` + `target_triple` + `deps_lock_blake3` (via `build.rs`)
-  and a `verify --expect-code <sha>` gate, so "exactly this code" stops being a lie and becomes a real
-  reproduction key.
+- **P0.3 — Build-identity in the receipt.** *(S)* **DONE.** Replaced the `tool_version = "0.1.0"`
+  half-measure with `code_git_sha` + `code_dirty` + `rustc_version` + `target_triple` + `deps_lock_blake3`
+  (baked at compile time by `build.rs`, each degrading to `"unknown"`), stamped into the *claim* (so they
+  are hash-protected and form the reproduction key), plus a `verify --expect-code <sha>` gate (prefix
+  match; flags a clean match from a dirty build; rejects a degenerate SHA). Schema 3 → 4. "Exactly this
+  code" is no longer a lie. **⇒ Phase 0 complete: the receipt is sound (conservative build estimate),
+  cross-machine stable (content-address claim + lossless measurement split), and code-identified.**
 
 ### Phase 1 — Sell what ships (harden + market the contract; no √t needed)
 

--- a/docs/superpowers/plans/2026-06-02-p0-3-build-identity.md
+++ b/docs/superpowers/plans/2026-06-02-p0-3-build-identity.md
@@ -1,0 +1,371 @@
+# P0.3 — Build-identity in the receipt — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Bake `code_git_sha` + `code_dirty` + `rustc_version` + `target_triple` + `deps_lock_blake3`
+into the binary at build time, stamp them into the receipt's claim, and add `verify --expect-code`.
+
+**Architecture:** A `build.rs` emits the five facts as `ROSALIND_*` rustc-env vars (graceful
+`"unknown"` fallbacks). `finalize()` stamps them into `params` (claim, before the self-hash). A pure
+`check_expected_code` powers `verify --expect-code`. Schema 3 → 4.
+
+**Reference:** spec `docs/superpowers/specs/2026-06-02-p0-3-build-identity-design.md`.
+
+---
+
+### Task 1: `build.rs` + the blake3 build-dependency
+
+**Files:** Create `build.rs`; modify `Cargo.toml`.
+
+- [ ] **Step 1: Add the build-dependency** — in `Cargo.toml`, after the `[dev-dependencies]` block:
+
+```toml
+[build-dependencies]
+# Same hash as the runtime receipt digests — for deps_lock_blake3 in build.rs.
+blake3 = "1.5"
+```
+
+- [ ] **Step 2: Write `build.rs`**
+
+```rust
+//! Bake build-identity into the binary so the reproducibility receipt records exactly
+//! which code, toolchain, and dependencies produced a run. Every value degrades to
+//! "unknown" (non-git build, `git` absent, …) and the script never panics, so the
+//! crate always compiles and `env!("ROSALIND_*")` always resolves.
+
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    emit_rerun_triggers();
+
+    let git_sha = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let git_dirty = match git(&["status", "--porcelain"]) {
+        Some(s) => if s.is_empty() { "false" } else { "true" }.to_string(),
+        None => "unknown".to_string(),
+    };
+    let rustc_version = rustc_version().unwrap_or_else(|| "unknown".to_string());
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    let deps_lock_blake3 = lockfile_blake3().unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=ROSALIND_GIT_SHA={git_sha}");
+    println!("cargo:rustc-env=ROSALIND_GIT_DIRTY={git_dirty}");
+    println!("cargo:rustc-env=ROSALIND_RUSTC_VERSION={rustc_version}");
+    println!("cargo:rustc-env=ROSALIND_TARGET={target}");
+    println!("cargo:rustc-env=ROSALIND_DEPS_LOCK_BLAKE3={deps_lock_blake3}");
+}
+
+/// Re-run when the commit, staged set, or lockfile changes so the baked identity stays
+/// current. Best-effort: a pure unstaged edit between builds may not re-trigger this
+/// (so `code_dirty` is accurate at commit/stage granularity).
+fn emit_rerun_triggers() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    if Path::new(".git/HEAD").exists() {
+        println!("cargo:rerun-if-changed=.git/HEAD");
+        println!("cargo:rerun-if-changed=.git/index");
+        if let Ok(head) = std::fs::read_to_string(".git/HEAD") {
+            if let Some(r) = head.strip_prefix("ref: ") {
+                println!("cargo:rerun-if-changed=.git/{}", r.trim());
+            }
+        }
+    }
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn rustc_version() -> Option<String> {
+    let rustc = std::env::var("RUSTC").ok()?;
+    let out = Command::new(rustc).arg("--version").output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn lockfile_blake3() -> Option<String> {
+    let dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let bytes = std::fs::read(Path::new(&dir).join("Cargo.lock")).ok()?;
+    Some(blake3::hash(&bytes).to_hex().to_string())
+}
+```
+
+- [ ] **Step 3: Verify it builds + emits** — `cargo build 2>&1 | tail -3` (clean). Sanity:
+  `./target/debug/rosalind --help` still runs.
+
+---
+
+### Task 2: Stamp build-identity in `finalize()` (TDD)
+
+**Files:** Modify `src/provenance/mod.rs`.
+
+- [ ] **Step 1: Write failing unit tests** (append to `mod tests`):
+
+```rust
+    #[test]
+    fn finalize_stamps_build_identity_into_the_claim() {
+        let mut m = RunManifest::new("variants");
+        m.finalize();
+        for k in [
+            "code_git_sha",
+            "code_dirty",
+            "rustc_version",
+            "target_triple",
+            "deps_lock_blake3",
+        ] {
+            assert!(
+                m.params.get(k).is_some_and(|v| !v.is_empty()),
+                "finalize must stamp {k}"
+            );
+        }
+        // Build-identity is in the claim → tampering it breaks the claim self-hash.
+        assert_eq!(m.self_hash_ok(), Some(true));
+        m.params
+            .insert("code_git_sha".to_string(), "tampered".to_string());
+        assert_eq!(m.self_hash_ok(), Some(false));
+    }
+
+    #[test]
+    fn check_expected_code_matches_mismatches_and_flags_dirty() {
+        let mk = |sha: &str, dirty: &str| {
+            let mut m = RunManifest::new("variants");
+            m.params.insert("code_git_sha".to_string(), sha.to_string());
+            m.params.insert("code_dirty".to_string(), dirty.to_string());
+            m
+        };
+        // Exact + prefix match on a clean build → no problems.
+        assert!(mk("abc123def456", "false")
+            .check_expected_code("abc123def456")
+            .is_empty());
+        assert!(mk("abc123def456", "false")
+            .check_expected_code("abc123")
+            .is_empty());
+        // Mismatch → one problem mentioning "mismatch".
+        let mm = mk("abc123", "false").check_expected_code("deadbeef");
+        assert_eq!(mm.len(), 1);
+        assert!(mm[0].contains("mismatch"));
+        // Match but dirty → one problem mentioning "dirty".
+        let dirty = mk("abc123", "true").check_expected_code("abc123");
+        assert_eq!(dirty.len(), 1);
+        assert!(dirty[0].contains("dirty"));
+        // Absent / unknown → cannot check (one problem each).
+        assert_eq!(
+            RunManifest::new("variants")
+                .check_expected_code("abc")
+                .len(),
+            1
+        );
+        assert_eq!(mk("unknown", "false").check_expected_code("abc").len(), 1);
+    }
+```
+
+- [ ] **Step 2: Confirm RED** — `cargo test -p rosalind --lib provenance 2>&1 | tail -12`
+  (compile error: `check_expected_code` missing; `finalize_stamps_build_identity` fails).
+
+- [ ] **Step 3: Bump the schema version**
+
+```rust
+/// … v3: content-only claim (paths dropped). v4: the claim records build-identity
+/// (`code_git_sha`/`code_dirty`/`rustc_version`/`target_triple`/`deps_lock_blake3`),
+/// so it commits to exactly which code, toolchain, and deps produced the run.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 4;
+```
+
+- [ ] **Step 4: Stamp build-identity in `finalize`** — in `finalize()`, immediately before the
+  `schema_version` insert (step 3 of the existing body), add:
+
+```rust
+        // Build-identity (baked at compile time by build.rs) — part of the claim, so it
+        // is committed to by the self-hash and forms the reproduction key.
+        for (k, v) in [
+            ("code_git_sha", env!("ROSALIND_GIT_SHA")),
+            ("code_dirty", env!("ROSALIND_GIT_DIRTY")),
+            ("rustc_version", env!("ROSALIND_RUSTC_VERSION")),
+            ("target_triple", env!("ROSALIND_TARGET")),
+            ("deps_lock_blake3", env!("ROSALIND_DEPS_LOCK_BLAKE3")),
+        ] {
+            self.params.insert(k.to_string(), v.to_string());
+        }
+```
+
+- [ ] **Step 5: Add `check_expected_code`** (near `claims_measurements`):
+
+```rust
+    /// Check the recorded `code_git_sha` against an expected commit (prefix match, so
+    /// short SHAs work). Returns the problems found: a mismatch, a clean match from a
+    /// DIRTY tree (not reproducible from a SHA alone), or an inability to check
+    /// (no/`unknown` SHA). An empty vec means a clean, matching build.
+    pub fn check_expected_code(&self, expected: &str) -> Vec<String> {
+        match self.params.get("code_git_sha").map(String::as_str) {
+            None => vec![
+                "cannot check --expect-code: the receipt records no code_git_sha (a pre-P0.3 receipt)"
+                    .to_string(),
+            ],
+            Some("unknown") => vec![
+                "cannot check --expect-code: the receipt's code_git_sha is 'unknown' (a non-git build)"
+                    .to_string(),
+            ],
+            Some(sha) if !sha.starts_with(expected) => vec![format!(
+                "code mismatch: receipt was built from {sha}, expected {expected}"
+            )],
+            Some(_) => {
+                if self.params.get("code_dirty").map(String::as_str) == Some("true") {
+                    vec![format!(
+                        "code matches {expected} but the receipt was built from a DIRTY tree \
+                         (uncommitted changes) — not reproducible from a commit SHA alone"
+                    )]
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 6: GREEN** — `cargo test -p rosalind --lib provenance 2>&1 | tail -12` (all pass,
+  including every P0.2/P0.2b test — build-identity is identical for both manifests in the
+  cross-machine tests, so they still match).
+
+- [ ] **Step 7: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add build.rs Cargo.toml Cargo.lock src/provenance/mod.rs \
+  docs/superpowers/specs/2026-06-02-p0-3-build-identity-design.md \
+  docs/superpowers/plans/2026-06-02-p0-3-build-identity.md
+git commit -m "feat(provenance): build-identity in the receipt — code/toolchain/deps reproduction key"
+```
+
+---
+
+### Task 3: `verify --expect-code`
+
+**Files:** Modify `src/main.rs`.
+
+- [ ] **Step 1: Add the CLI arg** — in the `Verify` variant (after `budget_mb`):
+
+```rust
+        /// Assert the receipt was built from exactly this commit SHA (prefix ok).
+        /// Fails verify on a mismatch, or on a clean match from a dirty build.
+        #[arg(long)]
+        expect_code: Option<String>,
+```
+
+- [ ] **Step 2: Thread it to `run_verify`** — update the match arm and the signature:
+
+```rust
+        Commands::Verify {
+            manifest,
+            budget_mb,
+            expect_code,
+        } => run_verify(manifest, budget_mb, expect_code)?,
+```
+
+and `fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>, expect_code: Option<String>) -> Result<()>`.
+
+- [ ] **Step 3: Apply the check** — in `run_verify`, after the measurement-hash match block (before
+  the `if problems.is_empty()`):
+
+```rust
+    // Build-identity: assert the receipt came from exactly the expected commit.
+    if let Some(expected) = &expect_code {
+        let code_problems = manifest.check_expected_code(expected);
+        if code_problems.is_empty() {
+            println!("verify: code matches {expected} (clean build)");
+        } else {
+            problems.extend(code_problems);
+        }
+    }
+```
+
+- [ ] **Step 4: Build + the verify-related integration tests compile** —
+  `cargo test -p rosalind --test plan_enforce verify 2>&1 | tail -10`.
+
+- [ ] **Step 5: `cargo fmt` + commit**
+
+```bash
+cargo fmt
+git add src/main.rs
+git commit -m "feat(verify): --expect-code <sha> gate against the receipt's build-identity"
+```
+
+---
+
+### Task 4: Integration tests + full verification
+
+**Files:** Modify `tests/plan_enforce.rs`.
+
+- [ ] **Step 1: Bump the schema assertion** — `"\"schema_version\":\"3\""` → `"\"schema_version\":\"4\""`.
+
+- [ ] **Step 2: Add a build-identity + expect-code e2e** (append to `tests/plan_enforce.rs`):
+
+```rust
+#[test]
+fn receipt_records_build_identity_and_verify_expect_code_catches_a_mismatch() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    for needle in [
+        "\"code_git_sha\":",
+        "\"code_dirty\":",
+        "\"rustc_version\":",
+        "\"target_triple\":",
+        "\"deps_lock_blake3\":",
+    ] {
+        assert!(text.contains(needle), "receipt missing {needle}: {text}");
+    }
+
+    // A wrong commit SHA must fail verify (robust regardless of the build's dirty state).
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .args(["--expect-code", "0000000000000000000000000000000000000000"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "a wrong --expect-code must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("code mismatch"),
+        "expected a code-mismatch error: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 3: Full suite + clippy + MSRV**
+
+```bash
+cargo test 2>&1 | grep -E "test result: FAILED|FAILED|^error"   # expect none
+cargo clippy --all-targets -- -D warnings 2>&1 | tail -3        # clean
+cargo +1.83 build 2>&1 | tail -3                                # MSRV (CI covers if absent)
+```
+
+- [ ] **Step 4: `cargo fmt` + commit, push, PR, watch CI, merge on green**
+
+```bash
+cargo fmt
+git add tests/plan_enforce.rs
+git commit -m "test: receipt schema 4 + build-identity / --expect-code e2e"
+git push -u origin rosalind/p0-3-build-identity
+gh pr create --title "feat(provenance): build-identity in the receipt + verify --expect-code (P0.3)" --body "<summary>"
+gh pr checks --watch
+```

--- a/docs/superpowers/specs/2026-06-02-p0-3-build-identity-design.md
+++ b/docs/superpowers/specs/2026-06-02-p0-3-build-identity-design.md
@@ -1,0 +1,101 @@
+# P0.3 — Build-identity in the receipt
+
+**Status:** design
+**Date:** 2026-06-02
+**Roadmap:** `docs/ROADMAP.md` §6 Phase 0, item P0.3 (closes Phase 0)
+**Predecessor:** P0.2 / P0.2b (the claim is now a cross-machine content-address)
+
+## The defect
+
+The receipt records `tool_version = env!("CARGO_PKG_VERSION") = "0.1.0"` — a static crate version
+that is identical across every commit. So "exactly this code" is a lie: two builds from different
+commits (different behavior) both record `tool_version: "0.1.0"`. A reproducibility receipt whose
+content-address (the P0.2b claim hash) does not commit to *which code, toolchain, and dependencies*
+produced the run cannot anchor `reproduce` (Phase 3): "re-run with exactly this code → expect this
+output" has no real key.
+
+## Design
+
+Bake five **build-identity** facts into the binary at compile time and stamp them into the receipt's
+**claim** (so they are part of the cross-machine content-address and are tamper-protected by the
+claim self-hash):
+
+| Field | Source (build time) | Meaning |
+|---|---|---|
+| `code_git_sha` | `git rev-parse HEAD` | the commit the binary was built from |
+| `code_dirty` | `git status --porcelain` non-empty | uncommitted changes at build time (not reproducible from a SHA alone) |
+| `rustc_version` | `$RUSTC --version` | the compiler (affects codegen/behavior) |
+| `target_triple` | cargo `TARGET` env | the build target |
+| `deps_lock_blake3` | BLAKE3 of `Cargo.lock` | the exact resolved dependency versions |
+
+These are deterministic *per binary* — the same binary reports the same values on any machine — so
+they fit the P0.2b content-address: two runs of the same binary on the same data hash identically,
+while two *different* builds (different commit/toolchain/target/deps) hash differently, which is
+exactly the reproduction distinction `reproduce` needs.
+
+### Capture: `build.rs`
+
+A new `build.rs` runs each build, shells out to `git`/`rustc`, reads `Cargo.lock`, and emits the five
+values as `cargo:rustc-env=ROSALIND_*` variables; the binary reads them with `env!`. Every fallible
+step degrades to the literal `"unknown"` (non-git build, `git` absent, etc.) and the script never
+panics, so `env!` always resolves and a build never fails because provenance was unavailable.
+
+`Cargo.lock` is hashed with a `[build-dependencies] blake3` (matching the runtime version) for digest
+consistency with the rest of the receipt. Re-run triggers: `Cargo.lock`, `.git/HEAD`, `.git/index`,
+and the ref `HEAD` resolves to — so the SHA re-stamps on commit/stage/branch-switch. **Honest
+limitation:** `code_dirty` is best-effort — accurate for CI/release builds from a committed tree; a
+pure *unstaged* edit between incremental builds may not re-trigger the script, so the flag is
+accurate at commit/stage granularity, not at the instant of an unstaged edit.
+
+### Stamp: `finalize()`
+
+`finalize()` stamps the five fields into `params` (the claim) **before** computing the claim hash, so
+they are committed to and tamper-evident (editing `code_git_sha` breaks `manifest_blake3` — no
+separate presence marker is needed, unlike the measurement block which lives *outside* the claim).
+They are stamped in `finalize`, not `new`, so an un-sealed manifest (and the exact-JSON unit test)
+stays free of the volatile SHA. Bump `MANIFEST_SCHEMA_VERSION` `3 → 4`: a v4 receipt is guaranteed to
+carry build-identity. The `claim_file_render` gate stays `>= 3 → content-only` (v4 ≥ 3), unchanged.
+
+### Check: `verify --expect-code <sha>`
+
+A new `RunManifest::check_expected_code(expected) -> Vec<String>` (the testable core) returns
+problems:
+
+- no `code_git_sha` recorded (pre-P0.3 receipt) → cannot check;
+- `code_git_sha == "unknown"` (non-git build) → cannot check;
+- recorded SHA does not start with `expected` (prefix match, so short SHAs work) → `code mismatch`;
+- match **but** `code_dirty == "true"` → matched, but built from a dirty tree → not reproducible
+  from a commit SHA alone.
+
+`verify` gains `--expect-code <sha>`; when supplied it extends `problems` with
+`check_expected_code` and, on a clean match, prints a positive note. `verify` without the flag is
+unchanged. The pure function keeps the match/dirty/absent logic unit-testable without a dirty working
+tree (which a CLI e2e cannot reliably produce).
+
+## Testing
+
+Unit (`provenance`):
+- `finalize` stamps all five build-identity fields (non-empty) and they are covered by the claim
+  hash (editing `code_git_sha` after finalize → `self_hash_ok() == Some(false)`).
+- `check_expected_code`: exact match (clean) → no problems; prefix match → no problems; mismatch →
+  one problem; recorded dirty + match → one (dirty) problem; absent → one problem; `"unknown"` → one
+  problem.
+
+Integration (`tests/`):
+- a real receipt's JSON contains `code_git_sha`, `rustc_version`, `target_triple`,
+  `deps_lock_blake3`, and `schema_version` `"4"`.
+- `verify --expect-code <a-wrong-sha>` exits 5 with `code mismatch` (robust regardless of the build's
+  dirty state — the positive/dirty paths are covered by the `check_expected_code` unit tests).
+
+## Out of scope
+
+Signing/attestation of the receipt (Ed25519 `verify-attest`) — Phase 3. Build-identity is the key
+that signing and `reproduce` will commit to.
+
+## Risks
+
+- **`env!` fails to resolve** if `build.rs` doesn't emit a var → mitigated by always emitting all five
+  (fallback `"unknown"`), so the crate always compiles.
+- **Stale `code_dirty`** on incremental local builds → documented as best-effort; the
+  reproduction-critical CI/release builds (clean, freshly built) are accurate.
+- **`git`/`Cargo.lock` absent** (vendored/published build) → graceful `"unknown"`, no build failure.

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,10 @@ enum Commands {
         /// `memory_budget_mb` recorded in the manifest, if any).
         #[arg(long)]
         budget_mb: Option<u64>,
+        /// Assert the receipt was built from exactly this commit SHA (prefix ok).
+        /// Fails verify on a mismatch, or on a clean match from a dirty build.
+        #[arg(long)]
+        expect_code: Option<String>,
     },
 }
 
@@ -517,7 +521,8 @@ fn main() -> Result<()> {
         Commands::Verify {
             manifest,
             budget_mb,
-        } => run_verify(manifest, budget_mb)?,
+            expect_code,
+        } => run_verify(manifest, budget_mb, expect_code)?,
     }
 
     Ok(())
@@ -882,7 +887,11 @@ fn run_pack(
 /// listed input/output and confirm the digests match, and confirm the recorded
 /// realized peak RSS landed within the budget (supplied, or recorded in the
 /// manifest). Exits non-zero with a per-check report on any mismatch.
-fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
+fn run_verify(
+    manifest_path: PathBuf,
+    budget_mb: Option<u64>,
+    expect_code: Option<String>,
+) -> Result<()> {
     use rosalind::provenance::{blake3_file, RunManifest};
 
     let text = std::fs::read_to_string(&manifest_path)
@@ -1021,6 +1030,17 @@ fn run_verify(manifest_path: PathBuf, budget_mb: Option<u64>) -> Result<()> {
                         .to_string(),
                 );
             }
+        }
+    }
+
+    // Build-identity: assert the receipt came from exactly the expected commit. A clean
+    // match prints a note; a mismatch / dirty-build / un-checkable receipt fails verify.
+    if let Some(expected) = &expect_code {
+        let code_problems = manifest.check_expected_code(expected);
+        if code_problems.is_empty() {
+            println!("verify: code matches {expected} (clean build)");
+        } else {
+            problems.extend(code_problems);
         }
     }
 

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -25,7 +25,10 @@ use std::path::{Path, PathBuf};
 /// the self-hash (`manifest_blake3`) covers the claim only. v3: the claim hashes
 /// inputs/outputs by their sorted `blake3` digests (paths dropped), so it is a
 /// cross-machine content-address — the same data at different paths hashes identically.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 3;
+/// v4: the claim records build-identity (`code_git_sha`/`code_dirty`/`rustc_version`/
+/// `target_triple`/`deps_lock_blake3`), committing to exactly which code, toolchain, and
+/// dependencies produced the run.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 4;
 
 /// Keys whose values are machine-/run-dependent measurements, not part of the
 /// deterministic claim. `finalize` relocates these out of `params` into the
@@ -212,6 +215,36 @@ impl RunManifest {
             .unwrap_or(false)
     }
 
+    /// Check the recorded `code_git_sha` against an expected commit (prefix match, so
+    /// short SHAs work). Returns the problems found: a mismatch, a clean match from a
+    /// DIRTY tree (not reproducible from a SHA alone), or an inability to check (no /
+    /// `unknown` SHA). An empty vec means a clean, matching build.
+    pub fn check_expected_code(&self, expected: &str) -> Vec<String> {
+        match self.params.get("code_git_sha").map(String::as_str) {
+            None => vec![
+                "cannot check --expect-code: the receipt records no code_git_sha (a pre-P0.3 receipt)"
+                    .to_string(),
+            ],
+            Some("unknown") => vec![
+                "cannot check --expect-code: the receipt's code_git_sha is 'unknown' (a non-git build)"
+                    .to_string(),
+            ],
+            Some(sha) if !sha.starts_with(expected) => vec![format!(
+                "code mismatch: receipt was built from {sha}, expected {expected}"
+            )],
+            Some(_) => {
+                if self.params.get("code_dirty").map(String::as_str) == Some("true") {
+                    vec![format!(
+                        "code matches {expected} but the receipt was built from a DIRTY tree \
+                         (uncommitted changes) — not reproducible from a commit SHA alone"
+                    )]
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+    }
+
     /// Seal the receipt: partition measured fields out of the claim, stamp the
     /// measurement hash, the schema version, then the claim self-hash LAST (so it
     /// covers every other claim field, including the version). Idempotent.
@@ -237,7 +270,19 @@ impl RunManifest {
             self.params
                 .insert("has_measurements".to_string(), "true".to_string());
         }
-        // 3. Stamp the version into the claim, then the claim self-hash last.
+        // 3. Build-identity (baked at compile time by build.rs) — part of the claim,
+        //    so it is committed to by the self-hash and forms the reproduction key:
+        //    exactly which code, toolchain, and deps produced this run.
+        for (k, v) in [
+            ("code_git_sha", env!("ROSALIND_GIT_SHA")),
+            ("code_dirty", env!("ROSALIND_GIT_DIRTY")),
+            ("rustc_version", env!("ROSALIND_RUSTC_VERSION")),
+            ("target_triple", env!("ROSALIND_TARGET")),
+            ("deps_lock_blake3", env!("ROSALIND_DEPS_LOCK_BLAKE3")),
+        ] {
+            self.params.insert(k.to_string(), v.to_string());
+        }
+        // 4. Stamp the version into the claim, then the claim self-hash last.
         self.params.insert(
             "schema_version".to_string(),
             MANIFEST_SCHEMA_VERSION.to_string(),
@@ -1056,5 +1101,61 @@ mod tests {
             seal("3", "/b/ref.idx").content_hash(),
             "the schema-3 claim form is content-only"
         );
+    }
+
+    #[test]
+    fn finalize_stamps_build_identity_into_the_claim() {
+        let mut m = RunManifest::new("variants");
+        m.finalize();
+        for k in [
+            "code_git_sha",
+            "code_dirty",
+            "rustc_version",
+            "target_triple",
+            "deps_lock_blake3",
+        ] {
+            assert!(
+                m.params.get(k).is_some_and(|v| !v.is_empty()),
+                "finalize must stamp {k}"
+            );
+        }
+        // Build-identity is in the claim → tampering it breaks the claim self-hash.
+        assert_eq!(m.self_hash_ok(), Some(true));
+        m.params
+            .insert("code_git_sha".to_string(), "tampered".to_string());
+        assert_eq!(m.self_hash_ok(), Some(false));
+    }
+
+    #[test]
+    fn check_expected_code_matches_mismatches_and_flags_dirty() {
+        let mk = |sha: &str, dirty: &str| {
+            let mut m = RunManifest::new("variants");
+            m.params.insert("code_git_sha".to_string(), sha.to_string());
+            m.params.insert("code_dirty".to_string(), dirty.to_string());
+            m
+        };
+        // Exact + prefix match on a clean build → no problems.
+        assert!(mk("abc123def456", "false")
+            .check_expected_code("abc123def456")
+            .is_empty());
+        assert!(mk("abc123def456", "false")
+            .check_expected_code("abc123")
+            .is_empty());
+        // Mismatch → one problem mentioning "mismatch".
+        let mm = mk("abc123", "false").check_expected_code("deadbeef");
+        assert_eq!(mm.len(), 1);
+        assert!(mm[0].contains("mismatch"));
+        // Match but dirty → one problem mentioning the DIRTY tree.
+        let dirty = mk("abc123", "true").check_expected_code("abc123");
+        assert_eq!(dirty.len(), 1);
+        assert!(dirty[0].contains("DIRTY"));
+        // Absent / unknown → cannot check (one problem each).
+        assert_eq!(
+            RunManifest::new("variants")
+                .check_expected_code("abc")
+                .len(),
+            1
+        );
+        assert_eq!(mk("unknown", "false").check_expected_code("abc").len(), 1);
     }
 }

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -220,6 +220,14 @@ impl RunManifest {
     /// DIRTY tree (not reproducible from a SHA alone), or an inability to check (no /
     /// `unknown` SHA). An empty vec means a clean, matching build.
     pub fn check_expected_code(&self, expected: &str) -> Vec<String> {
+        // Reject a degenerate expected SHA up front: an empty / too-short / non-hex
+        // value would match loosely (or vacuously) via `starts_with` and give false
+        // confidence — a scripted `--expect-code "$MAYBE_EMPTY"` must fail, not pass.
+        if expected.len() < 7 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+            return vec![format!(
+                "invalid --expect-code {expected:?}: expected a hex commit SHA of at least 7 chars"
+            )];
+        }
         match self.params.get("code_git_sha").map(String::as_str) {
             None => vec![
                 "cannot check --expect-code: the receipt records no code_git_sha (a pre-P0.3 receipt)"
@@ -1134,28 +1142,55 @@ mod tests {
             m.params.insert("code_dirty".to_string(), dirty.to_string());
             m
         };
-        // Exact + prefix match on a clean build → no problems.
+        // Exact + (>=7-char) prefix match on a clean build → no problems.
         assert!(mk("abc123def456", "false")
             .check_expected_code("abc123def456")
             .is_empty());
         assert!(mk("abc123def456", "false")
-            .check_expected_code("abc123")
+            .check_expected_code("abc123d")
             .is_empty());
         // Mismatch → one problem mentioning "mismatch".
-        let mm = mk("abc123", "false").check_expected_code("deadbeef");
+        let mm = mk("abc123def456", "false").check_expected_code("deadbeef");
         assert_eq!(mm.len(), 1);
         assert!(mm[0].contains("mismatch"));
         // Match but dirty → one problem mentioning the DIRTY tree.
-        let dirty = mk("abc123", "true").check_expected_code("abc123");
+        let dirty = mk("abc123def456", "true").check_expected_code("abc123def456");
         assert_eq!(dirty.len(), 1);
         assert!(dirty[0].contains("DIRTY"));
         // Absent / unknown → cannot check (one problem each).
         assert_eq!(
             RunManifest::new("variants")
-                .check_expected_code("abc")
+                .check_expected_code("abc1234")
                 .len(),
             1
         );
-        assert_eq!(mk("unknown", "false").check_expected_code("abc").len(), 1);
+        assert_eq!(
+            mk("unknown", "false").check_expected_code("abc1234").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn check_expected_code_rejects_a_degenerate_expected_sha() {
+        // An empty / too-short / non-hex expected must FAIL (not vacuously pass via
+        // starts_with) — otherwise `--expect-code "$MAYBE_EMPTY"` is a false-confidence
+        // footgun.
+        let m = {
+            let mut m = RunManifest::new("variants");
+            m.params
+                .insert("code_git_sha".to_string(), "abc123def456".to_string());
+            m.params
+                .insert("code_dirty".to_string(), "false".to_string());
+            m
+        };
+        for bad in ["", "9", "abc", "zzzzzzz"] {
+            let problems = m.check_expected_code(bad);
+            assert_eq!(problems.len(), 1, "{bad:?} must be rejected");
+            assert!(
+                problems[0].contains("invalid --expect-code"),
+                "{bad:?}: {}",
+                problems[0]
+            );
+        }
     }
 }

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -775,7 +775,7 @@ fn receipt_is_self_hashing_and_schema_versioned() {
         "no measurement self-hash: {text}"
     );
     assert!(
-        text.contains("\"schema_version\":\"3\""),
+        text.contains("\"schema_version\":\"4\""),
         "no schema_version: {text}"
     );
     // An untampered receipt verifies.
@@ -923,6 +923,53 @@ fn verify_rejects_a_receipt_with_its_measurement_block_stripped() {
     assert!(
         stderr.contains("measurement block missing"),
         "expected a stripped-block error: {stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn receipt_records_build_identity_and_verify_expect_code_catches_a_mismatch() {
+    let (dir, idx, bam) = build_sorted_bam_fixture();
+    let vcf = dir.join("calls.vcf");
+    let manifest = dir.join("calls.vcf.manifest.json");
+    let out = Command::new(bin())
+        .args(["variants", "--index"])
+        .arg(&idx)
+        .arg("--alignments")
+        .arg(&bam)
+        .args(["--memory-budget-mb", "4096", "--enforce", "-o"])
+        .arg(&vcf)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "run failed: {out:?}");
+
+    let text = std::fs::read_to_string(&manifest).unwrap();
+    for needle in [
+        "\"code_git_sha\":",
+        "\"code_dirty\":",
+        "\"rustc_version\":",
+        "\"target_triple\":",
+        "\"deps_lock_blake3\":",
+    ] {
+        assert!(text.contains(needle), "receipt missing {needle}: {text}");
+    }
+
+    // A wrong commit SHA must fail verify (robust regardless of the build's dirty state).
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(&manifest)
+        .args(["--expect-code", "0000000000000000000000000000000000000000"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        v.status.code(),
+        Some(5),
+        "a wrong --expect-code must fail verify: {v:?}"
+    );
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(
+        stderr.contains("code mismatch"),
+        "expected a code-mismatch error: {stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
## What & why

The receipt recorded only `tool_version = "0.1.0"` — the static crate version, identical across every commit. So "exactly this code" was a lie, and the P0.2b content-address claim committed to *nothing* about which code/toolchain/deps produced the run — leaving `reproduce` (Phase 3) without a real key. This closes Phase 0.

## The fix

A new **`build.rs`** bakes five build-identity facts into the binary at compile time, each degrading to `"unknown"` (non-git build, `git` absent, …) so the crate always compiles:

| Field | Source |
|---|---|
| `code_git_sha` | `git rev-parse HEAD` |
| `code_dirty` | `git status --porcelain` non-empty |
| `rustc_version` | `$RUSTC --version` |
| `target_triple` | cargo `TARGET` |
| `deps_lock_blake3` | BLAKE3 of `Cargo.lock` |

`finalize()` stamps them into the **claim** (`params`, before the self-hash), so they're committed to and **tamper-evident** — editing `code_git_sha` breaks `manifest_blake3` (no separate marker needed, unlike the out-of-claim measurement block). They're deterministic per-binary, so they preserve the P0.2b content-address (same binary + data → same hash) while distinguishing different build contexts (the reproduction distinction). Schema bumped 3 → 4.

## `verify --expect-code <sha>`

Asserts the receipt came from exactly the expected commit (prefix match). Fails on a mismatch, on a clean match from a **dirty** build (not reproducible from a SHA alone), or when the receipt can't be checked (no / `"unknown"` SHA). Powered by the pure, unit-tested `RunManifest::check_expected_code`.

## Adversarial review (ran before merge)

Verdict: sound/ship-ready. Confirmed `build.rs` never panics and always emits all five vars (so `env!` resolves); `git status --porcelain` is collapsed to a boolean *before* baking, closing cargo-directive/newline injection; the baked SHA can't go stale (watches the resolved ref); build-identity doesn't regress the content-address (same binary → same identity). Two LOW findings fixed: `--expect-code ""` / `9` passed vacuously via `starts_with` → now a degenerate (empty / <7-char / non-hex) expected is rejected as un-checkable; added a load-bearing-safety comment to `build.rs`.

## Tests

All test binaries green; clippy `-D warnings` clean; MSRV 1.83 builds; real git SHA confirmed baked into the binary end-to-end. New provenance unit tests (build-identity stamped + tamper-evident; `check_expected_code` match/prefix/mismatch/dirty/absent/unknown + degenerate-SHA rejection) + a build-identity / `--expect-code` mismatch e2e.

Spec: `docs/superpowers/specs/2026-06-02-p0-3-build-identity-design.md` · Plan: `docs/superpowers/plans/2026-06-02-p0-3-build-identity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)