### PR TITLE
Track D: reproduce + reproduction certificate + self-hosted badge; plus the honest-language pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,43 @@ jobs:
           test "$code" -eq 3
           grep -q "REFUSE" refuse.log
           test ! -f examples/data/illumina_toy/refused.vcf
+      - name: Reproduce fence — a stranger re-derives the result on this runner
+        # The contract.vcf + its receipt were produced above; reproduce re-derives it
+        # byte-for-byte from content-located inputs on THIS runner (a different machine
+        # than the author's), writes a chainable certificate, and a byte-changed input
+        # is correctly reported INCONCLUSIVE (exit 7) — never a false DIVERGED.
+        run: |
+          set -e
+          D=examples/data/illumina_toy
+          cargo run --release -- reproduce \
+            --manifest $D/contract.vcf.manifest.json \
+            --inputs $D/ | tee reproduce.log
+          grep -q "REPRODUCED" reproduce.log
+          test -f $D/contract.vcf.manifest.json.repro.json
+          # Negative: a byte-changed input can no longer be content-located -> exit 7.
+          mkdir -p tamper && cp $D/reference.idx tamper/ && cp $D/sorted.bam tamper/
+          printf 'x' >> tamper/sorted.bam
+          set +e
+          cargo run --release -- reproduce \
+            --manifest $D/contract.vcf.manifest.json --inputs tamper/ > /dev/null 2>&1
+          code=$?
+          set -e
+          test "$code" -eq 7
+      - name: Emit a self-hosted reproducibility badge
+        run: |
+          D=examples/data/illumina_toy
+          cargo run --release -- badge \
+            --manifest $D/contract.vcf.manifest.json \
+            --repro $D/contract.vcf.manifest.json.repro.json \
+            -o badge.json
+          cat badge.json
+      - name: Upload the reproducibility badge
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rosalind-reproducibility-badge
+          path: badge.json
+          if-no-files-found: ignore
       - name: Exercise the rosalind-budget Action (local, from-source binary)
         uses: ./
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ canonical bounded-memory substrate.
 ### Reproducibility — a stranger can re-derive your result (Track D)
 - **`rosalind reproduce`** re-derives a recorded result byte-for-byte from its receipt and
   content-located inputs, reporting REPRODUCED / DIVERGED / INCONCLUSIVE (exit 0 / 6 / 7; a
-  tampered receipt is exit 5). No incumbent caller can offer this — a non-deterministic caller
+  tampered receipt is exit 5). A non-deterministic caller can't offer this — it
   reports DIVERGED on a *correct* run. Honest scope: the deterministic text outputs
   (`variants → VCF`, `features → TSV`); BAM/bgzf is reported INCONCLUSIVE, never a false DIVERGED.
 - **Chainable reproduction certificate** (`<receipt>.repro.json`): a content-addressed,
@@ -41,7 +41,7 @@ canonical bounded-memory substrate.
 
 ### Fleet scheduling — prediction → placement
 - **`rosalind pack`** packs many bounded `variants` jobs onto fixed-size nodes by their predicted peaks
-  (read from each index header, additive) and *proves* a co-location fits before launching a byte, or
+  (read from each index header, additive) and *shows* a co-location fits within budget before launching a byte, or
   refuses (exit 3). `plan --index --json` emits the predicted peak for a scheduler to read.
 
 ### ColumnKit SDK — implement one trait, inherit the contract
@@ -69,10 +69,10 @@ contract** — predict it before you commit, honor it during the run, and verify
 
 ### Variant calling
 - **Bounded whole-genome germline SNV calling** (`variants --index`) over a coordinate-sorted BAM and a
-  persisted index: peak memory tracks coverage, not BAM size. Calibrated, abstention-aware.
-- **Unbiased depth-cap downsampling** — a content-hash reservoir that bounds the working set without
+  persisted index: peak memory tracks coverage, not BAM size. Genotype-likelihood, abstention-aware.
+- **Unbiased depth-cap downsampling** — deterministic content-hash selection that bounds the working set without
   biasing allele balance (no silent variant drops); dropped-read counts surfaced in the receipt.
-- **Tumor/normal somatic** SNV + simple-indel calling (`somatic`).
+- **Tumor/normal somatic** SNV calling (`somatic`).
 - **Measured detection accuracy** on simulated diploid truth (precision/recall 1.00/1.00 on clean data);
   `eval-germline` / `eval-somatic` truth-set comparison (the `eval-germline` path is GIAB-ready).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to Rosalind are recorded here. Versions follow [Semantic Ver
 A contract-hardening pass followed by moat-compounding capabilities, all on the
 canonical bounded-memory substrate.
 
+### Reproducibility — a stranger can re-derive your result (Track D)
+- **`rosalind reproduce`** re-derives a recorded result byte-for-byte from its receipt and
+  content-located inputs, reporting REPRODUCED / DIVERGED / INCONCLUSIVE (exit 0 / 6 / 7; a
+  tampered receipt is exit 5). No incumbent caller can offer this — a non-deterministic caller
+  reports DIVERGED on a *correct* run. Honest scope: the deterministic text outputs
+  (`variants → VCF`, `features → TSV`); BAM/bgzf is reported INCONCLUSIVE, never a false DIVERGED.
+- **Chainable reproduction certificate** (`<receipt>.repro.json`): a content-addressed,
+  self-hashing attestation that names the original receipt's claim hash. N certificates over the
+  same parent are N independent confirmations — a serverless reproducibility web. Signing-ready,
+  and itself `verify`-able.
+- **Schema 5 — a replayable command.** Every receipt now records a normalized, machine-independent
+  `command` recipe (one `CommandCapture` chokepoint), closing the prior gap where
+  `gvcf`/`chrom`/index-vs-reference mode went unrecorded. Pre-v5 receipts still parse and verify.
+- **`rosalind badge`** emits a self-hosted shields.io endpoint JSON + a static SVG
+  ("reproducible · fits N MiB") with no shields.io runtime dependency (works offline).
+- **CI reproduce fence:** the `cli-e2e` job re-derives a result on the GitHub runner (a different
+  machine than the author's) and confirms a byte-changed input is reported INCONCLUSIVE.
+- Internals: `verify_receipt` is now a shared library function — `verify`, `reproduce`, and a
+  future WASM verifier consume one source of truth, so they cannot drift.
+
 ### Contract hardening (true & trusted on real genomes)
 - **Predicted peak is a true upper bound.** The per-contig reference decode no longer holds a
   transient second copy (`decode_window_arc`); the prediction is recorded in the receipt and carries an

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -5,8 +5,8 @@
 Every other variant caller treats RAM as an emergent property you guess at (`-Xmx…`,
 `--target-mem` "heuristics may not work well") and then crash on. Rosalind treats it as a contract:
 
-> **Rosalind never silently OOM-kills you — it fits, or it tells you up front, and it proves the
-> realized peak with a receipt.**
+> **Rosalind never silently OOM-kills you — it fits, or it tells you up front, and it records the
+> realized peak in a receipt you can verify.**
 
 (It does *not* claim to "never refuse": when a budget is genuinely too small the run declines cleanly
 rather than crashing. Graceful degrade-don't-die — sliding down a space/time curve to finish anyway — is
@@ -54,7 +54,7 @@ With `--enforce`:
 
 Without `--enforce`, the budget is **record-only**: the run always completes and the verdict is recorded in
 the receipt. The active read set is capped at `--max-depth` (default 1000; `0` = uncapped) by an
-**unbiased** content-hash reservoir — it bounds the working set without biasing allele balance, so a deep
+**unbiased** content-hash downsampling — it bounds the working set without biasing allele balance, so a deep
 variant is *not* silently dropped. Output changes only at sites deeper than the cap, and the dropped-read
 count is surfaced (stderr + the receipt's `over_max_depth`).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ pack: 37 job(s) → 3 node(s) of 64000 MiB — every node proven within capacity
 
 `rosalind plan --index ref.idx --budget-mb 64000 --json` emits the same predicted peak as one line of JSON for a workflow engine to read. This is what an emergent-peak caller (GATK, DeepVariant) structurally cannot do: their peak is only known *after* a possible OOM-kill, so every co-location is a gamble. Here, `Packed` is a proof — each node's summed predicted peak is `≤` its capacity, established up front, and the schedule is deterministic.
 
+## Reproduce a result — a command a stranger can run
+
+Hand someone a `*.vcf` and its `*.manifest.json`. On a *different machine*, with one offline command, they re-derive it byte-for-byte — no GATK, no Docker, no Nextflow, no re-aligning:
+
+```bash
+rosalind reproduce --manifest sample.vcf.manifest.json --inputs ./data
+#   claim       : a1b2c3… (re-derived)
+#   code        : git 9f3a213 — matches
+#   inputs      : 2 file(s) indexed by content hash
+#   output      : output[0]  OK byte-identical (blake3 e4f5…)
+#   VERDICT     : REPRODUCED
+#   -> wrote reproduction certificate: sample.vcf.manifest.json.repro.json (chains to a1b2c3…)
+```
+
+It content-locates the recorded inputs by their BLAKE3 hash (paths don't matter), re-runs the exact recorded command (schema-5 receipts carry a normalized, replayable `command`), and compares output bytes — exit **0 REPRODUCED / 6 DIVERGED / 7 INCONCLUSIVE** (and **5** for a tampered receipt). **No incumbent caller can do this:** GATK/DeepVariant would report DIVERGED on a *correct* run, because their output is not byte-deterministic.
+
+Each run writes a **reproduction certificate** (`.repro.json`) — a content-addressed, self-hashing attestation that names the original receipt's claim hash. Independent parties who reproduce the same result mint certificates that all name the same parent — **N independent confirmations, with no server**: a reproducibility web. (Tamper-evident today; cryptographic signing is the next step.)
+
+**Honest scope:** byte-equality covers the deterministic text outputs (`variants → VCF`, `features → TSV`); BAM/bgzf is reported INCONCLUSIVE rather than risking a false DIVERGED. Drop the [Rosalind budget Action](#the-memory-contract-in-your-ci) + `rosalind badge` into CI to publish a self-hosted *“reproducible · fits N MiB”* badge.
+
 ## A reproducible feature substrate for ML
 
 The same bounded streaming engine that calls variants can emit **per-locus features** instead — one tabular row per callable position, ready for a model:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rosalind
 
-**A deterministic, low-memory genomics engine in Rust — call variants across a whole genome on a laptop, with memory you can predict and verify, and results that are byte-for-byte reproducible.**
+**A deterministic, low-memory genomics engine in Rust, built around a different promise: memory is a contract — you see it before you commit, and verify it after.**
 
-Most variant callers use memory that grows with your data, so "will this finish on my machine?" is something you find out the hard way. Rosalind is built around a different promise: **memory as a contract you can see before you commit and verify after the run.** It streams a coordinate-sorted BAM one read at a time, reads the reference from a compact portable index (no second copy of the genome in RAM), keeps its working set proportional to *local read depth* rather than file size, and prints a receipt showing the memory it actually used. Run it twice on the same inputs and you get identical output, bit for bit. And where the evidence is too thin to be sure, it **abstains** instead of guessing.
+Call variants across a whole genome on a laptop, in RAM you declare up front, and get results that reproduce byte-for-byte — with a receipt to prove it. Most variant callers spend memory that grows with your data, so "will this finish on my machine?" is something you find out the hard way. Rosalind inverts that: you state a budget, and it tells you *before committing a byte* whether the job fits, then honors that ceiling while it runs. It streams a coordinate-sorted BAM one read at a time, reads the reference from a compact memory-mapped index (no second copy of the genome in RAM), and keeps its working set proportional to *local read depth* rather than file size. Every run prints — and records — the memory it actually used. Where the evidence is too thin to be sure, it **abstains** instead of guessing.
 
-It's a Rust **library and CLI** you can call directly, extend with plugins, or drive from Python — not a black-box pipeline.
+The bounded engine is a substrate, not just a caller: **the receipt is the product, and variant calling is the first workload that runs on it.** It's a Rust **library and CLI** you can call directly, extend with one trait, or drive from Python — not a black-box pipeline.
 
 ---
 
@@ -33,7 +33,7 @@ rosalind variants \
 #   contract: OK — realized peak 412 MiB within declared 4096 MiB
 #   wrote reproducibility receipt: sample.vcf.manifest.json
 
-# 5. Re-check the receipt later — no re-run — to prove it fit and is reproducible.
+# 5. Re-check the receipt later — no re-run — to confirm it fit and is reproducible.
 rosalind verify --manifest sample.vcf.manifest.json
 ```
 
@@ -71,13 +71,13 @@ You'll see `plan` predict `[FITS]`, `variants --enforce` print `contract: OK —
 
 ## What it does today
 
-- **Bounded whole-genome germline calling** — `rosalind variants --index` streams a coordinate-sorted BAM over all contigs of a persisted index, calling SNVs to a multi-contig VCF with a working set bounded by coverage. Calls are calibrated and **abstention-aware** (no confident call → no row, rather than a guess). Detection accuracy is measured against simulated diploid truth (precision/recall 1.00/1.00 on clean data — see [Accuracy](#accuracy)).
+- **Bounded whole-genome germline calling** — `rosalind variants --index` streams a coordinate-sorted BAM over all contigs of a persisted index, calling SNVs to a multi-contig VCF with a working set bounded by coverage. Calls carry genotype-likelihood confidence (GT/GQ/PL) and are **abstention-aware** (no confident call → no row, rather than a guess). Detection accuracy is measured against simulated diploid truth (precision/recall 1.00/1.00 on clean data — see [Accuracy](#accuracy)).
 - **A reproducible ML feature substrate** — `rosalind features --index` emits the same bounded pileup stream as a per-locus feature **table** (TSV) instead of variant calls — byte-identical run-to-run, with a hash receipt, for **bit-reproducible** training inputs (see below).
 - **Build-once, query-many index** — `rosalind index` builds a portable, memory-mapped FM-index over a (multi-contig) reference; `rosalind locate` answers exact-match queries against it in milliseconds. The index is **never rebuilt on load** and is **byte-identical across builds** of the same reference.
 - **Alignment** — `rosalind align` builds a Burrows–Wheeler / FM-index over a reference contig and aligns reads via exact-match seeding, deterministic diagonal chaining, and banded affine-gap refinement. Emits SAM or BGZF-compressed BAM.
 - **Streaming I/O** — Reads plain or gzip/bgzf-compressed FASTA/FASTQ, auto-detected from the magic bytes; FASTQ can stream from stdin (`-`).
 - **Deterministic coordinate sort** — `rosalind sort`: an external merge sort (spills to disk) that orders a BAM by position within a configurable memory budget.
-- **Somatic (tumor/normal) calling** — `rosalind somatic` calls somatic SNVs and simple indels from a paired tumor/normal BAM set using a deterministic binomial log-likelihood-ratio model with explicit depth and allele-fraction filters.
+- **Somatic (tumor/normal) calling** — `rosalind somatic` calls somatic SNVs from a paired tumor/normal BAM set using a deterministic binomial log-likelihood-ratio model with explicit depth and allele-fraction filters.
 - **Truth-set evaluation** — `rosalind eval-germline` / `rosalind eval-somatic` compare a call set against a truth VCF over confident regions (BED), with variant normalization (left-align + trim) and precision / recall / F1. `eval-germline` is the drop-in interface for a GIAB benchmark.
 - **Extensibility** — Build custom bounded per-locus analytics by implementing one trait ([ColumnKit](#columnkit-implement-one-trait-inherit-the-contract); see [`examples/columnkit_coverage.rs`](examples/columnkit_coverage.rs)) — inheriting bounded memory, determinism, and a verifiable receipt for free. Or iterate the raw `PileupColumn` substrate directly ([`examples/custom_pileup_analytics.rs`](examples/custom_pileup_analytics.rs)).
 - **Determinism by design** — Primary artifacts are emitted in a canonical, stable order, byte-for-byte identical across repeated runs given identical inputs. See [`docs/determinism.md`](docs/determinism.md).
@@ -88,9 +88,9 @@ Three properties, treated as first-class guarantees rather than nice-to-haves:
 
 1. **Predictable memory.** The bet is that for a growing set of users — sequencing in the field, in the clinic, on a laptop, or at genome scale on modest hardware — *"it fits, and I knew it would"* matters more than raw throughput. Rosalind makes the streaming working set bounded by local coverage and surfaces the realized peak so the bound is **verifiable, not just claimed**.
 2. **Reproducibility.** Byte-identical outputs and a per-run BLAKE3 manifest make results auditable — a hard requirement for clinical and regulated pipelines, and a sanity-saver for everyone else.
-3. **Honest uncertainty.** Calibrated, abstention-aware calling refuses to emit a call where the evidence is insufficient, instead of papering over it.
+3. **Honest uncertainty.** Probabilistically grounded, abstention-aware calling refuses to emit a call where the evidence is insufficient, instead of papering over it.
 
-The contract is real today: `rosalind plan` predicts before you commit, `--enforce` honors the budget, and `rosalind verify` re-checks the receipt (see [CONTRACT.md](CONTRACT.md)). Looking ahead, Rosalind is *also* a research vehicle for **space-bounded genomics**: **sublinear-space index *construction*** along a `~√t` (square-root-space) space/time curve — the future Phase-D direction that would extend the contract to the index build step (today's build is `O(reference)`). That is a direction, not yet shipped; the bounded streaming engine you use today is the practical foundation it builds on.
+The contract is real today: `rosalind plan` predicts before you commit, `--enforce` honors the budget, and `rosalind verify` re-checks the receipt (see [CONTRACT.md](CONTRACT.md)). The roadmap's north star is to extend that same contract to index **construction** — building the index along a budget-selected space/time curve (in the `~√t` square-root-space lineage) so *"declare your RAM and it's honored"* holds end to end, not just for calling (construction is `O(reference)` today). That's the keystone the roadmap is climbing toward; the bounded streaming engine you use today is the foundation it builds on.
 
 ## Accuracy
 
@@ -112,7 +112,7 @@ The comparator is **GIAB-grade**: it scores **genotype concordance** (a het call
 
 - **Whole-genome:** germline variant calling via `rosalind variants --index` (all contigs, streaming, bounded) and exact-match lookup via `rosalind index` / `rosalind locate`.
 - **Single-contig:** Rosalind's own **aligner** (`rosalind align`) and the FASTA-based `variants --reference` path operate on one reference contig per run. For whole-genome calling, align with any standard aligner and bring the coordinate-sorted BAM to `variants --index`. (Wiring the *aligner* onto the persisted multi-contig index is a later phase — see the roadmap.)
-- Variant calling is **single-sample** (germline) or a **tumor/normal pair** (somatic); calling is SNV-focused, with simple indels in the somatic path.
+- Variant calling is **single-sample** (germline) or a **tumor/normal pair** (somatic); calling is SNV-focused.
 - The engine runs **single-threaded** today. `--memory-budget-mb` is record-only by default; add `--enforce` to honor it (refuse up front / fail loud — see [CONTRACT.md](CONTRACT.md)).
 
 ## The memory contract in *your* CI
@@ -129,11 +129,11 @@ Drop the Rosalind budget Action (this repo's [`action.yml`](action.yml)) into an
     max-read-len: 250       # optional (default 250)
 ```
 
-It runs `plan` (predicts the peak), then `variants --index --enforce` (honors the budget), and uploads the BLAKE3 receipt as a build artifact. This is the one thing a `--max-mem` flag on another caller can't give you: a portable, declarative, **verifiable** memory budget that fails a stranger's build loudly — the contract, enforced where your pipeline already lives. (Available once a release is published; see Quickstart.)
+It runs `plan` (predicts the peak), then `variants --index --enforce` (honors the budget), and uploads the BLAKE3 receipt as a build artifact. This is what a `--max-mem` flag on another caller can't give you: a portable, declarative, **verifiable** memory budget that fails a stranger's build loudly — the contract, enforced where your pipeline already lives. (Available once a release is published; see Quickstart.)
 
 ## Pack a fleet: prediction → placement
 
-Because the predicted peak is computed from the **index header alone** — no run, no read I/O, milliseconds — and is a conservative, *additive* upper bound, you can turn the prediction into a scheduling decision: **prove** that N calling jobs co-located on one node will all fit, before launching a single read.
+Because the predicted peak is computed from the **index header alone** — no run, no read I/O, milliseconds — and is a conservative, *additive* upper bound, you can turn the prediction into a scheduling decision: **show** that N calling jobs co-located on one node fit within their declared budgets, before launching a single read.
 
 ```sh
 # jobs.tsv: one job per line — <index>[\t<max-depth>[\t<max-read-len>]]
@@ -142,12 +142,12 @@ rosalind pack --jobs jobs.tsv --node-mb 64000 --nodes 4 # …or refuse (exit 3) 
 ```
 
 ```
-pack: 37 job(s) → 3 node(s) of 64000 MiB — every node proven within capacity
+pack: 37 job(s) → 3 node(s) of 64000 MiB — every node within capacity by predicted peak
   node 0: 61920 / 64000 MiB  [sampleA.idx, sampleB.idx, …]
   ...
 ```
 
-`rosalind plan --index ref.idx --budget-mb 64000 --json` emits the same predicted peak as one line of JSON for a workflow engine to read. This is what an emergent-peak caller (GATK, DeepVariant) structurally cannot do: their peak is only known *after* a possible OOM-kill, so every co-location is a gamble. Here, `Packed` is a proof — each node's summed predicted peak is `≤` its capacity, established up front, and the schedule is deterministic.
+`rosalind plan --index ref.idx --budget-mb 64000 --json` emits the same predicted peak as one line of JSON for a workflow engine to read. This is what emergent-peak callers (GATK, DeepVariant) can't tell you up front: their peak is only known *after* a possible OOM-kill, so every co-location is a gamble. Here, `Packed` is a decision you can check before you launch — each node's summed *predicted* peak is `≤` its capacity, established up front, and the schedule is deterministic.
 
 ## Reproduce a result — a command a stranger can run
 
@@ -163,7 +163,7 @@ rosalind reproduce --manifest sample.vcf.manifest.json --inputs ./data
 #   -> wrote reproduction certificate: sample.vcf.manifest.json.repro.json (chains to a1b2c3…)
 ```
 
-It content-locates the recorded inputs by their BLAKE3 hash (paths don't matter), re-runs the exact recorded command (schema-5 receipts carry a normalized, replayable `command`), and compares output bytes — exit **0 REPRODUCED / 6 DIVERGED / 7 INCONCLUSIVE** (and **5** for a tampered receipt). **No incumbent caller can do this:** GATK/DeepVariant would report DIVERGED on a *correct* run, because their output is not byte-deterministic.
+It content-locates the recorded inputs by their BLAKE3 hash (paths don't matter), re-runs the exact recorded command (schema-5 receipts carry a normalized, replayable `command`), and compares output bytes — exit **0 REPRODUCED / 6 DIVERGED / 7 INCONCLUSIVE** (and **5** for a tampered receipt). **A non-deterministic caller can't do this:** GATK/DeepVariant would report DIVERGED on a *correct* run, because their output is not byte-deterministic.
 
 Each run writes a **reproduction certificate** (`.repro.json`) — a content-addressed, self-hashing attestation that names the original receipt's claim hash. Independent parties who reproduce the same result mint certificates that all name the same parent — **N independent confirmations, with no server**: a reproducibility web. (Tamper-evident today; cryptographic signing is the next step.)
 
@@ -207,20 +207,20 @@ impl ColumnAnalyzer for CoverageTrack {
 //   → returns the bounded WorkingSet `plan`/`--enforce` reason about.
 ```
 
-The trait is *welded* to the bounded kernel — `run_bounded_whole_genome` drives the exact same column stream as the shipped `features` egress (which is itself just the first `ColumnAnalyzer`), so the estimator that admits a run provably upper-bounds the realized working set of *your* analyzer too. No other genomics library can offer "implement this trait, inherit a machine-checkable memory budget + a hash-verifiable receipt," because no other library has a memory contract to inherit. See [`examples/columnkit_coverage.rs`](examples/columnkit_coverage.rs).
+The trait is *welded* to the bounded kernel — `run_bounded_whole_genome` drives the exact same column stream as the shipped `features` egress (which is itself just the first `ColumnAnalyzer`), so the estimator that admits a run upper-bounds the realized working set of *your* analyzer too, by construction. Implement one trait and you inherit a machine-checkable memory budget and a hash-verifiable receipt for your own metric — what a library without a memory contract can't hand you. See [`examples/columnkit_coverage.rs`](examples/columnkit_coverage.rs).
 
 ## Roadmap
 
 The core primitive is a streaming, CIGAR-aware pileup column stream; variant calling and custom plugins consume it. Performance work deliberately *follows* the unique capability — the target user needs "it fits and is predictable" before "it's fastest."
 
-- **Phase A (done):** the streaming pileup engine; calibrated, abstention-aware germline SNV calling; tumor/normal somatic calling; spec-valid VCF; a BLAKE3 reproducibility receipt per run.
+- **Phase A (done):** the streaming pileup engine; genotype-likelihood, abstention-aware germline SNV calling; tumor/normal somatic calling; spec-valid VCF; a BLAKE3 reproducibility receipt per run.
 - **Phase B (done):** streaming gzip/bgzf input; a multi-contig FM-index over the concatenated genome with `(contig, position)` resolution; a build-once, memory-mapped, byte-reproducible persisted index (`rosalind index`/`locate`); zero-copy reference access from the index; and **bounded whole-genome germline calling over a sorted BAM** (`rosalind variants --index`) with a realized-memory receipt.
 - **Phase C (done):** memory as a *verifiable contract* — `rosalind plan` (a checkable envelope before you commit), `--enforce` (honor-or-refuse: refuse up front / fail loud, never a silent OOM-kill), and `rosalind verify`. See [CONTRACT.md](CONTRACT.md).
 - **Hardening & reach (done):** unbiased depth-cap downsampling (no silent variant drops) and a CI-enforced memory gate; **measured** germline detection accuracy ([Accuracy](#accuracy)); the **`rosalind features`** reproducible ML feature substrate; and a one-command adoption on-ramp — prebuilt binaries (`install.sh`, with checksum verification) plus the **Rosalind budget GitHub Action** (`action.yml`, used as `logannye/rosalind@v0.1.0`) that enforces the contract in *your* CI.
-- **Fleet scheduling (done):** [prediction → placement](#pack-a-fleet-prediction--placement) — `rosalind pack` proves a co-location of N calling jobs fits a node before launching a byte (predicted peaks are additive and read from the index header); `plan --index --json` for a scheduler to read.
+- **Fleet scheduling (done):** [prediction → placement](#pack-a-fleet-prediction--placement) — `rosalind pack` shows a co-location of N calling jobs fits within budget before launching a byte (predicted peaks are additive and read from the index header); `plan --index --json` for a scheduler to read.
 - **ColumnKit SDK (done):** [implement one trait, inherit the contract](#columnkit-implement-one-trait-inherit-the-contract) — a `ColumnAnalyzer` trait + `run_bounded_whole_genome` driver so a builder's own per-locus analyzer inherits bounded memory, determinism, and a verifiable receipt. The shipped `features` egress is the first impl.
-- **Bounded gVCF (done):** `variants --index --gvcf` emits a banded gVCF (every callable locus → a variant record or a `<NON_REF>` reference block with an `END=` span), so per-sample output joins into GLnexus/GATK cohort pipelines — bounded (the banding state is O(1)) and byte-reproducible, which neither GATK nor DeepVariant offers.
-- **Phase D (research):** sublinear-space index construction — the `~√t` space/time knob across the full curve — extending the contract to the index *build* step (today's build is O(reference)). The headline space-complexity bet; see [`docs/OPEN_PROBLEMS.md`](docs/OPEN_PROBLEMS.md).
+- **Bounded gVCF (done):** `variants --index --gvcf` emits a banded gVCF (every callable locus → a variant record or a `<NON_REF>` reference block with an `END=` span), so per-sample output joins into GLnexus/GATK cohort pipelines — bounded (O(1) banding state) and byte-reproducible run-to-run, a property production gVCF pipelines generally don't provide.
+- **Phase D (research):** sublinear-space index construction — the `~√t` space/time knob across the full curve — extending the contract to the index *build* step (today's build is `O(reference)`). The keystone that completes the memory contract end to end; see [`docs/OPEN_PROBLEMS.md`](docs/OPEN_PROBLEMS.md).
 - **Later:** the aligner over the persisted multi-contig index (`align --index`, whole-genome alignment); germline indels and richer read QC; deterministic multithreading; a Python/tensor binding over the pileup stream.
 
 Target architecture and per-phase specs/plans live in [`docs/superpowers/specs/`](docs/superpowers/specs/) and [`docs/superpowers/plans/`](docs/superpowers/plans/); the guiding thesis is in [`docs/OPEN_PROBLEMS.md`](docs/OPEN_PROBLEMS.md).
@@ -314,7 +314,7 @@ Run `rosalind <subcommand> --help` for exact flags.
 - `rosalind features --index genome.idx --alignments sorted.bam -o features.tsv` — stream a bounded, byte-identical per-locus feature table (TSV) under the same memory contract (see [the ML substrate](#a-reproducible-feature-substrate-for-ml)).
 - `rosalind locate --index genome.idx --pattern GATTACA` — exact-match positions in a prebuilt index (memory-mapped, never rebuilt). Exact-match only; seed/chain/extend alignment against the persisted index is a later phase.
 - `rosalind sort` — deterministic coordinate sort of a BAM within a memory budget.
-- `rosalind somatic` — tumor/normal somatic SNV + simple-indel calling from a paired BAM set over a region.
+- `rosalind somatic` — tumor/normal somatic SNV calling from a paired BAM set over a region.
 - `rosalind eval-germline` / `rosalind eval-somatic` — compare a germline / somatic call set to a truth VCF over confident regions (BED), reporting precision / recall / F1.
 
 ### Rust API
@@ -336,7 +336,7 @@ use rosalind::call::{call_germline_region, GermlineCall, GermlineParams};
 use rosalind::core::{AlignedRead, CoreError, Locus};
 use rosalind::pileup::{PileupParams, SliceSource};
 
-// Calibrated, abstention-aware germline SNV calls over one contig, from
+// Genotype-likelihood, abstention-aware germline SNV calls over one contig, from
 // coordinate-sorted reads. Each emitted site is (locus, ref_base, call).
 fn call_germline(
     reads: Vec<AlignedRead>,

--- a/docs/OPEN_PROBLEMS.md
+++ b/docs/OPEN_PROBLEMS.md
@@ -12,14 +12,14 @@ Rosalind does not try to out-align bwa-mem2/minimap2 or out-call DeepVariant —
 non-goal. Its differentiated, defensible contribution is a property almost no production genomics
 tool offers:
 
-> **Memory is a declared, predictable, never-refusing, verifiable contract** — across the entire
+> **Memory is a declared, predictable, verifiable contract** — and, as this thesis matures, a **never-refusing** one — across the entire
 > genomics lifecycle (index construction, alignment, pileup, calling, query), with a **continuous
 > space/time tradeoff** the builder selects by stating a RAM budget.
 
 You tell Rosalind the RAM you have; it tells you — *before you commit* — whether the job fits and
-how long it will take; it then honors that ceiling, sliding along a space/time curve to do so; and
-when the budget is below the comfortable in-RAM regime it **degrades gracefully** (more
-recomputation, then spill to disk) rather than refusing. Every run emits a receipt recording the
+how long it will take; it then honors that ceiling. Today it refuses cleanly when a budget is
+genuinely too small; the thesis's destination (Phase D) is to **degrade gracefully** instead —
+sliding along a space/time curve (more recomputation, then spill to disk) to finish anyway. Every run emits a receipt recording the
 *realized* peak working set, and CI enforces the bound. This is the capability that matters to the
 people who actually need Rosalind: **edge, field, clinical, and large-/meta-/pan-genome** settings
 where RAM is fixed, swap is death, and an unpredictable OOM at hour 20 of a build is unacceptable.
@@ -38,7 +38,7 @@ is that this is **not a single low-space operating point.** Block-respecting sim
 tunable block size `b` (and checkpoint density) yields a **continuous curve**: from `b = t`
 (standard, fast, O(t) space) through `b = √t` (minimal space ~√t, more
 recomputation) and onward toward external-memory spill. **A declared RAM budget simply selects the
-point on that curve.** The theory layer's job is to *be the knob.*
+point on that curve.** The role of the √t theory is to *be the knob.*
 
 ## 3. The open problem
 
@@ -119,8 +119,8 @@ A single declared budget governs the whole system, not just one stage:
 - **Declare → predict.** `rosalind plan --budget 4G …` reports *feasibility*, the *predicted peak
   working set*, the *estimated time*, and the *curve* ("at 8 GB → ~3× faster") — so you commit with
   your eyes open. No surprise OOM, no surprise multi-day run.
-- **Honor or refuse — then degrade rather than refuse.** Every streaming stage exposes a provable
-  working-set bound and honors the ceiling; below the in-RAM threshold it slides further down the
+- **Honor or refuse today; degrade-rather-than-refuse is the Phase-D aim.** Every streaming stage exposes a conservative
+  working-set bound and honors the ceiling; the aim is that below the in-RAM threshold it slides further down the
   curve (more recomputation → external-memory spill) and **still completes**, slower. A 2 GB field
   device builds a human index; it does not get "won't fit."
 - **Lifecycle-wide.** The same budget bounds **construction, mmap-query (tunable SA-sampling),
@@ -139,8 +139,7 @@ D lands the space-complexity headline on top.
 
 - **B — Genome-scale kernel (finish).** Zero-copy persisted lean multi-contig index (build-once →
   mmap), wired consumers, whole-genome pileup, pipe-native. Lay the `MemoryBudget` / space-accounting
-  hooks. The theory layer (`algebra`/`ledger`/`machine`/`tree`/`space`) is **kept and repurposed**,
-  not feature-gated away.
+  hooks the future budget-tunable build will consume.
 - **C — Memory as a verifiable contract.** Declared `MemoryBudget` threaded through every streaming
   stage + mmap-query; `rosalind plan` (envelope + curve); honor-or-refuse + graceful degradation;
   real RSS gates in CI; deterministic (thread-count-invariant) execution + receipts + `rosalind

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,7 +40,7 @@ real memory-bound build.
 
 Each is tagged **[shipped]** or **[to build]** and tied to the persona who actually needs it.
 
-| Capability | Persona who needs it | Why incumbents structurally can't match it |
+| Capability | Persona who needs it | Why it's hard for incumbents to match |
 |---|---|---|
 | **Never a silent OOM — predict, then refuse / fail loud** [shipped] | Field/outbreak operator on a no-swap laptop driving a MinION | GATK `-Xmx` crashes; DeepVariant OOM-kills; pSAscan/Big-BWT/ropebwt3 have no governor. `plan` gives a FITS/REFUSE verdict in ms; the runtime governor (`core/governor.rs`) fails loud at exit 4. |
 | **Verify-without-rerun** [shipped] | Air-gapped / regulated / CRO auditor | A non-deterministic caller can't emit a byte-reproducible hash, so it can't anchor an audit at all. `rosalind verify` re-checks inputs/outputs + realized-peak-vs-budget offline in seconds. |
@@ -160,7 +160,7 @@ The strongest *differentiated* claims are real **today**. Make them legible and 
   An asciinema: `variants` → `verify` OK → a human edits one byte → `verify` exits 5. Then compile
   `provenance/mod.rs` (std + hand-rolled canonical-JSON + blake3, zero htslib) to `wasm32` for a
   drag-a-receipt-in-the-browser verifier — the most viral artifact in the repo and a structural
-  capability no incumbent has. **Honest copy:** catches corruption/casual edits, *not* a motivated
+  capability we're not aware of in incumbent callers. **Honest copy:** catches corruption/casual edits, *not* a motivated
   forger who re-runs `finalize()` — that needs the signature (Phase 3).
 - **P1.3 — A scope-boundary benchmark + a README scope table.** *(S, the anti-hype guardrail)* A
   reproducible benchmark showing **both** the in-scope win (construction peak slides down the curve)
@@ -204,7 +204,7 @@ The strongest *differentiated* claims are real **today**. Make them legible and 
 - **P3.4 — `rosalind cohort`: a verifiable Merkle ledger for biobank-scale re-analysis.** *(L)* Roll
   *N* byte-stable per-sample receipts into a signed root; `cohort verify` re-derives without re-running
   and, on mismatch, reports the **exact changed leaves and which field drifted**; `cohort plan` reuses
-  `pack` to prove the re-run co-locates. **Beats** GenomicsDB/GLnexus (outputs not byte-stable, no
+  `pack` to show the re-run co-locates within budget. **Beats** GenomicsDB/GLnexus (outputs not byte-stable, no
   receipt, emergent memory). Depends on P0.2 + P3.1 + P3.2.
 
 ### Phase 4 — Complete the contract end-to-end (the √t build)

--- a/docs/superpowers/plans/2026-06-05-track-d-reproduce-certificate.md
+++ b/docs/superpowers/plans/2026-06-05-track-d-reproduce-certificate.md
@@ -1,0 +1,943 @@
+# Track D — `reproduce` + reproduction certificate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `rosalind reproduce` re-derive a recorded result byte-for-byte from content-located inputs, mint a chainable `.repro.json` reproduction certificate, and gate CI on it — building only on Rosalind's shipped determinism + receipt (standalone, no cross-repo).
+
+**Architecture:** A single `CommandCapture` chokepoint records a normalized, machine-independent, hash-protected `command` recipe into the claim (schema 4→5) and is the same structure `reproduce` replays. `reproduce` (an htslib-free driver) integrity-checks the receipt via an extracted `verify_receipt`, content-locates inputs by BLAKE3, re-execs `current_exe()`, byte-compares outputs (text only in v1), and writes a content-addressed `ReproReceipt` that chains to the parent's `content_hash`. A `badge` verb + a CI fence (cross-machine REPRODUCED + one-byte-flip DIVERGED) complete it.
+
+**Tech Stack:** Rust (edition per repo, MSRV 1.72), `anyhow`, `clap` derive, `std::collections::BTreeMap`, `std::process::Command` + `std::env::current_exe`, the in-repo `blake3_*` helpers. No new runtime deps.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-track-d-reproduce-certificate-design.md`. Branch: `rosalind/track-d-reproduce`.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/provenance/command.rs` | `CommandCapture` — capture a normalized replayable invocation into the claim; reconstruct an argv from it. |
+| Create | `src/provenance/repro.rs` | `ReproReceipt` — the reproduction certificate: type, canonical render + self-hash, chaining, parse. |
+| Create | `src/provenance/badge.rs` | `badge_json` / `badge_svg` — self-hosted shields-endpoint JSON + static SVG. |
+| Create | `src/reproduce.rs` | the `reproduce` driver: locate inputs, re-exec, classify outputs, mint the certificate. |
+| Modify | `src/provenance/mod.rs` | `MANIFEST_SCHEMA_VERSION = 5`; `mod command/repro/badge`; `verify_receipt` + `VerifyReport`; re-exports. |
+| Modify | `src/lib.rs` | re-export the new public items. |
+| Modify | `src/main.rs` | adopt `CommandCapture` at the 4 receipt sites; `Reproduce` + `Badge` clap variants + dispatch; `run_verify` calls `verify_receipt`. |
+| Create | `tests/reproduce.rs` | end-to-end gates: REPRODUCED, DIVERGED (pure-fn), INCONCLUSIVE, back-compat, certificate, chaining. |
+| Create | `.github/workflows/reproduce.yml` | the cross-machine reproduce fence. |
+| Create | `tests/golden/reproduce/` | committed golden chain (inputs + receipt + expected VCF) for the fence. |
+| Modify | `CHANGELOG.md`, `README.md` | document the verb, the certificate, the badge. |
+
+**Commit/PR boundary note:** Tasks 1–3 (capture + schema-5 + `verify_receipt`) are a coherent first half (receipts now self-describe their command; shared verifier extracted). Tasks 4–7 build `reproduce`/certificate/badge/CI on top. Commit after every task.
+
+---
+
+## Part 1 — Capture + extraction
+
+### Task 1: `CommandCapture` — the capture/replay chokepoint
+
+**Files:**
+- Create: `src/provenance/command.rs`
+- Modify: `src/provenance/mod.rs` (add `mod command; pub use command::CommandCapture;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the bottom of `src/provenance/command.rs` (created in Step 3, but write the test first in the same file under a `#[cfg(test)]` module — create the file with only the test to start):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::RunManifest;
+    use std::path::Path;
+
+    // Build a capture WITHOUT touching the filesystem by injecting hashes directly.
+    fn sample() -> CommandCapture {
+        let mut c = CommandCapture::new("variants");
+        c.input_hashed("--index", "ref.idx", "h_idx");
+        c.input_hashed("--alignments", "s.bam", "h_bam");
+        c.opt("--mapq-threshold", 20u8);
+        c.opt("--max-depth", 1000u32);
+        c.flag_if(true, "--enforce");
+        c.flag_if(false, "--gvcf");
+        c.opt("--memory-budget-mb", 256u64);
+        c.output_hashed("-o", "out.vcf", "h_out");
+        c
+    }
+
+    #[test]
+    fn record_into_writes_command_inputs_outputs_and_discrete_params() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+
+        // command recipe: canonical, operands as @in:/@out:, gvcf absent (flag was false)
+        assert_eq!(
+            m.params.get("command").unwrap(),
+            "variants --index @in:h_idx --alignments @in:h_bam \
+             --mapq-threshold 20 --max-depth 1000 --memory-budget-mb 256 --enforce -o @out:h_out"
+        );
+        // inputs/outputs derived from the builder, in insertion order
+        assert_eq!(m.inputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(), ["h_idx", "h_bam"]);
+        assert_eq!(m.outputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(), ["h_out"]);
+        // discrete params projected mechanically (flag -> key); mode inferred from --index
+        assert_eq!(m.params.get("mapq_threshold").unwrap(), "20");
+        assert_eq!(m.params.get("max_depth").unwrap(), "1000");
+        assert_eq!(m.params.get("memory_budget_mb").unwrap(), "256");
+        assert_eq!(m.params.get("enforce").unwrap(), "true");
+        assert_eq!(m.params.get("mode").unwrap(), "index");
+        assert!(!m.params.contains_key("gvcf")); // false flag is not recorded
+    }
+
+    #[test]
+    fn argv_roundtrips_from_the_recorded_command() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+        let command = m.params.get("command").unwrap();
+
+        let locate = |h: &str| match h {
+            "h_idx" => Some("/data/ref.idx".to_string()),
+            "h_bam" => Some("/data/s.bam".to_string()),
+            _ => None,
+        };
+        let out_temp = |_h: &str| "/tmp/out.vcf".to_string();
+        let argv = CommandCapture::argv_from_command(command, &locate, &out_temp).unwrap();
+
+        assert_eq!(
+            argv,
+            vec![
+                "variants", "--index", "/data/ref.idx", "--alignments", "/data/s.bam",
+                "--mapq-threshold", "20", "--max-depth", "1000", "--memory-budget-mb", "256",
+                "--enforce", "-o", "/tmp/out.vcf",
+            ]
+        );
+    }
+
+    #[test]
+    fn argv_errors_when_an_input_cannot_be_located() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+        let command = m.params.get("command").unwrap();
+        let locate = |_h: &str| None;
+        let out_temp = |_h: &str| "/tmp/out.vcf".to_string();
+        let err = CommandCapture::argv_from_command(command, &locate, &out_temp).unwrap_err();
+        assert!(err.contains("h_idx"), "error names the unresolved input hash: {err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rosalind --lib provenance::command 2>&1 | tail -20`
+Expected: FAIL — `cannot find type CommandCapture` / module not declared.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Put this ABOVE the `#[cfg(test)]` module in `src/provenance/command.rs`:
+
+```rust
+//! `CommandCapture` — the single chokepoint that records a normalized, replayable
+//! invocation into a receipt's claim, and reconstructs an argv from it. Recording and
+//! replay share this one structure so they cannot drift (the "forgot to record flag X"
+//! bug class is eliminated by construction).
+
+use std::path::Path;
+
+use super::{blake3_file, FileHash, RunManifest};
+
+/// One token of a recorded invocation. Input/output operands carry a content hash, not
+/// a path, so the recorded command is machine-independent and hash-protected.
+enum Token {
+    Flag(String),
+    Opt(String, String),
+    Input { flag: String, blake3: String },
+    Output { flag: String, blake3: String },
+}
+
+/// Accumulates an invocation, then writes it into a `RunManifest` (claim) and/or
+/// reconstructs an argv for re-execution.
+pub struct CommandCapture {
+    subcommand: String,
+    tokens: Vec<Token>,
+    inputs: Vec<FileHash>,
+    outputs: Vec<FileHash>,
+}
+
+impl CommandCapture {
+    pub fn new(subcommand: impl Into<String>) -> Self {
+        Self { subcommand: subcommand.into(), tokens: Vec::new(), inputs: Vec::new(), outputs: Vec::new() }
+    }
+
+    /// A content-addressed input operand; hashes the file and records it.
+    pub fn input(&mut self, flag: &str, path: &Path) -> std::io::Result<&mut Self> {
+        let h = blake3_file(path)?;
+        Ok(self.input_hashed(flag, &path.display().to_string(), &h))
+    }
+    /// A content-addressed output operand; hashes the file and records it.
+    pub fn output(&mut self, flag: &str, path: &Path) -> std::io::Result<&mut Self> {
+        let h = blake3_file(path)?;
+        Ok(self.output_hashed(flag, &path.display().to_string(), &h))
+    }
+    /// Input operand with a precomputed hash (used when the caller already hashed it,
+    /// and by tests). `path` is recorded into `inputs[]` for humans/`verify`.
+    pub fn input_hashed(&mut self, flag: &str, path: &str, blake3: &str) -> &mut Self {
+        self.inputs.push(FileHash { path: path.to_string(), blake3: blake3.to_string() });
+        self.tokens.push(Token::Input { flag: flag.to_string(), blake3: blake3.to_string() });
+        self
+    }
+    pub fn output_hashed(&mut self, flag: &str, path: &str, blake3: &str) -> &mut Self {
+        self.outputs.push(FileHash { path: path.to_string(), blake3: blake3.to_string() });
+        self.tokens.push(Token::Output { flag: flag.to_string(), blake3: blake3.to_string() });
+        self
+    }
+    pub fn opt(&mut self, flag: &str, value: impl ToString) -> &mut Self {
+        self.tokens.push(Token::Opt(flag.to_string(), value.to_string()));
+        self
+    }
+    pub fn flag(&mut self, flag: &str) -> &mut Self {
+        self.tokens.push(Token::Flag(flag.to_string()));
+        self
+    }
+    pub fn flag_if(&mut self, cond: bool, flag: &str) -> &mut Self {
+        if cond { self.flag(flag) } else { self }
+    }
+
+    /// Render the normalized, machine-independent command string. Canonical order:
+    /// subcommand, then input operands, then options (sorted by flag), then bare flags
+    /// (sorted), then output operands — so the recorded command is stable run-to-run.
+    fn render_command(&self) -> String {
+        let mut parts: Vec<String> = vec![self.subcommand.clone()];
+        for t in &self.tokens {
+            if let Token::Input { flag, blake3 } = t {
+                parts.push(flag.clone());
+                parts.push(format!("@in:{blake3}"));
+            }
+        }
+        let mut opts: Vec<(&String, &String)> =
+            self.tokens.iter().filter_map(|t| match t { Token::Opt(f, v) => Some((f, v)), _ => None }).collect();
+        opts.sort_by(|a, b| a.0.cmp(b.0));
+        for (f, v) in opts {
+            parts.push(f.clone());
+            parts.push(v.clone());
+        }
+        let mut flags: Vec<&String> =
+            self.tokens.iter().filter_map(|t| match t { Token::Flag(f) => Some(f), _ => None }).collect();
+        flags.sort();
+        for f in flags { parts.push(f.clone()); }
+        for t in &self.tokens {
+            if let Token::Output { flag, blake3 } = t {
+                parts.push(flag.clone());
+                parts.push(format!("@out:{blake3}"));
+            }
+        }
+        parts.join(" ")
+    }
+
+    /// Write the capture into a manifest's claim: the `command` recipe, the derived
+    /// `inputs[]`/`outputs[]`, the discrete params (mechanical flag->key projection),
+    /// and the inferred `mode`. Call before `finalize()`. Measurement fields are the
+    /// caller's responsibility (recorded separately, relocated by `finalize`).
+    pub fn record_into(self, m: &mut RunManifest) {
+        m.params.insert("command".to_string(), self.render_command());
+        for t in &self.tokens {
+            match t {
+                Token::Opt(f, v) => { m.params.insert(flag_to_key(f), v.clone()); }
+                Token::Flag(f) => { m.params.insert(flag_to_key(f), "true".to_string()); }
+                _ => {}
+            }
+        }
+        let has = |want: &str| self.tokens.iter().any(|t| matches!(t, Token::Input { flag, .. } if flag == want));
+        if has("--index") {
+            m.params.insert("mode".to_string(), "index".to_string());
+        } else if has("--reference") {
+            m.params.insert("mode".to_string(), "reference".to_string());
+        }
+        m.inputs = self.inputs;
+        m.outputs = self.outputs;
+    }
+
+    /// Reconstruct an argv from a recorded `command`: substitute each `@in:<h>` with the
+    /// located input path and each `@out:<h>` with a caller-supplied temp path. Errors
+    /// (naming the hash) if an input cannot be located.
+    pub fn argv_from_command(
+        command: &str,
+        locate_input: &dyn Fn(&str) -> Option<String>,
+        temp_output: &dyn Fn(&str) -> String,
+    ) -> Result<Vec<String>, String> {
+        let mut argv = Vec::new();
+        for tok in command.split(' ') {
+            if let Some(h) = tok.strip_prefix("@in:") {
+                match locate_input(h) {
+                    Some(p) => argv.push(p),
+                    None => return Err(format!("input not located by content hash @in:{h}")),
+                }
+            } else if let Some(h) = tok.strip_prefix("@out:") {
+                argv.push(temp_output(h));
+            } else {
+                argv.push(tok.to_string());
+            }
+        }
+        Ok(argv)
+    }
+}
+
+/// Mechanical `--max-depth` -> `max_depth` projection (strip leading dashes,
+/// dashes -> underscores). Deterministic; no per-flag config.
+fn flag_to_key(flag: &str) -> String {
+    flag.trim_start_matches('-').replace('-', "_")
+}
+```
+
+Declare the module in `src/provenance/mod.rs` (near the top, after the existing items):
+
+```rust
+mod command;
+pub use command::CommandCapture;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rosalind --lib provenance::command 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/provenance/command.rs src/provenance/mod.rs
+git commit -m "feat(provenance): CommandCapture — the normalized capture/replay chokepoint"
+```
+
+---
+
+### Task 2: Schema 4→5 + wire `CommandCapture` into the four receipt sites
+
+**Files:**
+- Modify: `src/provenance/mod.rs:31` (`MANIFEST_SCHEMA_VERSION`)
+- Modify: `src/main.rs` — `run_variants_index` (~2233-2305), `run_variants` (~1599-1623), `run_features` (~1852-1923), `run_somatic` (~1229-1250)
+- Test: `tests/variants_index.rs` (add a receipt-shape assertion) + the existing provenance unit tests
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/variants_index.rs` (it already exercises `variants --index`; mirror its setup — reuse the existing helper that builds an index + sorted BAM and runs the binary, then read the manifest):
+
+```rust
+#[test]
+fn variants_index_receipt_records_a_replayable_command() {
+    // (reuse this file's existing fixture: build index + sorted bam, run `variants --index`
+    //  with -o <vcf> and --gvcf omitted; `man` = parsed RunManifest of <vcf>.manifest.json)
+    let man = run_variants_index_and_read_manifest(/* gvcf = */ false);
+    let command = man.params.get("command").expect("schema-5 receipt records `command`");
+    assert!(command.starts_with("variants --index @in:"), "got: {command}");
+    assert!(command.contains("-o @out:"), "command records the output operand: {command}");
+    assert_eq!(man.params.get("mode").map(String::as_str), Some("index"));
+    assert_eq!(man.params.get("gvcf"), None); // false flag omitted
+    assert_eq!(man.params.get("schema_version").map(String::as_str), Some("5"));
+}
+```
+
+If `run_variants_index_and_read_manifest` does not already exist in the test file, add a small helper there that runs the binary (via `env!("CARGO_BIN_EXE_rosalind")`, the pattern this file already uses) with `--gvcf` controlled by the arg and returns `RunManifest::from_canonical_json(&fs::read_to_string(manifest_path))`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rosalind --test variants_index records_a_replayable_command 2>&1 | tail -20`
+Expected: FAIL — no `command` param (and `schema_version` is `4`).
+
+- [ ] **Step 3a: Bump the schema version**
+
+`src/provenance/mod.rs:31`:
+
+```rust
+pub const MANIFEST_SCHEMA_VERSION: u32 = 5;
+```
+
+(No change to `claim_file_render`: content-only rendering already applies at schema ≥ 3, so schema-5 inherits it. `verify`/`from_canonical_json` are schema-agnostic and keep parsing ≤ 4 receipts — back-compat is preserved.)
+
+- [ ] **Step 3b: Migrate `run_variants_index` (the flagship)**
+
+Replace the inputs/outputs pushes and the *claim* `params.insert` calls (the block at ~main.rs:2234-2263 covering `index`/`alignments`/`output` and `mapq_threshold`/`min_qual`/`max_depth`/`max_read_len`/`enforced`) with the builder. **Keep** every measurement insert (`peak_rss_bytes`, `predicted_peak_rss_bytes`, `max_working_set_bytes`, `governor`, `baseline_rss_bytes`, `rss_residual_bytes`, `io_rss_overhead_assumed_bytes`, `over_max_depth`, `reads_skipped_total`, `memory_budget_mb`, `contract_verdict`) and the `finalize()` + `std::fs::write` exactly as they are:
+
+```rust
+let mut manifest = RunManifest::new("variants");
+let mut cmd = CommandCapture::new("variants");
+cmd.input("--index", &index_path)?;
+cmd.input("--alignments", &alignments_path)?;
+cmd.opt("--mapq-threshold", mapq_threshold);
+cmd.opt("--min-qual", quality_threshold as f64);
+cmd.opt("--max-depth", max_depth);
+cmd.opt("--max-read-len", max_read_len);
+cmd.flag_if(enforce, "--enforce");
+cmd.flag_if(gvcf, "--gvcf");
+if let Some(mb) = memory_budget_mb {
+    cmd.opt("--memory-budget-mb", mb);
+}
+if let Some(path) = &output {
+    cmd.output("-o", path)?;
+}
+cmd.record_into(&mut manifest);
+// ---- measurement inserts unchanged below this line (peak_rss_bytes, ... contract_verdict) ----
+```
+
+Add `CommandCapture` to the `use rosalind::provenance::{...}` import in this function. **Note:** the discrete key for `--enforce` is now `enforce` (was `enforced`); for `--min-qual` it is `min_qual` (matches the existing key). Grep the repo for any reader/test of the literal `"enforced"` and update to `"enforce"` (`rg '"enforced"' src tests`).
+
+- [ ] **Step 3c: Migrate the other three sites the same way**
+
+For each, replace the claim `params.insert`/`inputs.push`/`outputs.push` calls with a `CommandCapture` matching that subcommand's CLI flags; leave measurement inserts + `finalize()` + `write_manifest`/`fs::write` untouched.
+
+`run_variants` (reference path, ~1599-1623), subcommand `"variants"`:
+```rust
+let mut cmd = CommandCapture::new("variants");
+cmd.input("--reference", &reference_path)?;       // the FASTA path this fn opened
+cmd.input("--alignments", &alignments_path)?;
+cmd.opt("--chrom", &chrom_name);                  // now recorded (was the gap)
+cmd.opt("--region-start", region_start);
+cmd.opt("--mapq-threshold", mapq_threshold);
+cmd.opt("--min-qual", quality_threshold as f64);
+if let Some(path) = &output { cmd.output("-o", path)?; }
+cmd.record_into(&mut manifest);
+```
+
+`run_features` (~1852-1923), subcommand `"features"`:
+```rust
+let mut cmd = CommandCapture::new("features");
+cmd.input("--index", &index_path)?;
+cmd.input("--alignments", &alignments_path)?;
+cmd.opt("--mapq-threshold", mapq_threshold);
+cmd.opt("--max-depth", max_depth);
+cmd.opt("--max-read-len", max_read_len);
+cmd.flag_if(enforce, "--enforce");
+if let Some(mb) = memory_budget_mb { cmd.opt("--memory-budget-mb", mb); }
+if let Some(path) = &output { cmd.output("-o", path)?; }
+cmd.record_into(&mut manifest);
+```
+
+`run_somatic` (~1229-1250), subcommand `"somatic"` (region-bounded; reproduce treats it as a non-text/unsupported path in v1 — capture is still recorded for provenance):
+```rust
+let mut cmd = CommandCapture::new("somatic");
+cmd.input("--reference", &reference_path)?;
+cmd.input("--tumor", &tumor_path)?;               // use the resolved single-file inputs this fn holds
+cmd.input("--normal", &normal_path)?;
+cmd.output("-o", &output_vcf)?;
+cmd.record_into(&mut manifest);
+```
+(If somatic holds paired-FASTQ inputs rather than single files, record each with its own flag — `--tumor-r1`, etc. Match whatever paths the function already hashed into `inputs[]`.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p rosalind --test variants_index 2>&1 | tail -20` then `cargo test -p rosalind --lib provenance 2>&1 | tail -20`
+Expected: the new test PASSES; existing provenance tests pass (update any that asserted `schema_version == "4"` or the literal `"enforced"` key — these are legitimate schema-5 refreshes, noted in the commit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/provenance/mod.rs src/main.rs tests/variants_index.rs
+git commit -m "feat(provenance): schema 5 — record a replayable command at every receipt site (closes the arg-recording gap)"
+```
+
+---
+
+### Task 3: Extract `verify_receipt` into the library (anti-drift)
+
+**Files:**
+- Modify: `src/provenance/mod.rs` (add `VerifyReport` + `verify_receipt`)
+- Modify: `src/main.rs:890-1060` (`run_verify` becomes a thin shell)
+- Modify: `src/lib.rs` (re-export)
+- Test: `src/provenance/mod.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the provenance test module:
+
+```rust
+#[test]
+fn verify_receipt_reports_a_tampered_claim() {
+    let mut m = RunManifest::new("variants");
+    m.inputs.push(FileHash { path: "a".into(), blake3: "aa".into() });
+    m.finalize();
+    let mut text = m.to_canonical_json();
+    // flip a byte of a recorded input digest without re-sealing -> self-hash must catch it
+    text = text.replace("\"aa\"", "\"ab\"");
+    let report = verify_receipt(&text, &VerifyOpts::default());
+    assert!(!report.ok, "tampered claim must not verify");
+    assert!(report.problems.iter().any(|p| p.contains("manifest_blake3")), "{:?}", report.problems);
+}
+
+#[test]
+fn verify_receipt_passes_a_clean_receipt() {
+    let mut m = RunManifest::new("variants");
+    m.finalize();
+    let report = verify_receipt(&m.to_canonical_json(), &VerifyOpts::default());
+    assert!(report.ok, "{:?}", report.problems);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rosalind --lib provenance::tests::verify_receipt 2>&1 | tail -20`
+Expected: FAIL — `verify_receipt` / `VerifyReport` / `VerifyOpts` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/provenance/mod.rs`, add (this is the file-rehashing-free core; file existence checks stay in the CLI shell so the library core is pure over the receipt text + an optional `budget_mb`/`expect_code`):
+
+```rust
+/// Inputs to `verify_receipt` beyond the receipt text itself.
+#[derive(Default)]
+pub struct VerifyOpts {
+    pub budget_mb: Option<u64>,
+    pub expect_code: Option<String>,
+    /// When set, re-hash files at recorded paths and check digests (the CLI sets this;
+    /// callers verifying receipt-internal integrity only can leave it false).
+    pub rehash_files: bool,
+}
+
+/// The outcome of checking a receipt: a list of problems (empty == ok) and the parsed
+/// manifest for callers that want it.
+pub struct VerifyReport {
+    pub ok: bool,
+    pub problems: Vec<String>,
+    pub manifest: Option<RunManifest>,
+}
+
+/// Check a receipt's internal integrity (self-hashes, cross-field consistency, optional
+/// budget + expected-code), and — when `opts.rehash_files` — re-hash recorded files.
+/// The single source of truth shared by `verify` and `reproduce` (and a future wasm
+/// verifier) so they cannot drift.
+pub fn verify_receipt(text: &str, opts: &VerifyOpts) -> VerifyReport {
+    let manifest = match RunManifest::from_canonical_json(text) {
+        Ok(m) => m,
+        Err(e) => return VerifyReport { ok: false, problems: vec![format!("parse error: {e}")], manifest: None },
+    };
+    let mut problems: Vec<String> = Vec::new();
+
+    if opts.rehash_files {
+        for (kind, files) in [("input", &manifest.inputs), ("output", &manifest.outputs)] {
+            for f in files {
+                match blake3_file(std::path::Path::new(&f.path)) {
+                    Ok(h) if h == f.blake3 => {}
+                    Ok(h) => problems.push(format!("{kind} {} hash mismatch: recorded {}, now {}", f.path, f.blake3, h)),
+                    Err(e) => problems.push(format!("{kind} {} unreadable: {e}", f.path)),
+                }
+            }
+        }
+    }
+
+    // (Move the existing numeric-parse + budget + internal-consistency + self_hash_ok +
+    //  measurement_hash_ok + claims_measurements + expect_code logic from run_verify here
+    //  verbatim, pushing into `problems` instead of printing. Keep the println! notes as
+    //  pushes into a separate `notes` vec or drop them — the CLI shell re-prints.)
+
+    VerifyReport { ok: problems.is_empty(), problems, manifest: Some(manifest) }
+}
+```
+
+Then rewrite `run_verify` (main.rs) as a thin shell: read the file, call `verify_receipt(&text, &VerifyOpts { budget_mb, expect_code, rehash_files: true })`, print each problem to stderr, and `std::process::exit(5)` if `!report.ok` (preserving today's exact exit code + the "verify: OK …" success line).
+
+Re-export in `src/lib.rs`:
+```rust
+pub use provenance::{verify_receipt, VerifyOpts, VerifyReport};
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rosalind --lib provenance 2>&1 | tail -20` then `cargo test -p rosalind --test plan_enforce 2>&1 | tail -20`
+Expected: PASS (the `plan_enforce` suite exercises `verify` end-to-end; its exit-5 behavior must be unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/provenance/mod.rs src/main.rs src/lib.rs
+git commit -m "refactor(verify): extract verify_receipt into the library (shared by verify + reproduce)"
+```
+
+---
+
+## Part 2 — `reproduce`, the certificate, the badge, CI
+
+### Task 4: The `reproduce` driver (text outputs)
+
+**Files:**
+- Create: `src/reproduce.rs`
+- Modify: `src/lib.rs` (`pub mod reproduce;` + re-exports), `src/main.rs` (`Reproduce` clap variant + dispatch + `run_reproduce`)
+- Test: `src/reproduce.rs` `#[cfg(test)]` (pure classification) + `tests/reproduce.rs` (end-to-end)
+
+- [ ] **Step 1: Write the failing test (pure classification + argv)**
+
+In `src/reproduce.rs` (file starts as the test module; impl added Step 3):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::FileHash;
+
+    fn fh(role_hash: &str) -> FileHash { FileHash { path: "x".into(), blake3: role_hash.into() } }
+
+    #[test]
+    fn classify_reproduced_when_all_outputs_match() {
+        let recorded = vec![fh("h1")];
+        let produced = vec![("o0".to_string(), "h1".to_string())];
+        let v = classify_outputs(&recorded, &produced);
+        assert!(matches!(v.verdict, Verdict::Reproduced));
+    }
+
+    #[test]
+    fn classify_diverged_names_the_first_mismatch() {
+        let recorded = vec![fh("h1")];
+        let produced = vec![("o0".to_string(), "DIFFERENT".to_string())];
+        let v = classify_outputs(&recorded, &produced);
+        assert!(matches!(v.verdict, Verdict::Diverged));
+        assert!(v.diffs.iter().any(|d| d.contains("h1") && d.contains("DIFFERENT")));
+    }
+
+    #[test]
+    fn exit_codes_are_stable() {
+        assert_eq!(Verdict::Reproduced.exit_code(), 0);
+        assert_eq!(Verdict::Diverged.exit_code(), 6);
+        assert_eq!(Verdict::Inconclusive.exit_code(), 7);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rosalind --lib reproduce 2>&1 | tail -20`
+Expected: FAIL — module/types not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/reproduce.rs` (above the test module). The driver is split into pure, testable pieces (`classify_outputs`) and an IO orchestrator (`reproduce`):
+
+```rust
+//! `reproduce` — re-derive a recorded result and compare it byte-for-byte. Standalone:
+//! filesystem + blake3 + subprocess only (no htslib). Verdict is over OUTPUT bytes;
+//! code/inputs/resource are diagnostic context.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::provenance::{blake3_file, CommandCapture, RunManifest, FileHash};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict { Reproduced, Diverged, Inconclusive }
+
+impl Verdict {
+    pub fn exit_code(self) -> i32 {
+        match self { Verdict::Reproduced => 0, Verdict::Diverged => 6, Verdict::Inconclusive => 7 }
+    }
+    pub fn label(self) -> &'static str {
+        match self { Verdict::Reproduced => "REPRODUCED", Verdict::Diverged => "DIVERGED", Verdict::Inconclusive => "INCONCLUSIVE" }
+    }
+}
+
+pub struct Outcome { pub verdict: Verdict, pub diffs: Vec<String> }
+
+/// Pure: compare produced (role, hash) pairs against the recorded outputs. REPRODUCED iff
+/// every recorded output has a produced match; DIVERGED otherwise, naming each mismatch.
+pub fn classify_outputs(recorded: &[FileHash], produced: &[(String, String)]) -> Outcome {
+    let mut diffs = Vec::new();
+    for (i, rec) in recorded.iter().enumerate() {
+        match produced.get(i) {
+            Some((_, got)) if *got == rec.blake3 => {}
+            Some((role, got)) => diffs.push(format!("output {role}: recorded {} got {got}", rec.blake3)),
+            None => diffs.push(format!("output {i}: recorded {} but not produced", rec.blake3)),
+        }
+    }
+    let verdict = if diffs.is_empty() { Verdict::Reproduced } else { Verdict::Diverged };
+    Outcome { verdict, diffs }
+}
+
+/// Output types reproduce can byte-compare in v1. BAM/bgzf is out of scope (a C zlib not
+/// captured by deps_lock); reproduce reports those INCONCLUSIVE rather than false-DIVERGED.
+fn output_is_text(path: &str) -> bool {
+    let p = path.to_ascii_lowercase();
+    p.ends_with(".vcf") || p.ends_with(".tsv") || p.ends_with(".txt")
+}
+
+/// Build a content-hash -> path index of every file directly under `inputs_dir`.
+fn index_inputs(inputs_dir: &Path) -> std::io::Result<BTreeMap<String, PathBuf>> {
+    let mut idx = BTreeMap::new();
+    for entry in std::fs::read_dir(inputs_dir)? {
+        let p = entry?.path();
+        if p.is_file() {
+            if let Ok(h) = blake3_file(&p) { idx.entry(h).or_insert(p); }
+        }
+    }
+    Ok(idx)
+}
+```
+
+Then the orchestrator `pub fn reproduce(manifest_path, inputs_dir) -> anyhow::Result<ReproOutcome>` that: reads the receipt text; calls `verify_receipt(&text, &VerifyOpts::default())` and returns `Inconclusive`/exit-5-mapping on a tampered/malformed receipt; reads `params["command"]` (absent → `Inconclusive`, "pre-schema-5 receipt: no recorded command"); checks every recorded output `output_is_text` (else `Inconclusive`, "BAM/bgzf not byte-comparable in v1"); builds the input index; binds `@in:` via the index (missing → `Inconclusive`, naming the hash) and `@out:` to temp paths in a `tempdir`; re-execs `std::env::current_exe()?` with `CommandCapture::argv_from_command(...)`; on a non-zero child exit returns `Inconclusive` with the child's stderr; hashes the produced temp outputs (`blake3_file`) into `(role, hash)` pairs; calls `classify_outputs`; reads the child's temp `<out>.manifest.json` for `peak_rss_bytes`/`memory_budget_mb` to build the machine-local resource line; compares the receipt's `code_git_sha` to the current build (re-derive via the same `build.rs` constants the binary exposes) for the code line. Return a struct carrying the verdict, the diffs, the resource line, the code line, and the parsed parent manifest (Task 5 mints the certificate from it).
+
+(`ReproOutcome` fields: `verdict: Verdict`, `outcome: Outcome`, `resource_line: String`, `code_line: String`, `parent: RunManifest`, `parent_claim: String` = `parent.content_hash()`.)
+
+- [ ] **Step 4: Add the CLI verb + dispatch + run_reproduce**
+
+`src/main.rs` — add to `enum Commands`:
+```rust
+/// Re-derive a recorded result from its receipt and content-located inputs, and
+/// write a chainable reproduction certificate. Verdict is over output bytes.
+Reproduce {
+    /// Path to a `*.manifest.json` from a previous run.
+    #[arg(long)]
+    manifest: PathBuf,
+    /// Directory holding the recorded inputs (located by content hash).
+    #[arg(long)]
+    inputs: PathBuf,
+    /// Do not write a `.repro.json` certificate.
+    #[arg(long, default_value_t = false)]
+    no_attest: bool,
+    /// Where to write the certificate (default: `<manifest>.repro.json`).
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+},
+```
+Dispatch arm:
+```rust
+Commands::Reproduce { manifest, inputs, no_attest, output } =>
+    run_reproduce(manifest, inputs, no_attest, output)?,
+```
+`run_reproduce` calls `rosalind::reproduce::reproduce(...)`, prints the aligned verdict block (matching the spec's mock), writes the certificate unless `no_attest` (Task 5), and `std::process::exit(outcome.verdict.exit_code())` when non-zero (exit 0 returns `Ok(())`).
+
+Re-export in `src/lib.rs`: `pub mod reproduce;`
+
+- [ ] **Step 5: Write the end-to-end test**
+
+`tests/reproduce.rs`:
+```rust
+// Reuses the index+sorted-BAM fixture pattern from tests/variants_index.rs and runs the
+// real binary via env!("CARGO_BIN_EXE_rosalind").
+#[test]
+fn reproduces_a_variants_index_vcf_byte_for_byte() {
+    // 1. build index + sorted bam under a temp `data/` dir
+    // 2. run: variants --index <idx> --alignments <bam> -o <vcf>  (writes <vcf>.manifest.json)
+    // 3. run: reproduce --manifest <vcf>.manifest.json --inputs <data/>
+    // assert: exit 0, stdout contains "REPRODUCED", and <vcf>.manifest.json.repro.json exists
+}
+
+#[test]
+fn inconclusive_when_an_input_is_missing() {
+    // run reproduce with --inputs pointing at an EMPTY dir -> exit 7, "INCONCLUSIVE", names a hash
+}
+
+#[test]
+fn inconclusive_on_a_pre_schema_5_receipt() {
+    // hand-write a minimal schema-4 receipt (no `command`) -> reproduce exits 7 with a clear message
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p rosalind --lib reproduce 2>&1 | tail -20` then `cargo test -p rosalind --test reproduce 2>&1 | tail -30`
+Expected: PASS (note: the `.repro.json` assertion in test 1 depends on Task 5; until then, assert only exit 0 + "REPRODUCED" and add the certificate assertion in Task 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/reproduce.rs src/main.rs src/lib.rs tests/reproduce.rs
+git commit -m "feat(reproduce): byte re-derivation verb — REPRODUCED/DIVERGED/INCONCLUSIVE (exit 0/6/7), text outputs"
+```
+
+---
+
+### Task 5: The reproduction certificate (`.repro.json`)
+
+**Files:**
+- Create: `src/provenance/repro.rs`
+- Modify: `src/provenance/mod.rs` (`mod repro; pub use repro::ReproReceipt;`), `src/reproduce.rs` (mint + write), `src/lib.rs`
+- Test: `src/provenance/repro.rs` `#[cfg(test)]` + extend `tests/reproduce.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn certificate_self_hashes_and_roundtrips() {
+        let mut r = ReproReceipt::new("a1b2", "variants", "REPRODUCED");
+        r.outputs.push(ReproOutput { role: "-o".into(), recorded_blake3: "h".into(), observed_blake3: "h".into(), matched: true });
+        r.chain_depth = 1;
+        let json = r.to_canonical_json(); // stamps repro_blake3 last
+        let back = ReproReceipt::from_canonical_json(&json).unwrap();
+        assert_eq!(back.parent_claim, "a1b2");
+        assert_eq!(back.chain_depth, 1);
+        assert!(back.self_hash_ok());
+    }
+
+    #[test]
+    fn tamper_breaks_the_self_hash() {
+        let r = ReproReceipt::new("a1b2", "variants", "REPRODUCED");
+        let json = r.to_canonical_json().replace("a1b2", "ffff");
+        let back = ReproReceipt::from_canonical_json(&json).unwrap();
+        assert!(!back.self_hash_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rosalind --lib provenance::repro 2>&1 | tail -20`
+Expected: FAIL — types not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/provenance/repro.rs` — a small content-addressed type mirroring `RunManifest`'s canonical-JSON + self-hash discipline (sorted keys, no timestamps, `repro_blake3` stamped last over the rest), with a hand-parser like `from_canonical_json`. Reuse `blake3_hex`. Fields per the spec §8: `schema_version`, `parent_claim`, `parent_subcommand`, `verdict`, `outputs: Vec<ReproOutput>`, `reproducer_code` (git_sha/dirty/rustc/target_triple/deps_lock — read the same `build.rs` constants the binary already bakes), `resource_here` (peak_rss_bytes/declared_budget_mb/fit), `chain_depth`, `repro_blake3`. Provide `new`, `to_canonical_json` (stamps the self-hash), `from_canonical_json`, `self_hash_ok`.
+
+- [ ] **Step 4: Mint + write in `reproduce`**
+
+In `src/reproduce.rs`, after classifying: build a `ReproReceipt` from the parent (`parent_claim = parent.content_hash()`, `parent_subcommand = parent.subcommand`, `verdict`, `outputs`, `resource_here`, `reproducer_code`). For `chain_depth`: if the input `--manifest` parses as a `ReproReceipt`, set `chain_depth = parent.chain_depth + 1`; else `1`. `run_reproduce` writes it unless `--no-attest`: default path `<manifest>.repro.json` (Decision 1), or `-o`.
+
+Extend `tests/reproduce.rs` test 1: assert `<vcf>.manifest.json.repro.json` exists, parses as a `ReproReceipt`, `self_hash_ok()`, `verdict == "REPRODUCED"`, and `parent_claim == <original receipt>.content_hash()`. Add a chaining test: `reproduce` the `.repro.json` itself → a new certificate with `chain_depth == 2`.
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `cargo test -p rosalind reproduce 2>&1 | tail -30` and `cargo test -p rosalind --lib provenance::repro 2>&1 | tail -20`
+Expected: PASS.
+```bash
+git add src/provenance/repro.rs src/provenance/mod.rs src/reproduce.rs src/lib.rs tests/reproduce.rs
+git commit -m "feat(reproduce): chainable, self-hashing .repro.json reproduction certificate"
+```
+
+---
+
+### Task 6: `rosalind badge` — self-hosted shields-endpoint JSON + static SVG
+
+**Files:**
+- Create: `src/provenance/badge.rs`
+- Modify: `src/provenance/mod.rs`, `src/main.rs` (`Badge` variant + dispatch + `run_badge`), `src/lib.rs`
+- Test: `src/provenance/badge.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn badge_json_is_shields_endpoint_shaped() {
+        let j = badge_json(true, Some(256));
+        assert!(j.contains("\"schemaVersion\":1"));
+        assert!(j.contains("\"label\":\"rosalind\""));
+        assert!(j.contains("reproducible"));
+        assert!(j.contains("256 MiB"));
+        assert!(j.contains("\"color\":\"brightgreen\""));
+    }
+
+    #[test]
+    fn badge_json_red_when_not_reproducible() {
+        let j = badge_json(false, None);
+        assert!(j.contains("\"color\":\"red\""));
+        assert!(j.contains("not reproducible"));
+    }
+
+    #[test]
+    fn badge_svg_is_well_formed() {
+        let s = badge_svg(true, Some(256));
+        assert!(s.starts_with("<svg") && s.trim_end().ends_with("</svg>"));
+        assert!(s.contains("reproducible"));
+    }
+}
+```
+
+- [ ] **Step 2: Run → fail.** `cargo test -p rosalind --lib provenance::badge 2>&1 | tail -20` → not found.
+
+- [ ] **Step 3: Implement** `badge_json(reproducible: bool, fits_mb: Option<u64>) -> String` (a hand-built shields.io endpoint object: `schemaVersion`, `label`, `message` e.g. `"reproducible · fits 256 MiB"`, `color`) and `badge_svg(...) -> String` (a minimal static two-segment SVG, no external fetch). Add `Badge { manifest: PathBuf, repro: Option<PathBuf>, output: PathBuf }` to `Commands` + `run_badge` that parses the receipt (and optional `.repro.json`), derives `reproducible` (from the repro verdict if given, else "fits-only") and `fits_mb` (from `memory_budget_mb` vs `peak_rss_bytes`), and writes `.json`/`.svg` by `output` extension.
+
+- [ ] **Step 4: Run → pass.** `cargo test -p rosalind --lib provenance::badge 2>&1 | tail -20`
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/provenance/badge.rs src/provenance/mod.rs src/main.rs src/lib.rs
+git commit -m "feat(badge): self-hosted shields-endpoint JSON + static SVG (no shields.io dependency)"
+```
+
+---
+
+### Task 7: CI fence + golden chain + docs
+
+**Files:**
+- Create: `tests/golden/reproduce/` (a tiny reference + sorted BAM + the receipt + expected VCF)
+- Create: `.github/workflows/reproduce.yml`
+- Create: `tests/reproduce_golden.rs`
+- Modify: `CHANGELOG.md`, `README.md`
+
+- [ ] **Step 1: Generate + commit the golden chain**
+
+Use the bundled toy data path (`examples/data/illumina_toy`) or `scripts/generate_toy_data.py` to produce a tiny deterministic reference + sorted BAM, run `variants --index -o golden.vcf`, and commit `tests/golden/reproduce/{ref.fa, sorted.bam, golden.vcf, golden.vcf.manifest.json}`. (Keep it small — this is a fixture, not a benchmark.)
+
+- [ ] **Step 2: Write the failing golden test**
+
+`tests/reproduce_golden.rs`:
+```rust
+#[test]
+fn golden_chain_reproduces_byte_for_byte() {
+    // run: reproduce --manifest tests/golden/reproduce/golden.vcf.manifest.json
+    //               --inputs tests/golden/reproduce/
+    // assert: exit 0, stdout "REPRODUCED"
+}
+
+#[test]
+fn one_byte_flip_diverges() {
+    // copy the golden inputs to a temp dir, flip one byte of the BAM, run reproduce
+    // -> the input hash no longer matches -> INCONCLUSIVE (exit 7), NOT a false DIVERGED.
+    // To exercise true DIVERGED, assert classify_outputs on a mismatch (unit, Task 4) —
+    // a same-binary same-input run cannot non-deterministically diverge by design.
+}
+```
+(Document honestly in a comment: DIVERGED is unit-tested via `classify_outputs`; the integration negative is INCONCLUSIVE-on-tamper, because byte-identical determinism means the only way to make the *same* binary produce different bytes from the *same* inputs is to change the binary — which `reproduce` surfaces as the code line.)
+
+- [ ] **Step 3: Run → fail, then pass** once the fixture + verb exist.
+Run: `cargo test -p rosalind --test reproduce_golden 2>&1 | tail -20`
+
+- [ ] **Step 4: The CI workflow**
+
+`.github/workflows/reproduce.yml`: on push/PR, build `--release`, run `cargo test --test reproduce_golden`, then run the binary directly to prove cross-machine reproduction on the runner:
+```yaml
+name: reproduce
+on: [push, pull_request]
+jobs:
+  reproduce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release
+      - name: Reproduce the golden chain on a different machine
+        run: |
+          ./target/release/rosalind reproduce \
+            --manifest tests/golden/reproduce/golden.vcf.manifest.json \
+            --inputs tests/golden/reproduce/
+      - name: Emit the badge
+        run: |
+          ./target/release/rosalind badge \
+            --manifest tests/golden/reproduce/golden.vcf.manifest.json \
+            -o badge.json
+      - uses: actions/upload-artifact@v4
+        with: { name: rosalind-repro-badge, path: badge.json }
+```
+
+- [ ] **Step 5: Docs**
+
+`CHANGELOG.md` `[Unreleased]`: add a "Reproducibility" bullet group (the `reproduce` verb, the chainable `.repro.json` certificate, the `badge` verb, schema 5's recorded command, the CI fence). `README.md`: add a short "Reproduce a result (a stranger can run it)" section with the one-command demo and the honest scope (text outputs; tamper-evident not tamper-proof). Keep copy honest — no "tamper-proof", verdict is over output bytes, resource line is "(here: this machine)".
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `cargo fmt --all -- --check && cargo build --release 2>&1 | tail -5 && cargo test 2>&1 | tail -30`
+Expected: 0 warnings; full suite green.
+```bash
+git add tests/golden/reproduce .github/workflows/reproduce.yml tests/reproduce_golden.rs CHANGELOG.md README.md
+git commit -m "test(ci): cross-machine reproduce fence + golden chain; docs for reproduce/certificate/badge"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** schema-5 normalized capture → Task 1+2; `reproduce` engine + verdict + exit codes + forensic diff + honesty scope → Task 4; reproduction certificate + chaining + default sidecar → Task 5; `verify_receipt` anti-drift extraction → Task 3; CI fence + self-hosted badge → Task 6+7; all 10 spec acceptance gates map to a task's tests (gate 1→T1; 2→T1/T2; 3→T4/T5; 4→T4 unit; 5→T4; 6→T2/T4; 7→T4; 8→T5; 9→T7; 10→T7 final). Resolved decisions (sidecar default, exit codes 0/6/7/5) are in T4/T5.
+
+**Placeholder scan:** the migration steps for the three non-flagship receipt sites (T2 Step 3c) give exact `CommandCapture` call sequences; the `reproduce` orchestrator (T4 Step 3) and the `repro`/`badge` impls (T5/T6 Step 3) describe the exact functions/fields with the test contracts pinning their shapes — no "TBD". The one deliberate "reuse the existing fixture helper" references (T2/T4/T7) point at the concrete pattern already in `tests/variants_index.rs` (`env!("CARGO_BIN_EXE_rosalind")`).
+
+**Type consistency:** `CommandCapture` methods (`new/input/output/input_hashed/output_hashed/opt/flag/flag_if/record_into/argv_from_command`) are identical across T1 and their uses in T2/T4. `Verdict`/`Outcome`/`classify_outputs` consistent across T4. `ReproReceipt`/`ReproOutput`/`to_canonical_json`/`from_canonical_json`/`self_hash_ok` consistent across T5 and its uses. `verify_receipt`/`VerifyOpts`/`VerifyReport` consistent across T3/T4. Exit codes `0/6/7` (reproduce) and `5` (verify, reused) consistent. Schema version `5` consistent (T2 + T4 back-compat).
+
+**Known schema-shape changes (intentional, schema-5):** the discrete `enforced` key becomes `enforce`; `gvcf`/`chrom`/`mode`/`command` are added; `schema_version` is `5`. Any golden manifest fixture or unit test pinning the old shape is refreshed under T2 (committed as a documented schema bump); `from_canonical_json`/`verify` keep reading ≤4 receipts (back-compat preserved, tested in T4).

--- a/docs/superpowers/specs/2026-06-05-track-d-reproduce-certificate-design.md
+++ b/docs/superpowers/specs/2026-06-05-track-d-reproduce-certificate-design.md
@@ -1,0 +1,262 @@
+# Track D — `rosalind reproduce` + the reproduction certificate (design)
+
+**Status:** Approved design — 2026-06-05. Author: Logan Nye. Companion to
+[`docs/ROADMAP.md`](../../ROADMAP.md) (P3.2 + the reproducibility CI badge) and
+[`CONTRACT.md`](../../../CONTRACT.md). Implements the standalone-roadmap critical-path track
+(`project_rosalind_roadmap`): third-party byte re-derivation from a receipt, plus a
+reproducibility/resource CI fence + self-hosted badge.
+
+This is a **standalone** feature — no dependency on any other repository. It builds only on
+Rosalind's already-shipped determinism + content-addressed receipt.
+
+---
+
+## 1. Goal
+
+Make **"reproduce this exact result"** a command a stranger can run — and turn each successful
+reproduction into a **portable, content-addressed certificate that chains to the original**, so
+independent reproductions accumulate into a decentralized "reproducibility web" with no server.
+
+The flagship demo this unlocks: a stranger takes a real `*.vcf` + its `*.manifest.json`, on a
+*different machine*, runs one offline command, and gets a green **REPRODUCED** (byte-identical) —
+with no GATK, no Docker, no Nextflow, no re-aligning — plus a `.repro.json` certificate that
+countersigns the original claim. Flip one input byte → **DIVERGED**, naming the exact field. No
+incumbent caller can do this (a non-deterministic caller reports DIVERGED on a *correct* run).
+
+## 2. Non-goals (explicit)
+
+- **Not** a correctness/biology claim. `reproduce` attests *re-derivation of output bytes from
+  content-addressed inputs under a recorded code identity* — never that the calls are biologically
+  right. The verdict text and docs say so.
+- **Not** cryptographic authentication (yet). The certificate is tamper-**evident** (self-hashing
+  BLAKE3), **signing-ready** for the later Ed25519 track (P3.3) — not tamper-**proof** today.
+- **Not** BAM/bgzf reproduction in v1 (see §7 honesty scope).
+- **Not** chain-of-artifacts traversal — that is Track C (`verify --chain`). `reproduce` operates
+  on a single receipt; the two compose later but are independent here.
+- **No cross-repo integration** of any kind.
+
+## 3. Background — the current code (verified 2026-06-05)
+
+- `src/provenance/mod.rs`: `RunManifest { tool_version, subcommand, inputs: Vec<FileHash>,
+  params: BTreeMap<String,String>, outputs: Vec<FileHash>, measurements: BTreeMap<String,String> }`.
+  `params` is the deterministic **claim**; `measurements` is machine-dependent and excluded from
+  the claim hash (`MEASUREMENT_KEYS`, mod.rs:37). `content_hash()` (mod.rs:183) = BLAKE3 of the
+  claim canonical JSON with `manifest_blake3` removed and (schema ≥ 3) paths dropped — a
+  cross-machine content-address. `MANIFEST_SCHEMA_VERSION = 4` (mod.rs:31). `finalize()` (mod.rs:259)
+  partitions measurements out, stamps `measurement_blake3`, `schema_version`, then `manifest_blake3`
+  last. `from_canonical_json` (mod.rs:170) is a hand-parser round-tripping `to_canonical_json`.
+  `write_manifest` (mod.rs:594) writes the sidecar.
+- **The gap (confirmed):** the `subcommand` string is recorded, but the *args needed to replay it*
+  are written ad hoc per call site and several are missing — `gvcf` (main.rs:1977, unrecorded),
+  `chrom` (arg at main.rs:84, omitted in the receipt at ~main.rs:1599-1622), and the
+  index-vs-reference **mode** (only inferable from input file type). A naive replay would run the
+  **wrong** command and report a **false DIVERGED**.
+- Receipt-writing sites are not centralized: `run_somatic` (~main.rs:1229-1250), `run_variants`
+  (reference path, ~1599-1623), `run_features` (~1852-1923), `run_variants_index` (variants + gVCF,
+  ~2233-2305). All call `RunManifest::new(...)` + ad-hoc `params` inserts + `finalize()` +
+  `write_manifest`.
+- `run_verify` (main.rs:890-1060) is the verb template: parse → re-derive → per-check report →
+  exit 5 on drift. It is **not** factored into a reusable library function today.
+- `action.yml` is the shipped composite Action (plan → variants --enforce → upload receipt).
+
+## 4. Components & module layout (each one purpose, testable in isolation)
+
+| New/changed | File | Responsibility |
+|---|---|---|
+| **new** | `src/provenance/command.rs` | `CommandCapture` — the single capture chokepoint: record a normalized, replayable invocation into the claim, and reconstruct an argv from it. |
+| **new** | `src/provenance/repro.rs` | `ReproReceipt` — the reproduction certificate: type, self-hash, chaining, canonical JSON render/parse. |
+| **new** | `src/provenance/badge.rs` | `badge` — emit a self-hosted shields-endpoint JSON + a static SVG. |
+| **new** | `src/reproduce.rs` | the `reproduce` driver (fs + blake3 + process only; no htslib): locate inputs by content hash, re-exec, compare, mint the certificate. |
+| **changed** | `src/provenance/mod.rs` | bump schema 4→5 (version-gated); add `verify_receipt` (extracted, see below); wire `CommandCapture`. |
+| **changed** | `src/main.rs` | adopt `CommandCapture` at all four receipt sites; add `Reproduce` + `Badge` clap variants + thin dispatch; extract `run_verify`'s core into the library `verify_receipt`. |
+| **changed** | `action.yml` (+ a new CI workflow) | the reproduce fence (cross-machine REPRODUCED + one-byte-flip negative) and badge publication. |
+
+**Anti-drift extraction:** lift the receipt-checking core of `run_verify` (main.rs:890-1060) into a
+library `verify_receipt(receipt_text, opts) -> VerifyReport`, consumed by both `verify` and
+`reproduce` (and the future wasm verifier, Track B) so the three cannot diverge. `run_verify`
+becomes a thin CLI shell over it.
+
+## 5. Schema 5 — normalized command capture
+
+A single builder, used at every receipt site, that is the same structure `reproduce` replays — so
+recording and replay cannot drift.
+
+```rust
+// src/provenance/command.rs
+let mut cmd = CommandCapture::new("variants");
+cmd.input("--index", &index_path, &index_blake3);   // content-addressed input operand
+cmd.input("--alignments", &bam_path, &bam_blake3);
+cmd.opt("--mapq-threshold", mapq.to_string());      // defaults resolved explicitly
+cmd.opt("--max-depth", max_depth.to_string());
+cmd.opt("--max-read-len", max_read_len.to_string());
+cmd.opt("--memory-budget-mb", budget.to_string());
+cmd.flag_if(enforce, "--enforce");
+cmd.flag_if(gvcf, "--gvcf");
+cmd.output("-o", &out_path, &out_blake3);           // content-addressed output operand
+cmd.record_into(&mut manifest);                      // the ONE place that writes the claim command
+```
+
+`record_into`:
+1. **Populates `inputs[]` and `outputs[]`** from the `input()`/`output()` calls — so these stop
+   being hand-maintained per site (drift eliminated; one source of truth).
+2. **Writes `params["command"]`** — a deterministic, machine-independent normalized form where
+   input/output operands are replaced by placeholders `@in:<blake3>` / `@out:<blake3>`. Example
+   recorded value:
+   `variants --index @in:<h1> --alignments @in:<h2> --mapq-threshold 20 --max-depth 1000 --max-read-len 250 --memory-budget-mb 256 --enforce -o @out:<h3>`
+   Because operands are content hashes (not paths), `params["command"]` is hash-protected by the
+   existing claim hash (editing the recorded command is caught) and stays a cross-machine
+   content-address.
+3. **Token ordering is normalized** (a fixed canonical order: positional/required flags, then
+   options sorted by flag, then bare flags, then output) so the recorded command is stable
+   run-to-run and the claim hash is meaningful.
+
+**Relationship to discrete params (no drift):** `params["command"]` is the **authoritative replay
+recipe**. To preserve human-readability and the existing back-compat `verify` behavior, the *same*
+builder calls also write discrete claim params via a **mechanical** flag→key mapping (strip `--`,
+dashes→underscores: `--max-depth` → `max_depth`, `--gvcf` → `gvcf`, etc.), so the discrete params
+cannot drift from `command` — they are projections of the same calls, not a second hand-maintained
+list. The index-vs-reference **mode** is captured implicitly by which input flag the recipe carries
+(`--index` vs `--reference`) and surfaced as a discrete `mode` param for readability. Build-identity
+(`code_git_sha`, …) and contract/measurement fields are untouched — still set by `finalize()` /
+`record_measurement()`.
+
+**Reconstruction** (`CommandCapture::to_argv(resolver)`): parse `params["command"]`, substitute
+each `@in:<h>` with the resolver's content-located path and each `@out:<h>` with a caller-provided
+temp path, yielding a `Vec<String>` argv for `current_exe()`. **No per-subcommand logic** lives in
+`reproduce`; new subcommands/flags are captured automatically by using the builder.
+
+**Schema bump 4 → 5**, version-gated exactly like the prior bumps (`claim_file_render` pattern,
+mod.rs:131): schema-5 receipts carry `params["command"]`; schema ≤ 4 receipts have no `command`
+and `reproduce` reports INCONCLUSIVE ("pre-schema-5 receipt: no recorded command to replay") rather
+than guessing. `verify` continues to handle ≤ 4 unchanged.
+
+## 6. `reproduce` — algorithm
+
+`rosalind reproduce --manifest <m> --inputs <dir> [--no-attest] [-o <repro.json>]`
+
+1. **Read + integrity-check** the receipt via `verify_receipt` (self-hash intact? schema known?).
+   Tampered/malformed → exit 5 (reuse verify's code) with the per-check report.
+2. **Schema/command gate:** schema ≥ 5 with a `command` param, and a supported output type
+   (§7). Otherwise → INCONCLUSIVE (exit 7) with the reason.
+3. **Content-locate inputs:** index every file under `--inputs` by BLAKE3 once
+   (`hash → path`); bind each `@in:<h>` placeholder. Any unresolved input → INCONCLUSIVE
+   (exit 7), naming the missing hash (it is "couldn't check," not "the result changed").
+4. **Bind outputs** to fresh temp paths; **re-exec `current_exe()`** with the reconstructed argv
+   (re-running enforces the recorded budget too, so the run's own contract still applies).
+5. **Compare:** BLAKE3 each produced output vs the recorded `outputs[].blake3`.
+6. **Resource-aware context:** read the re-run's realized peak from its temp receipt; report
+   `peak X ≤/> declared Y (here: this machine)` — diagnostic, explicitly machine-local.
+7. **Code context:** compare the current binary's build-identity (`code_git_sha`, `code_dirty`, …)
+   to the receipt's; surface a mismatch prominently. A byte-match under a *different* code SHA is
+   still REPRODUCED (a stronger result), with the difference noted.
+8. **Verdict (on output bytes):** REPRODUCED (all supported outputs byte-identical) → exit 0;
+   DIVERGED (any mismatch) → exit 6, with a **forensic diff** (which output; for text outputs, the
+   first differing line / locus).
+9. **Mint the certificate** (§8) unless `--no-attest`.
+
+Verdicts/exit codes (Decision 2, **resolved**): `0` REPRODUCED · `6` DIVERGED · `7` INCONCLUSIVE
+(couldn't run: pre-schema-5 / input not located / unsupported output) · `5` malformed/tampered
+receipt (reused from `verify`). The 6-vs-7 split lets CI and humans distinguish "the result
+*changed*" from "I *couldn't check*."
+
+## 7. Honesty scope (the brand)
+
+- **v1 covers the deterministic text outputs Rosalind emits: `variants → VCF` and `features → TSV`**
+  — the flagship paths. Byte-equality there is airtight (canonical, deterministic rendering).
+- **BAM/bgzf-producing verbs (`align`, `sort`) are out of scope for v1.** bgzf rests on a C zlib
+  not captured by `deps_lock_blake3`, so `reproduce` reports them as INCONCLUSIVE — "not
+  byte-comparable (bgzf/zlib) in v1" — rather than risking a false DIVERGED. (A future
+  decompressed-content comparison is noted in §11.)
+- The resource line is always labeled `(here: this machine)`; realized peak is machine-dependent.
+- The certificate attests re-derivation, not correctness; its rendered verdict and the docs state
+  this in one sentence.
+
+## 8. The reproduction certificate (`.repro.json`)
+
+A new lightweight, content-addressed type (`src/provenance/repro.rs`) — deliberately **not** a
+`RunManifest`, to keep the boundary clean:
+
+```
+ReproReceipt {
+  schema_version,
+  parent_claim,                 // the original receipt's content_hash() — the cross-machine ID it chains to
+  parent_subcommand,
+  verdict,                      // REPRODUCED | DIVERGED
+  outputs: [ { role, recorded_blake3, observed_blake3, match } ],
+  reproducer_code: { git_sha, dirty, rustc, target_triple, deps_lock_blake3 },  // who/what reproduced
+  resource_here: { peak_rss_bytes, declared_budget_mb, fit },   // machine-local, labeled
+  chain_depth,                  // parent's depth + 1 (1 if the parent is an original run receipt)
+  repro_blake3,                 // self-hash over the canonical form (tamper-evident; Ed25519-signable later)
+}
+```
+
+- **Chaining / the web:** keyed on the parent's `content_hash` (the stable cross-machine ID). N
+  independent reproductions of the same result mint N certificates pointing at one `parent_claim`
+  → "+N independent confirmations," emergent with **no server**. A reproduce-of-a-`.repro.json`
+  reads the parent's `chain_depth` and increments it.
+- **Canonical render + self-hash** mirror `RunManifest`'s discipline (sorted keys, no timestamps,
+  `repro_blake3` stamped last over the rest). A `from_canonical_json` parser round-trips it so a
+  `.repro.json` is itself reproduce-able / chainable.
+- **Write behavior (Decision 1, resolved):** by default write a `<manifest>.repro.json` sidecar
+  next to the input `--manifest` (deterministic, non-cwd location — avoids the C3 "don't pollute a
+  pipe user's cwd" footgun). `--no-attest` skips writing; `-o <path>` redirects.
+
+## 9. CI fence + self-hosted badge
+
+- **Fence (the substance):** a committed golden chain (a small input set + the receipt + the
+  expected VCF) and a CI job that runs `reproduce` on the GitHub runner — a *different machine than
+  the author's* — asserting **REPRODUCED**, plus a negative (a one-byte-flipped input → DIVERGED,
+  exit 6). This is a regression fence on determinism itself.
+- **Badge (cosmetic):** `rosalind badge --manifest <m> [--repro <r>] -o badge.{json,svg}` emits a
+  shields.io-*endpoint-format* JSON **and** a static SVG — **self-hosted, no shields.io runtime
+  dependency** — e.g. `● reproducible · fits 256 MiB`. The Action publishes it (artifact / committed
+  to a badges branch).
+
+## 10. Acceptance gates (spec §-gates; all must pass)
+
+1. **Capture/replay roundtrip:** `CommandCapture` → `params["command"]` → `to_argv` reconstructs
+   the original argv (operands substituted); property-tested over flags/opts/inputs/outputs.
+2. **Single-source inputs/outputs:** `inputs[]`/`outputs[]` produced by `record_into` match the
+   `input()`/`output()` calls; a consistency test asserts no drift between `command` operands and
+   `inputs[]`/`outputs[]`.
+3. **Real reproduce (flagship):** a `variants --index → VCF` run, then `reproduce` against
+   content-located inputs → REPRODUCED, exit 0, and a `.repro.json` that self-hashes and whose
+   `parent_claim == original.content_hash()`.
+4. **Tamper → DIVERGED:** flip one output byte → DIVERGED, exit 6, forensic first-diff locus
+   correct.
+5. **Missing input → INCONCLUSIVE:** exit 7, names the absent hash; not DIVERGED.
+6. **Back-compat:** a schema-4 receipt still `verify`s; `reproduce` on it → INCONCLUSIVE (no
+   `command`), never a panic.
+7. **BAM honesty:** a BAM-output verb → INCONCLUSIVE "not byte-comparable (bgzf/zlib)", not a false
+   DIVERGED.
+8. **Chaining:** `reproduce` of a `.repro.json` increments `chain_depth`; two certificates over the
+   same parent share `parent_claim`.
+9. **Cross-machine CI fence:** golden chain REPRODUCED on the runner; the one-byte-flip negative
+   DIVERGED (exit 6). Determinism unaffected by the schema-5 change (existing `determinism` /
+   `golden_vcf` suites stay green; goldens refreshed only if the *claim shape* legitimately changes,
+   documented).
+10. **Build hygiene:** `cargo fmt --check`, `cargo build` 0 warnings (debug + release), full suite
+    green; `verify`/`--expect-code` unaffected by the schema bump.
+
+## 11. Decisions resolved & out-of-scope/future
+
+**Resolved:** Decision 1 → certificate default-writes a `<manifest>.repro.json` sidecar
+(`--no-attest`/`-o`). Decision 2 → exit codes `0/6/7/5`.
+
+**Future (not this track):** Ed25519-signing the `.repro.json` (Track A / P3.3) → counter-*signed*
+reproduction; decompressed-content comparison for BAM; chain-aware `reproduce --chain` composing
+with Track C; a public reproduction index/web (emergent from many certificates — no server built
+here).
+
+## 12. Risks
+
+- **Schema-evolution collision:** Track D owns the 4→5 bump; Tracks E/I (if ever built) must rebase
+  onto it. Track H (ColumnKit) must land *after* schema-5 freezes so `verify`/`--expect-code` keep
+  passing.
+- **Re-exec environment:** `reproduce` re-runs `current_exe()`; a different binary build legitimately
+  may diverge. Mitigated by surfacing the build-identity comparison prominently and by the verdict
+  being about output bytes with code-mismatch noted (not silently passed).
+- **Over-claim guardrails:** the certificate must render an explicit "re-derivation, not
+  correctness" line; the resource line must read "(here: this machine)"; the badge must not imply
+  tamper-*proof* (it is tamper-*evident* until signing lands). Honesty is the brand — these are
+  acceptance-level, not cosmetic.

--- a/src/call/columnkit.rs
+++ b/src/call/columnkit.rs
@@ -12,7 +12,7 @@
 //! the SAME verifiable receipt the shipped `variants`/`features` subcommands
 //! enjoy — for free. The trait is *welded* to the bounded kernel: the driver runs
 //! the exact same column stream as `stream_features_whole_genome`, so the
-//! estimator that admits a run provably upper-bounds the realized working set of
+//! estimator that admits a run upper-bounds the realized working set of
 //! the builder's analyzer too. It is the contract made composable, not a feature
 //! bolted beside it. (`FeatureAnalyzer` is the first impl — proof the trait
 //! carries the real shipped analyzer, not a toy.)

--- a/src/call/germline.rs
+++ b/src/call/germline.rs
@@ -1,6 +1,6 @@
 //! The germline diploid genotype-likelihood model: per-observation base-quality
 //! error integrated into [0/0, 0/1, 1/1] log-likelihoods, then a prior, then a
-//! calibrated, abstention-aware call.
+//! probabilistically-grounded, abstention-aware call.
 
 use crate::call::types::{Filter, Genotype, GermlineCall, GermlineParams, ACGT};
 use crate::core::allele_index;
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn thin_alt_evidence_abstains() {
         // 3 ref + 1 alt at bq30: a lone alt read cannot overcome the θ=1e-3
-        // prior, so the calibrated model abstains (no-call) rather than overcall.
+        // prior, so the model abstains (no-call) rather than overcall.
         let thin = [(0u8, 30u8), (0, 30), (0, 30), (1, 30)];
         assert!(call_germline(&col(b'A', &thin), &GermlineParams::default()).is_none());
     }

--- a/src/call/gvcf.rs
+++ b/src/call/gvcf.rs
@@ -9,8 +9,9 @@
 //! streaming-friendly: reference blocks are locus-ordered and append-only, so the
 //! whole-genome gVCF stays inside the same per-contig streaming envelope as
 //! `variants` — the bander holds O(1) state (one open block). Combined with the
-//! BLAKE3 receipt, each sample's gVCF is byte-reproducible, which neither GATK nor
-//! DeepVariant offers — and that reproducibility compounds at cohort scale.
+//! BLAKE3 receipt, each sample's gVCF is byte-reproducible — a property production
+//! gVCF pipelines generally don't provide — and that reproducibility compounds at
+//! cohort scale.
 
 use std::io::{self, Write};
 use std::ops::Range;

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -1,4 +1,4 @@
-//! The calling layer: turn the `PileupColumn` stream into calibrated,
+//! The calling layer: turn the `PileupColumn` stream into probabilistically-grounded,
 //! abstention-aware variant calls. Built on `crate::core` + `crate::pileup`
 //! only; no VCF writing or CLI wiring (those are later phases).
 

--- a/src/call/pack.rs
+++ b/src/call/pack.rs
@@ -3,11 +3,11 @@
 //!
 //! Each job's peak is a conservative upper bound computed from the index header
 //! alone (no run, no read I/O — milliseconds), and peaks are additive. So a
-//! scheduler can SUM predicted peaks across co-located jobs and *prove* a node
-//! fits before launching a byte. No incumbent caller can: GATK/DeepVariant peaks
-//! are emergent and only known after a possible OOM-kill, so every co-location is
-//! a gamble. Here, `Packed(...)` is a proof — every node's summed peak is `<=`
-//! its capacity, established up front.
+//! scheduler can SUM predicted peaks across co-located jobs and show a node stays
+//! within budget before launching a byte. Emergent-peak callers (GATK/DeepVariant)
+//! only learn their peak after a possible OOM-kill, so every co-location is a
+//! gamble. Here, `Packed(...)` reports a placement whose every node's summed
+//! predicted peak is `<=` its capacity, established up front.
 
 /// A job to place: a label and its predicted peak RSS, in bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,7 +19,7 @@ pub struct PackJob {
 }
 
 /// One node's assignment: which jobs land on it and their summed predicted peak
-/// (which is `<=` the node capacity — the fit, proven).
+/// (which is `<=` the node capacity — the fit, by predicted peak).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeAssignment {
     /// Node index (0-based).
@@ -34,7 +34,7 @@ pub struct NodeAssignment {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackOutcome {
     /// Every job placed. Each `NodeAssignment.used_bytes <= node_capacity_bytes`,
-    /// so the node is *proven* to fit before any job runs.
+    /// so the node is within capacity by predicted peak before any job runs.
     Packed(Vec<NodeAssignment>),
     /// No safe packing exists under the constraints.
     NoFit {
@@ -123,13 +123,13 @@ mod tests {
     }
 
     #[test]
-    fn packs_all_jobs_and_every_node_is_proven_within_capacity() {
+    fn packs_all_jobs_and_every_node_is_within_capacity() {
         let jobs = vec![job("a", 30), job("b", 40), job("c", 50), job("d", 20)];
         let cap = 100;
         let PackOutcome::Packed(nodes) = first_fit_decreasing(&jobs, cap, None) else {
             panic!("should pack");
         };
-        // THE proof property: every node's summed peak is within capacity.
+        // THE invariant: every node's summed predicted peak is within capacity.
         for n in &nodes {
             assert!(
                 n.used_bytes <= cap,

--- a/src/call/plan.rs
+++ b/src/call/plan.rs
@@ -17,7 +17,7 @@ use crate::core::{
 /// largest contig's reference (decoded, 1×) + the depth-capped active read set +
 /// the fixed engine overhead. An upper bound when actual reads do not exceed
 /// `max_read_len` and depth is capped at `max_depth`. Depth is always enforced at
-/// runtime (the pileup reservoir bounds the active set); `max_read_len` is checked
+/// runtime (the pileup depth cap bounds the active set); `max_read_len` is checked
 /// at ingest under `--enforce` (a longer read aborts the run, so it cannot silently
 /// exceed the bound), with the realized post-run RSS check as the final backstop.
 pub fn estimate_variants_working_set(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,4 +79,4 @@ pub use call::{
 pub use core::{MemoryBudget, WorkingSet};
 // Build-once → mmap index + the reproducibility receipt:
 pub use genomics::{GenomeIndex, IndexReader, ReferenceView};
-pub use provenance::RunManifest;
+pub use provenance::{verify_receipt, CommandCapture, RunManifest, VerifyOpts, VerifyReport};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 #![allow(clippy::new_without_default)]
 
 // Each module is a layer of the genomics engine.
-/// The calling layer: calibrated, abstention-aware variant calls from pileup columns.
+/// The calling layer: probabilistically-grounded, abstention-aware variant calls from pileup columns.
 pub mod call;
 /// Core types: the lingua franca shared by every layer (io, index, align, pileup, call).
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod io;
 pub mod pileup;
 /// Reproducibility receipts: canonical-JSON BLAKE3 manifests for every run.
 pub mod provenance;
+/// Third-party byte re-derivation from a receipt (the `reproduce` verb).
+pub mod reproduce;
 /// Helper utilities: read-only mmap + peak-RSS measurement.
 pub mod util;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ enum Commands {
         output: Option<PathBuf>,
     },
     /// Call germline variants from aligned reads (streaming pileup engine +
-    /// calibrated, abstention-aware genotype-likelihood caller).
+    /// abstention-aware genotype-likelihood caller).
     Variants {
         /// Persisted index (`rosalind index`); calls all contigs, reference from
         /// the index. Mutually exclusive with `--reference`.
@@ -286,9 +286,9 @@ enum Commands {
         json: bool,
     },
     /// Pack many bounded `variants` jobs onto fixed-size nodes by their PREDICTED
-    /// peaks — prove a co-location fits before launching a byte. Each job's peak
-    /// is read from its index header (no run); peaks are additive, so the sum is a
-    /// conservative bound a scheduler can refuse on. Exit 3 if no packing fits.
+    /// peaks — show a co-location fits within budget before launching a byte. Each
+    /// job's peak is read from its index header (no run); peaks are additive, so the
+    /// sum is a conservative bound a scheduler can refuse on. Exit 3 if no packing fits.
     Pack {
         /// A jobs file: one job per line, `<index_path>[\t<max_depth>[\t<max_read_len>]]`
         /// (TSV or whitespace; blank lines and `#` comments ignored).
@@ -802,9 +802,9 @@ fn run_plan(
 
 /// Pack many bounded `variants` jobs onto fixed-size nodes by their PREDICTED
 /// peaks — each read from the job's index header (no run, no read I/O). Peaks are
-/// conservative upper bounds and additive, so the printed schedule PROVES every
-/// node fits before a single job launches — the contract turned into a placement
-/// decision. Exits 3 when no safe packing exists.
+/// conservative upper bounds and additive, so the printed schedule shows every
+/// node within capacity by predicted peak before a single job launches — the
+/// contract turned into a placement decision. Exits 3 when no safe packing exists.
 fn run_pack(
     jobs_path: PathBuf,
     node_mb: u64,
@@ -902,7 +902,7 @@ fn run_pack(
                 println!("{s}");
             } else {
                 println!(
-                    "pack: {} job(s) → {} node(s) of {} MiB — every node proven within capacity",
+                    "pack: {} job(s) → {} node(s) of {} MiB — every node within capacity by predicted peak",
                     pack_jobs.len(),
                     assignments.len(),
                     node_mb

--- a/src/main.rs
+++ b/src/main.rs
@@ -892,167 +892,34 @@ fn run_verify(
     budget_mb: Option<u64>,
     expect_code: Option<String>,
 ) -> Result<()> {
-    use rosalind::provenance::{blake3_file, RunManifest};
+    use rosalind::provenance::{verify_receipt, VerifyOpts};
 
     let text = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("failed to read manifest {}", manifest_path.display()))?;
-    let manifest = RunManifest::from_canonical_json(&text)
-        .map_err(|e| anyhow!("failed to parse manifest {}: {e}", manifest_path.display()))?;
-
-    let mut problems: Vec<String> = Vec::new();
-
-    // Re-hash inputs + outputs against the recorded digests.
-    for (kind, files) in [("input", &manifest.inputs), ("output", &manifest.outputs)] {
-        for f in files {
-            match blake3_file(std::path::Path::new(&f.path)) {
-                Ok(h) if h == f.blake3 => {}
-                Ok(h) => problems.push(format!(
-                    "{kind} {} hash mismatch: recorded {}, now {}",
-                    f.path, f.blake3, h
-                )),
-                Err(e) => problems.push(format!("{kind} {} unreadable: {e}", f.path)),
-            }
-        }
+    let report = verify_receipt(
+        &text,
+        &VerifyOpts {
+            budget_mb,
+            expect_code,
+            rehash_files: true,
+        },
+    );
+    for n in &report.notes {
+        println!("verify: {n}");
     }
-
-    // Strictly parse the numeric fields verify consults. A field that is PRESENT but
-    // unparseable is corruption, not absence — flag it rather than silently skipping
-    // the check it feeds (the closure takes `&mut problems` as an argument so it does
-    // not capture the borrow). `get_recorded` reads measurements (v2) or params
-    // (pre-v2) uniformly.
-    let parse_num = |k: &str, problems: &mut Vec<String>| -> Option<u64> {
-        match manifest.get_recorded(k) {
-            None => None,
-            Some(v) => match v.parse::<u64>() {
-                Ok(n) => Some(n),
-                Err(_) => {
-                    problems.push(format!("malformed numeric field {k}: {v:?}"));
-                    None
-                }
-            },
-        }
-    };
-    let recorded_peak = parse_num("peak_rss_bytes", &mut problems);
-    let recorded_ws = parse_num("max_working_set_bytes", &mut problems);
-    let recorded_budget = parse_num("memory_budget_mb", &mut problems);
-
-    // Re-check the recorded realized peak against the budget (CLI overrides manifest).
-    let budget_mb = budget_mb.or(recorded_budget);
-    match (budget_mb, recorded_peak) {
-        (Some(mb), Some(peak)) => {
-            let budget = rosalind::core::MemoryBudget::from_mb(mb);
-            if budget.admits(peak) {
-                println!(
-                    "verify: peak {} MiB within budget {mb} MiB",
-                    peak / (1 << 20)
-                );
-            } else {
-                problems.push(format!(
-                    "recorded peak {} MiB exceeded budget {mb} MiB",
-                    peak / (1 << 20)
-                ));
-            }
-        }
-        (None, _) => println!("verify: no budget to check (none supplied or recorded)"),
-        (Some(_), None) => problems.push("manifest has no recorded peak_rss_bytes".to_string()),
-    }
-
-    // Internal-consistency cross-checks: a receipt's self-reported numbers must
-    // agree with each other. The claim self-hash (manifest_blake3) cannot see an
-    // edit to a measured field (the measurement is excluded from the claim by
-    // design), so alongside the measurement self-hash these cheap checks are the
-    // semantic guard against a hand-edited receipt — e.g. someone lowering
-    // `peak_rss_bytes` to pass `verify` but leaving the other fields inconsistent.
-    //
-    // The working set is a subset of resident memory; it cannot exceed peak RSS.
-    if let (Some(ws), Some(peak)) = (recorded_ws, recorded_peak) {
-        if ws > peak {
-            problems.push(format!(
-                "internally inconsistent: max_working_set_bytes ({ws}) exceeds peak_rss_bytes ({peak})"
-            ));
-        }
-    }
-    // A recorded verdict must agree with the recorded peak vs the recorded budget.
-    if let (Some(verdict), Some(mb), Some(peak)) = (
-        manifest
-            .get_recorded("contract_verdict")
-            .map(String::as_str),
-        recorded_budget,
-        recorded_peak,
-    ) {
-        let actually_within = rosalind::core::MemoryBudget::from_mb(mb).admits(peak);
-        if verdict == "within" && !actually_within {
-            problems.push(format!(
-                "internally inconsistent: contract_verdict='within' but recorded peak {} MiB \
-                 exceeds recorded budget {mb} MiB",
-                peak / (1 << 20)
-            ));
-        }
-        if verdict == "over" && actually_within {
-            problems.push(format!(
-                "internally inconsistent: contract_verdict='over' but recorded peak {} MiB \
-                 is within recorded budget {mb} MiB",
-                peak / (1 << 20)
-            ));
-        }
-    }
-
-    // Claim self-hash: catches any post-write edit to the claim (inputs, outputs,
-    // declared params) — cross-machine stable. A pre-1.2 receipt has none — note and skip.
-    match manifest.self_hash_ok() {
-        Some(true) => {}
-        Some(false) => problems.push(
-            "manifest_blake3 mismatch: the receipt was modified after it was written".to_string(),
-        ),
-        None => {
-            println!("verify: note — no manifest_blake3 (a pre-1.2 receipt); skipping self-hash")
-        }
-    }
-
-    // Measurement self-hash: catches an edit to a measured field (e.g. lowering
-    // peak_rss_bytes to fake a fit) that the claim hash cannot see by design. This is
-    // an unkeyed self-hash — tamper-EVIDENCE against an accidental edit, not
-    // tamper-resistance against a forger who re-hashes; the cross-checks above are the
-    // semantic backstop.
-    match manifest.measurement_hash_ok() {
-        Some(true) => {}
-        Some(false) => problems.push(
-            "measurement_blake3 mismatch: a measured field was modified after the run".to_string(),
-        ),
-        // No measurement block. Legitimate for a pre-v2 / measurement-free receipt —
-        // but if the (hash-protected) claim records that one must exist, its absence
-        // means the whole block was stripped to evade the budget/consistency checks.
-        None => {
-            if manifest.claims_measurements() {
-                problems.push(
-                    "measurement block missing: the claim records a measurement block but \
-                     the receipt has none (stripped after the run?)"
-                        .to_string(),
-                );
-            }
-        }
-    }
-
-    // Build-identity: assert the receipt came from exactly the expected commit. A clean
-    // match prints a note; a mismatch / dirty-build / un-checkable receipt fails verify.
-    if let Some(expected) = &expect_code {
-        let code_problems = manifest.check_expected_code(expected);
-        if code_problems.is_empty() {
-            println!("verify: code matches {expected} (clean build)");
-        } else {
-            problems.extend(code_problems);
-        }
-    }
-
-    if problems.is_empty() {
+    if report.ok {
+        let m = report
+            .manifest
+            .as_ref()
+            .expect("a passing report always carries the parsed manifest");
         println!(
             "verify: OK — {} input(s), {} output(s) match",
-            manifest.inputs.len(),
-            manifest.outputs.len()
+            m.inputs.len(),
+            m.outputs.len()
         );
         Ok(())
     } else {
-        for p in &problems {
+        for p in &report.problems {
             eprintln!("verify: FAIL — {p}");
         }
         std::process::exit(5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1183,7 +1183,7 @@ fn run_somatic(
     use rosalind::io::bam::BamSource;
     use rosalind::io::vcf::write_somatic_vcf;
     use rosalind::pileup::PileupParams;
-    use rosalind::provenance::{blake3_file, write_manifest, FileHash, RunManifest};
+    use rosalind::provenance::{write_manifest, CommandCapture, RunManifest};
 
     let start_call = Instant::now();
     let mut contigs = ContigSet::new();
@@ -1227,22 +1227,20 @@ fn run_somatic(
         _ => Vec::new(),
     };
     let mut manifest = RunManifest::new("somatic");
-    manifest.inputs.push(FileHash {
-        path: reference_path.display().to_string(),
-        blake3: blake3_file(&reference_path)?,
-    });
-    for p in tumor_inputs.iter().chain(normal_inputs.iter()) {
+    let mut cmd = CommandCapture::new("somatic");
+    cmd.input("--reference", &reference_path)?;
+    for p in tumor_inputs.iter() {
         if p.exists() {
-            manifest.inputs.push(FileHash {
-                path: p.display().to_string(),
-                blake3: blake3_file(p)?,
-            });
+            cmd.input("--tumor", p)?;
         }
     }
-    manifest.outputs.push(FileHash {
-        path: output_vcf.display().to_string(),
-        blake3: blake3_file(&output_vcf)?,
-    });
+    for p in normal_inputs.iter() {
+        if p.exists() {
+            cmd.input("--normal", p)?;
+        }
+    }
+    cmd.output("-o", &output_vcf)?;
+    cmd.record_into(&mut manifest);
     manifest
         .params
         .insert("somatic_snv_only".to_string(), "true".to_string());
@@ -1513,7 +1511,7 @@ fn run_variants(
     use rosalind::io::bam::BamSource;
     use rosalind::io::vcf::{write_germline_vcf, GermlineRow};
     use rosalind::pileup::{PileupParams, SliceSource};
-    use rosalind::provenance::{blake3_file, write_manifest, FileHash, RunManifest};
+    use rosalind::provenance::{write_manifest, CommandCapture, RunManifest};
 
     let fasta = read_fasta(&reference_path)
         .with_context(|| format!("failed to read reference from {}", reference_path.display()))?;
@@ -1597,28 +1595,15 @@ fn run_variants(
 
             // Reproducibility receipt next to the VCF.
             let mut manifest = RunManifest::new("variants");
-            manifest.inputs.push(FileHash {
-                path: reference_path.display().to_string(),
-                blake3: blake3_file(&reference_path)?,
-            });
-            manifest.inputs.push(FileHash {
-                path: alignments_path.display().to_string(),
-                blake3: blake3_file(&alignments_path)?,
-            });
-            manifest.outputs.push(FileHash {
-                path: path.display().to_string(),
-                blake3: blake3_file(&path)?,
-            });
-            manifest
-                .params
-                .insert("mapq_threshold".to_string(), mapq_threshold.to_string());
-            manifest.params.insert(
-                "min_qual".to_string(),
-                (quality_threshold as f64).to_string(),
-            );
-            manifest
-                .params
-                .insert("region_start".to_string(), region_start.to_string());
+            let mut cmd = CommandCapture::new("variants");
+            cmd.input("--reference", &reference_path)?;
+            cmd.input("--alignments", &alignments_path)?;
+            cmd.opt("--chrom", &chrom_name);
+            cmd.opt("--region-start", region_start);
+            cmd.opt("--mapq-threshold", mapq_threshold);
+            cmd.opt("--quality-threshold", quality_threshold as f64);
+            cmd.output("-o", &path)?;
+            cmd.record_into(&mut manifest);
             manifest.finalize();
             let manifest_path = write_manifest(&path, &manifest)?;
             eprintln!("wrote reproducibility receipt: {}", manifest_path.display());
@@ -1656,7 +1641,7 @@ fn run_features(
     use rosalind::genomics::IndexReader;
     use rosalind::io::bam::StreamingBamSource;
     use rosalind::pileup::PileupParams;
-    use rosalind::provenance::{blake3_file, FileHash, RunManifest};
+    use rosalind::provenance::{CommandCapture, RunManifest};
 
     let loaded = IndexReader::open(&index_path)
         .with_context(|| format!("failed to open index {}", index_path.display()))?;
@@ -1850,32 +1835,20 @@ fn run_features(
     };
     if let Some(dest) = receipt_dest {
         let mut manifest = RunManifest::new("features");
-        manifest.inputs.push(FileHash {
-            path: index_path.display().to_string(),
-            blake3: blake3_file(&index_path)?,
-        });
-        manifest.inputs.push(FileHash {
-            path: alignments_path.display().to_string(),
-            blake3: blake3_file(&alignments_path)?,
-        });
-        if let Some(path) = &output {
-            manifest.outputs.push(FileHash {
-                path: path.display().to_string(),
-                blake3: blake3_file(path)?,
-            });
+        let mut cmd = CommandCapture::new("features");
+        cmd.input("--index", &index_path)?;
+        cmd.input("--alignments", &alignments_path)?;
+        cmd.opt("--mapq-threshold", mapq_threshold);
+        cmd.opt("--max-depth", max_depth);
+        cmd.opt("--max-read-len", max_read_len);
+        cmd.flag_if(enforce, "--enforce");
+        if let Some(mb) = memory_budget_mb {
+            cmd.opt("--memory-budget-mb", mb);
         }
-        manifest
-            .params
-            .insert("mapq_threshold".to_string(), mapq_threshold.to_string());
-        manifest
-            .params
-            .insert("max_depth".to_string(), max_depth.to_string());
-        manifest
-            .params
-            .insert("max_read_len".to_string(), max_read_len.to_string());
-        manifest
-            .params
-            .insert("enforced".to_string(), enforce.to_string());
+        if let Some(path) = &output {
+            cmd.output("-o", path)?;
+        }
+        cmd.record_into(&mut manifest);
         manifest
             .params
             .insert("peak_rss_bytes".to_string(), peak_rss.to_string());
@@ -1912,11 +1885,6 @@ fn run_features(
         manifest
             .params
             .insert("reads_skipped_total".to_string(), skips.total().to_string());
-        if let Some(mb) = memory_budget_mb {
-            manifest
-                .params
-                .insert("memory_budget_mb".to_string(), mb.to_string());
-        }
         manifest
             .params
             .insert("contract_verdict".to_string(), verdict.to_string());
@@ -1985,7 +1953,7 @@ fn run_variants_index(
     use rosalind::io::bam::StreamingBamSource;
     use rosalind::io::vcf::{write_germline_header, write_germline_row, GermlineRow};
     use rosalind::pileup::PileupParams;
-    use rosalind::provenance::{blake3_file, FileHash, RunManifest};
+    use rosalind::provenance::{CommandCapture, RunManifest};
 
     let loaded = IndexReader::open(&index_path)
         .with_context(|| format!("failed to open index {}", index_path.display()))?;
@@ -2231,36 +2199,22 @@ fn run_variants_index(
     };
     if let Some(dest) = receipt_dest {
         let mut manifest = RunManifest::new("variants");
-        manifest.inputs.push(FileHash {
-            path: index_path.display().to_string(),
-            blake3: blake3_file(&index_path)?,
-        });
-        manifest.inputs.push(FileHash {
-            path: alignments_path.display().to_string(),
-            blake3: blake3_file(&alignments_path)?,
-        });
-        if let Some(path) = &output {
-            manifest.outputs.push(FileHash {
-                path: path.display().to_string(),
-                blake3: blake3_file(path)?,
-            });
+        let mut cmd = CommandCapture::new("variants");
+        cmd.input("--index", &index_path)?;
+        cmd.input("--alignments", &alignments_path)?;
+        cmd.opt("--mapq-threshold", mapq_threshold);
+        cmd.opt("--quality-threshold", quality_threshold as f64);
+        cmd.opt("--max-depth", max_depth);
+        cmd.opt("--max-read-len", max_read_len);
+        cmd.flag_if(enforce, "--enforce");
+        cmd.flag_if(gvcf, "--gvcf");
+        if let Some(mb) = memory_budget_mb {
+            cmd.opt("--memory-budget-mb", mb);
         }
-        manifest
-            .params
-            .insert("mapq_threshold".to_string(), mapq_threshold.to_string());
-        manifest.params.insert(
-            "min_qual".to_string(),
-            (quality_threshold as f64).to_string(),
-        );
-        manifest
-            .params
-            .insert("max_depth".to_string(), max_depth.to_string());
-        manifest
-            .params
-            .insert("max_read_len".to_string(), max_read_len.to_string());
-        manifest
-            .params
-            .insert("enforced".to_string(), enforce.to_string());
+        if let Some(path) = &output {
+            cmd.output("-o", path)?;
+        }
+        cmd.record_into(&mut manifest);
         manifest
             .params
             .insert("peak_rss_bytes".to_string(), peak_rss.to_string());
@@ -2294,11 +2248,6 @@ fn run_variants_index(
         manifest
             .params
             .insert("reads_skipped_total".to_string(), skips.total().to_string());
-        if let Some(mb) = memory_budget_mb {
-            manifest
-                .params
-                .insert("memory_budget_mb".to_string(), mb.to_string());
-        }
         manifest
             .params
             .insert("contract_verdict".to_string(), verdict.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,23 @@ enum Commands {
         #[arg(long)]
         expect_code: Option<String>,
     },
+    /// Re-derive a recorded result from its receipt and content-located inputs, and
+    /// write a chainable reproduction certificate. The verdict is over output bytes
+    /// (exit 0 REPRODUCED / 6 DIVERGED / 7 INCONCLUSIVE / 5 tampered receipt).
+    Reproduce {
+        /// Path to a `*.manifest.json` from a previous run.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Directory holding the recorded inputs (located by content hash).
+        #[arg(long)]
+        inputs: PathBuf,
+        /// Do not write a `.repro.json` reproduction certificate.
+        #[arg(long, default_value_t = false)]
+        no_attest: bool,
+        /// Where to write the certificate (default: `<manifest>.repro.json`).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, Eq, PartialEq)]
@@ -523,6 +540,12 @@ fn main() -> Result<()> {
             budget_mb,
             expect_code,
         } => run_verify(manifest, budget_mb, expect_code)?,
+        Commands::Reproduce {
+            manifest,
+            inputs,
+            no_attest,
+            output,
+        } => run_reproduce(manifest, inputs, no_attest, output)?,
     }
 
     Ok(())
@@ -924,6 +947,27 @@ fn run_verify(
         }
         std::process::exit(5);
     }
+}
+
+/// Re-derive a recorded result and report REPRODUCED / DIVERGED / INCONCLUSIVE (and
+/// TAMPERED for a modified receipt), exiting 0 / 6 / 7 / 5 respectively. Writes a
+/// `.repro.json` reproduction certificate next to the receipt unless `--no-attest`.
+fn run_reproduce(
+    manifest: PathBuf,
+    inputs: PathBuf,
+    no_attest: bool,
+    output: Option<PathBuf>,
+) -> Result<()> {
+    let report = rosalind::reproduce::reproduce(&manifest, &inputs)?;
+    for line in &report.lines {
+        println!("{line}");
+    }
+    // The reproduction certificate is minted here in Task 5.
+    let _ = (no_attest, output);
+    if report.exit_code != 0 {
+        std::process::exit(report.exit_code);
+    }
+    Ok(())
 }
 
 /// Load a prebuilt index and print exact-match loci for `pattern` (B3c). This is

--- a/src/main.rs
+++ b/src/main.rs
@@ -958,12 +958,56 @@ fn run_reproduce(
     no_attest: bool,
     output: Option<PathBuf>,
 ) -> Result<()> {
+    use rosalind::provenance::{ReproOutput, ReproReceipt};
+
     let report = rosalind::reproduce::reproduce(&manifest, &inputs)?;
     for line in &report.lines {
         println!("{line}");
     }
-    // The reproduction certificate is minted here in Task 5.
-    let _ = (no_attest, output);
+
+    // Mint a chainable reproduction certificate when a real comparison happened
+    // (REPRODUCED / DIVERGED) — unless the caller opted out.
+    if report.compared && !no_attest {
+        let outputs: Vec<ReproOutput> = report
+            .outputs
+            .iter()
+            .map(|c| ReproOutput {
+                role: c.role.clone(),
+                recorded_blake3: c.recorded.clone(),
+                observed_blake3: c.observed.clone(),
+                matched: c.matched,
+            })
+            .collect();
+        let cert = ReproReceipt::build(
+            &report.parent_claim,
+            &report.parent_subcommand,
+            &report.verdict_label,
+            1,
+            &outputs,
+            report.resource_here.peak_rss_bytes,
+            report.resource_here.declared_budget_mb,
+        );
+        let dest = match &output {
+            Some(p) => p.clone(),
+            None => {
+                let mut s = manifest.as_os_str().to_os_string();
+                s.push(".repro.json");
+                PathBuf::from(s)
+            }
+        };
+        std::fs::write(&dest, cert.to_canonical_json()).with_context(|| {
+            format!(
+                "failed to write reproduction certificate {}",
+                dest.display()
+            )
+        })?;
+        println!(
+            "  -> wrote reproduction certificate: {} (chains to {})",
+            dest.display(),
+            &report.parent_claim[..report.parent_claim.len().min(10)]
+        );
+    }
+
     if report.exit_code != 0 {
         std::process::exit(report.exit_code);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,21 @@ enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+    /// Emit a self-hosted status badge — a shields.io endpoint JSON or a static SVG —
+    /// asserting "reproducible · fits N MiB" for a run. With `--repro` the reproducible
+    /// claim is backed by a reproduction certificate; otherwise it reflects the
+    /// deterministic engine (an intact receipt re-derives byte-identically).
+    Badge {
+        /// The run's `*.manifest.json`.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// An optional `*.repro.json` whose verdict backs the "reproducible" claim.
+        #[arg(long)]
+        repro: Option<PathBuf>,
+        /// Output path; a `.svg` extension emits the static SVG, else a shields JSON.
+        #[arg(short, long)]
+        output: PathBuf,
+    },
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, Eq, PartialEq)]
@@ -546,6 +561,11 @@ fn main() -> Result<()> {
             no_attest,
             output,
         } => run_reproduce(manifest, inputs, no_attest, output)?,
+        Commands::Badge {
+            manifest,
+            repro,
+            output,
+        } => run_badge(manifest, repro, output)?,
     }
 
     Ok(())
@@ -1011,6 +1031,57 @@ fn run_reproduce(
     if report.exit_code != 0 {
         std::process::exit(report.exit_code);
     }
+    Ok(())
+}
+
+/// Emit a self-hosted status badge for a run. `fits` comes from the receipt's recorded
+/// peak vs declared budget; `reproducible` comes from a `--repro` certificate's verdict,
+/// or (absent one) from the receipt's intact self-hash (the engine is deterministic, so
+/// an intact Rosalind receipt re-derives byte-identically by construction).
+fn run_badge(manifest: PathBuf, repro: Option<PathBuf>, output: PathBuf) -> Result<()> {
+    use rosalind::core::MemoryBudget;
+    use rosalind::provenance::{badge_json, badge_svg, ReproReceipt, RunManifest};
+
+    let text = std::fs::read_to_string(&manifest)
+        .with_context(|| format!("failed to read receipt {}", manifest.display()))?;
+    let m = RunManifest::from_canonical_json(&text)
+        .map_err(|e| anyhow!("failed to parse receipt {}: {e}", manifest.display()))?;
+
+    let budget = m
+        .get_recorded("memory_budget_mb")
+        .and_then(|v| v.parse::<u64>().ok());
+    let peak = m
+        .get_recorded("peak_rss_bytes")
+        .and_then(|v| v.parse::<u64>().ok());
+    let fits_mb = match (budget, peak) {
+        (Some(mb), Some(p)) if MemoryBudget::from_mb(mb).admits(p) => Some(mb),
+        _ => None,
+    };
+
+    let reproducible = match &repro {
+        Some(p) => {
+            let ctext = std::fs::read_to_string(p)
+                .with_context(|| format!("failed to read certificate {}", p.display()))?;
+            let cert = ReproReceipt::from_canonical_json(&ctext)
+                .map_err(|e| anyhow!("failed to parse certificate {}: {e}", p.display()))?;
+            cert.self_hash_ok() && cert.verdict() == Some("REPRODUCED")
+        }
+        None => m.self_hash_ok() == Some(true),
+    };
+
+    let is_svg = output
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("svg"))
+        .unwrap_or(false);
+    let body = if is_svg {
+        badge_svg(reproducible, fits_mb)
+    } else {
+        badge_json(reproducible, fits_mb)
+    };
+    std::fs::write(&output, &body)
+        .with_context(|| format!("failed to write badge {}", output.display()))?;
+    eprintln!("wrote badge: {}", output.display());
     Ok(())
 }
 

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -54,8 +54,8 @@ pub struct PileupParams {
     /// Skip PCR/optical duplicates (SAM flag 0x400).
     pub skip_duplicate: bool,
     /// Cap on the active read set per position (deterministic downsampling).
-    /// `None` = uncapped (default). When `Some(d)`, an unbiased min-hash reservoir
-    /// keeps `d` reads covering each position; reads removed are counted
+    /// `None` = uncapped (default). When `Some(d)`, an unbiased min-hash bottom-k
+    /// cap keeps `d` reads covering each position; reads removed are counted
     /// `over_max_depth`.
     pub max_depth: Option<u32>,
     /// When `Some(m)` (set only under `--enforce`), a read whose `seq.len()`
@@ -136,7 +136,7 @@ struct ActiveRead {
     mapq: u8,
     /// Reverse-strand flag (metadata only — never applied to `seq`).
     reverse: bool,
-    /// Fixed-seed content hash — the depth-cap reservoir admission/eviction key.
+    /// Fixed-seed content hash — the depth-cap selector admission/eviction key.
     priority: u64,
 }
 
@@ -235,7 +235,7 @@ impl<S: ReadSource> PileupEngine<S> {
     }
 
     /// Precompute a read's reference→read-offset map and add it to the active set.
-    /// `priority` is the precomputed reservoir key (see `read_priority`).
+    /// `priority` is the precomputed selector key (see `read_priority`).
     fn ingest(&mut self, read: AlignedRead, priority: u64) {
         let end = read.end();
         let mut ref_to_read = HashMap::new();
@@ -306,7 +306,7 @@ impl<S: ReadSource> PileupEngine<S> {
                     let prio = read_priority(&read);
                     if let Some(max) = self.params.max_depth {
                         if self.active.len() as u32 >= max {
-                            // Unbiased min-hash reservoir: keep the `max`
+                            // Unbiased min-hash bottom-k cap: keep the `max`
                             // smallest-priority reads covering the cursor. Evict the
                             // greatest-priority resident iff the newcomer ranks below
                             // it; otherwise refuse. Either way the cap removed one
@@ -370,7 +370,7 @@ impl<S: ReadSource> PileupEngine<S> {
         // Emit observations in a canonical total order so the downstream diploid
         // log-likelihood accumulation (germline.rs, an order-sensitive f64 sum) is
         // order-independent and the VCF stays byte-identical regardless of the
-        // active set's internal order (which the depth-cap reservoir may permute).
+        // active set's internal order (which the depth-cap selector may permute).
         obs.sort_by(|a, b| {
             (a.allele, a.base_qual, a.mapq, a.reverse as u8).cmp(&(
                 b.allele,
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn unbiased_cap_keeps_downstream_starting_reads() {
         // The biased (leftmost-arrival) cap dropped reads that START at a deep
-        // variant, zeroing the alt allele. The min-hash reservoir keeps a
+        // variant, zeroing the alt allele. The min-hash bottom-k cap keeps a
         // start-position-independent sample, so a variant carried only by reads
         // that begin AT the variant column survives. Reads must be DISTINCT
         // (real reads are) — identical content shares one hash and degenerates.

--- a/src/provenance/badge.rs
+++ b/src/provenance/badge.rs
@@ -1,0 +1,81 @@
+//! Self-hosted status badges — a shields.io *endpoint*-format JSON and a static SVG —
+//! asserting "reproducible · fits N MiB" for a run. Self-hosted: no shields.io runtime
+//! dependency (we emit the SVG directly), so the badge works offline / air-gapped.
+
+use super::json_escape;
+
+/// The badge message + color for a (reproducible, fits-budget?) status.
+fn badge_message(reproducible: bool, fits_mb: Option<u64>) -> (String, &'static str) {
+    if !reproducible {
+        return ("not reproducible".to_string(), "red");
+    }
+    match fits_mb {
+        Some(mb) => (format!("reproducible, fits {mb} MiB"), "brightgreen"),
+        None => ("reproducible".to_string(), "brightgreen"),
+    }
+}
+
+/// A shields.io endpoint-format JSON object (consume via shields.io's `endpoint` badge,
+/// or render the SVG below directly).
+pub fn badge_json(reproducible: bool, fits_mb: Option<u64>) -> String {
+    let (msg, color) = badge_message(reproducible, fits_mb);
+    format!(
+        "{{\"schemaVersion\":1,\"label\":\"rosalind\",\"message\":\"{}\",\"color\":\"{}\"}}",
+        json_escape(&msg),
+        color
+    )
+}
+
+/// A minimal, static, self-contained SVG badge (no external fetch).
+pub fn badge_svg(reproducible: bool, fits_mb: Option<u64>) -> String {
+    let (msg, color) = badge_message(reproducible, fits_mb);
+    let fill = match color {
+        "brightgreen" => "#4c1",
+        "red" => "#e05d44",
+        _ => "#9f9f9f",
+    };
+    // Width scales loosely with the message length so the text fits.
+    let msg_w = 12 + msg.len() as u32 * 7;
+    let total = 70 + msg_w;
+    let msg_mid = 70 + msg_w / 2;
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{total}\" height=\"20\" \
+role=\"img\" aria-label=\"rosalind: {msg}\">\
+<rect width=\"70\" height=\"20\" fill=\"#555\"/>\
+<rect x=\"70\" width=\"{msg_w}\" height=\"20\" fill=\"{fill}\"/>\
+<g fill=\"#fff\" font-family=\"Verdana,Geneva,sans-serif\" font-size=\"11\">\
+<text x=\"8\" y=\"14\">rosalind</text>\
+<text x=\"{msg_mid}\" y=\"14\" text-anchor=\"middle\">{msg}</text>\
+</g></svg>"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn badge_json_is_shields_endpoint_shaped() {
+        let j = badge_json(true, Some(256));
+        assert!(j.contains("\"schemaVersion\":1"), "{j}");
+        assert!(j.contains("\"label\":\"rosalind\""), "{j}");
+        assert!(j.contains("reproducible"), "{j}");
+        assert!(j.contains("256 MiB"), "{j}");
+        assert!(j.contains("\"color\":\"brightgreen\""), "{j}");
+    }
+
+    #[test]
+    fn badge_json_red_when_not_reproducible() {
+        let j = badge_json(false, None);
+        assert!(j.contains("\"color\":\"red\""), "{j}");
+        assert!(j.contains("not reproducible"), "{j}");
+    }
+
+    #[test]
+    fn badge_svg_is_well_formed() {
+        let s = badge_svg(true, Some(256));
+        assert!(s.starts_with("<svg"), "{s}");
+        assert!(s.trim_end().ends_with("</svg>"), "{s}");
+        assert!(s.contains("reproducible"), "{s}");
+    }
+}

--- a/src/provenance/command.rs
+++ b/src/provenance/command.rs
@@ -151,7 +151,8 @@ impl CommandCapture {
     /// the inferred `mode`. Call before `finalize()`. Measurement fields remain the
     /// caller's responsibility (recorded separately, relocated by `finalize`).
     pub fn record_into(self, m: &mut RunManifest) {
-        m.params.insert("command".to_string(), self.render_command());
+        m.params
+            .insert("command".to_string(), self.render_command());
         for t in &self.tokens {
             match t {
                 Token::Opt(f, v) => {
@@ -238,11 +239,17 @@ mod tests {
              --mapq-threshold 20 --max-depth 1000 --memory-budget-mb 256 --enforce -o @out:h_out"
         );
         assert_eq!(
-            m.inputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(),
+            m.inputs
+                .iter()
+                .map(|f| f.blake3.as_str())
+                .collect::<Vec<_>>(),
             ["h_idx", "h_bam"]
         );
         assert_eq!(
-            m.outputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(),
+            m.outputs
+                .iter()
+                .map(|f| f.blake3.as_str())
+                .collect::<Vec<_>>(),
             ["h_out"]
         );
         assert_eq!(m.params.get("mapq_threshold").unwrap(), "20");
@@ -296,6 +303,9 @@ mod tests {
         let locate = |_h: &str| None;
         let out_temp = |_h: &str| "/tmp/out.vcf".to_string();
         let err = CommandCapture::argv_from_command(command, &locate, &out_temp).unwrap_err();
-        assert!(err.contains("h_idx"), "error names the unresolved input hash: {err}");
+        assert!(
+            err.contains("h_idx"),
+            "error names the unresolved input hash: {err}"
+        );
     }
 }

--- a/src/provenance/command.rs
+++ b/src/provenance/command.rs
@@ -1,0 +1,301 @@
+//! `CommandCapture` — the single chokepoint that records a normalized, replayable
+//! invocation into a receipt's claim, and reconstructs an argv from it. Recording and
+//! replay share this one structure so they cannot drift (the "forgot to record flag X"
+//! bug class is eliminated by construction).
+//!
+//! Input/output operands carry a content hash, not a path, so the recorded `command`
+//! string is machine-independent and is protected by the existing claim self-hash.
+
+use std::path::Path;
+
+use super::{blake3_file, FileHash, RunManifest};
+
+/// One token of a recorded invocation.
+#[derive(Debug)]
+enum Token {
+    Flag(String),
+    Opt(String, String),
+    Input { flag: String, blake3: String },
+    Output { flag: String, blake3: String },
+}
+
+/// Accumulates an invocation, then writes it into a `RunManifest` (claim) and/or
+/// reconstructs an argv for re-execution.
+#[derive(Debug)]
+pub struct CommandCapture {
+    subcommand: String,
+    tokens: Vec<Token>,
+    inputs: Vec<FileHash>,
+    outputs: Vec<FileHash>,
+}
+
+impl CommandCapture {
+    /// Start capturing an invocation of `subcommand` (e.g. `"variants"`).
+    pub fn new(subcommand: impl Into<String>) -> Self {
+        Self {
+            subcommand: subcommand.into(),
+            tokens: Vec::new(),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        }
+    }
+
+    /// A content-addressed input operand; hashes the file and records it.
+    pub fn input(&mut self, flag: &str, path: &Path) -> std::io::Result<&mut Self> {
+        let h = blake3_file(path)?;
+        Ok(self.input_hashed(flag, &path.display().to_string(), &h))
+    }
+
+    /// A content-addressed output operand; hashes the file and records it.
+    pub fn output(&mut self, flag: &str, path: &Path) -> std::io::Result<&mut Self> {
+        let h = blake3_file(path)?;
+        Ok(self.output_hashed(flag, &path.display().to_string(), &h))
+    }
+
+    /// Input operand with a precomputed hash (when the caller already hashed it, and in
+    /// tests). `path` is recorded into `inputs[]` for humans / `verify` to re-hash.
+    pub fn input_hashed(&mut self, flag: &str, path: &str, blake3: &str) -> &mut Self {
+        self.inputs.push(FileHash {
+            path: path.to_string(),
+            blake3: blake3.to_string(),
+        });
+        self.tokens.push(Token::Input {
+            flag: flag.to_string(),
+            blake3: blake3.to_string(),
+        });
+        self
+    }
+
+    /// Output operand with a precomputed hash.
+    pub fn output_hashed(&mut self, flag: &str, path: &str, blake3: &str) -> &mut Self {
+        self.outputs.push(FileHash {
+            path: path.to_string(),
+            blake3: blake3.to_string(),
+        });
+        self.tokens.push(Token::Output {
+            flag: flag.to_string(),
+            blake3: blake3.to_string(),
+        });
+        self
+    }
+
+    /// An option with a value, e.g. `("--max-depth", 1000)`.
+    pub fn opt(&mut self, flag: &str, value: impl ToString) -> &mut Self {
+        self.tokens
+            .push(Token::Opt(flag.to_string(), value.to_string()));
+        self
+    }
+
+    /// A bare flag, e.g. `"--enforce"`.
+    pub fn flag(&mut self, flag: &str) -> &mut Self {
+        self.tokens.push(Token::Flag(flag.to_string()));
+        self
+    }
+
+    /// Record `flag` only when `cond` (so a `false` boolean leaves no trace).
+    pub fn flag_if(&mut self, cond: bool, flag: &str) -> &mut Self {
+        if cond {
+            self.flag(flag)
+        } else {
+            self
+        }
+    }
+
+    /// Render the normalized, machine-independent command string. Canonical order:
+    /// subcommand, then input operands (in order added), then options sorted by flag,
+    /// then bare flags sorted, then output operands — so it is stable run-to-run.
+    fn render_command(&self) -> String {
+        let mut parts: Vec<String> = vec![self.subcommand.clone()];
+        for t in &self.tokens {
+            if let Token::Input { flag, blake3 } = t {
+                parts.push(flag.clone());
+                parts.push(format!("@in:{blake3}"));
+            }
+        }
+        let mut opts: Vec<(&String, &String)> = self
+            .tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::Opt(f, v) => Some((f, v)),
+                _ => None,
+            })
+            .collect();
+        opts.sort_by(|a, b| a.0.cmp(b.0));
+        for (f, v) in opts {
+            parts.push(f.clone());
+            parts.push(v.clone());
+        }
+        let mut flags: Vec<&String> = self
+            .tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::Flag(f) => Some(f),
+                _ => None,
+            })
+            .collect();
+        flags.sort();
+        for f in flags {
+            parts.push(f.clone());
+        }
+        for t in &self.tokens {
+            if let Token::Output { flag, blake3 } = t {
+                parts.push(flag.clone());
+                parts.push(format!("@out:{blake3}"));
+            }
+        }
+        parts.join(" ")
+    }
+
+    /// Write the capture into a manifest's claim: the `command` recipe, the derived
+    /// `inputs[]`/`outputs[]`, the discrete params (mechanical flag→key projection), and
+    /// the inferred `mode`. Call before `finalize()`. Measurement fields remain the
+    /// caller's responsibility (recorded separately, relocated by `finalize`).
+    pub fn record_into(self, m: &mut RunManifest) {
+        m.params.insert("command".to_string(), self.render_command());
+        for t in &self.tokens {
+            match t {
+                Token::Opt(f, v) => {
+                    m.params.insert(flag_to_key(f), v.clone());
+                }
+                Token::Flag(f) => {
+                    m.params.insert(flag_to_key(f), "true".to_string());
+                }
+                _ => {}
+            }
+        }
+        let has = |want: &str| {
+            self.tokens
+                .iter()
+                .any(|t| matches!(t, Token::Input { flag, .. } if flag == want))
+        };
+        if has("--index") {
+            m.params.insert("mode".to_string(), "index".to_string());
+        } else if has("--reference") {
+            m.params.insert("mode".to_string(), "reference".to_string());
+        }
+        m.inputs = self.inputs;
+        m.outputs = self.outputs;
+    }
+
+    /// Reconstruct an argv from a recorded `command`: substitute each `@in:<h>` with the
+    /// located input path and each `@out:<h>` with a caller-supplied temp path. Errors
+    /// (naming the hash) if an input cannot be located.
+    pub fn argv_from_command(
+        command: &str,
+        locate_input: &dyn Fn(&str) -> Option<String>,
+        temp_output: &dyn Fn(&str) -> String,
+    ) -> Result<Vec<String>, String> {
+        let mut argv = Vec::new();
+        for tok in command.split(' ') {
+            if let Some(h) = tok.strip_prefix("@in:") {
+                match locate_input(h) {
+                    Some(p) => argv.push(p),
+                    None => return Err(format!("input not located by content hash @in:{h}")),
+                }
+            } else if let Some(h) = tok.strip_prefix("@out:") {
+                argv.push(temp_output(h));
+            } else {
+                argv.push(tok.to_string());
+            }
+        }
+        Ok(argv)
+    }
+}
+
+/// Mechanical `--max-depth` → `max_depth` projection (strip leading dashes,
+/// dashes → underscores). Deterministic; no per-flag config.
+fn flag_to_key(flag: &str) -> String {
+    flag.trim_start_matches('-').replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::RunManifest;
+
+    // Build a capture WITHOUT touching the filesystem by injecting hashes directly.
+    fn sample() -> CommandCapture {
+        let mut c = CommandCapture::new("variants");
+        c.input_hashed("--index", "ref.idx", "h_idx");
+        c.input_hashed("--alignments", "s.bam", "h_bam");
+        c.opt("--mapq-threshold", 20u8);
+        c.opt("--max-depth", 1000u32);
+        c.flag_if(true, "--enforce");
+        c.flag_if(false, "--gvcf");
+        c.opt("--memory-budget-mb", 256u64);
+        c.output_hashed("-o", "out.vcf", "h_out");
+        c
+    }
+
+    #[test]
+    fn record_into_writes_command_inputs_outputs_and_discrete_params() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+
+        assert_eq!(
+            m.params.get("command").unwrap(),
+            "variants --index @in:h_idx --alignments @in:h_bam \
+             --mapq-threshold 20 --max-depth 1000 --memory-budget-mb 256 --enforce -o @out:h_out"
+        );
+        assert_eq!(
+            m.inputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(),
+            ["h_idx", "h_bam"]
+        );
+        assert_eq!(
+            m.outputs.iter().map(|f| f.blake3.as_str()).collect::<Vec<_>>(),
+            ["h_out"]
+        );
+        assert_eq!(m.params.get("mapq_threshold").unwrap(), "20");
+        assert_eq!(m.params.get("max_depth").unwrap(), "1000");
+        assert_eq!(m.params.get("memory_budget_mb").unwrap(), "256");
+        assert_eq!(m.params.get("enforce").unwrap(), "true");
+        assert_eq!(m.params.get("mode").unwrap(), "index");
+        assert!(!m.params.contains_key("gvcf"));
+    }
+
+    #[test]
+    fn argv_roundtrips_from_the_recorded_command() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+        let command = m.params.get("command").unwrap();
+
+        let locate = |h: &str| match h {
+            "h_idx" => Some("/data/ref.idx".to_string()),
+            "h_bam" => Some("/data/s.bam".to_string()),
+            _ => None,
+        };
+        let out_temp = |_h: &str| "/tmp/out.vcf".to_string();
+        let argv = CommandCapture::argv_from_command(command, &locate, &out_temp).unwrap();
+
+        assert_eq!(
+            argv,
+            vec![
+                "variants",
+                "--index",
+                "/data/ref.idx",
+                "--alignments",
+                "/data/s.bam",
+                "--mapq-threshold",
+                "20",
+                "--max-depth",
+                "1000",
+                "--memory-budget-mb",
+                "256",
+                "--enforce",
+                "-o",
+                "/tmp/out.vcf",
+            ]
+        );
+    }
+
+    #[test]
+    fn argv_errors_when_an_input_cannot_be_located() {
+        let mut m = RunManifest::new("variants");
+        sample().record_into(&mut m);
+        let command = m.params.get("command").unwrap();
+        let locate = |_h: &str| None;
+        let out_temp = |_h: &str| "/tmp/out.vcf".to_string();
+        let err = CommandCapture::argv_from_command(command, &locate, &out_temp).unwrap_err();
+        assert!(err.contains("h_idx"), "error names the unresolved input hash: {err}");
+    }
+}

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -26,6 +26,9 @@ pub use command::CommandCapture;
 mod repro;
 pub use repro::{ReproOutput, ReproReceipt};
 
+mod badge;
+pub use badge::{badge_json, badge_svg};
+
 /// Current receipt/feature schema version. Bump on any breaking schema change.
 /// v2: split into a deterministic *claim* and a machine-dependent *measurement* block;
 /// the self-hash (`manifest_blake3`) covers the claim only. v3: the claim hashes

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -595,6 +595,183 @@ pub fn blake3_file(path: &Path) -> io::Result<String> {
     Ok(hasher.finalize().to_hex().to_string())
 }
 
+/// Options for [`verify_receipt`] beyond the receipt text itself.
+#[derive(Debug, Default)]
+pub struct VerifyOpts {
+    /// Budget (MiB) to check the recorded peak against (overrides the recorded one).
+    pub budget_mb: Option<u64>,
+    /// Assert the receipt was built from exactly this commit SHA (prefix match).
+    pub expect_code: Option<String>,
+    /// Re-hash the files at the recorded input/output paths and check their digests.
+    pub rehash_files: bool,
+}
+
+/// The outcome of [`verify_receipt`]: failures (empty == ok), informational notes, and
+/// the parsed manifest (when parsing succeeded).
+#[derive(Debug)]
+pub struct VerifyReport {
+    /// Whether the receipt passed every check.
+    pub ok: bool,
+    /// Human-readable failures (empty when `ok`).
+    pub problems: Vec<String>,
+    /// Informational, non-failing notes (e.g. "peak within budget").
+    pub notes: Vec<String>,
+    /// The parsed manifest, when parsing succeeded.
+    pub manifest: Option<RunManifest>,
+}
+
+/// Check a receipt's internal integrity — self-hashes, cross-field consistency, optional
+/// budget + expected-code — and, when `opts.rehash_files`, re-hash recorded files. The
+/// single source of truth shared by the `verify` CLI and `reproduce` (and a future WASM
+/// verifier) so they cannot drift.
+pub fn verify_receipt(text: &str, opts: &VerifyOpts) -> VerifyReport {
+    let manifest = match RunManifest::from_canonical_json(text) {
+        Ok(m) => m,
+        Err(e) => {
+            return VerifyReport {
+                ok: false,
+                problems: vec![format!("parse error: {e}")],
+                notes: Vec::new(),
+                manifest: None,
+            }
+        }
+    };
+    let mut problems: Vec<String> = Vec::new();
+    let mut notes: Vec<String> = Vec::new();
+
+    // Re-hash inputs + outputs against the recorded digests (CLI sets this).
+    if opts.rehash_files {
+        for (kind, files) in [("input", &manifest.inputs), ("output", &manifest.outputs)] {
+            for f in files {
+                match blake3_file(Path::new(&f.path)) {
+                    Ok(h) if h == f.blake3 => {}
+                    Ok(h) => problems.push(format!(
+                        "{kind} {} hash mismatch: recorded {}, now {}",
+                        f.path, f.blake3, h
+                    )),
+                    Err(e) => problems.push(format!("{kind} {} unreadable: {e}", f.path)),
+                }
+            }
+        }
+    }
+
+    // Strictly parse the numeric fields. A PRESENT-but-unparseable field is corruption,
+    // not absence. `get_recorded` reads measurements (v2) or params (pre-v2) uniformly.
+    let parse_num = |k: &str, problems: &mut Vec<String>| -> Option<u64> {
+        match manifest.get_recorded(k) {
+            None => None,
+            Some(v) => match v.parse::<u64>() {
+                Ok(n) => Some(n),
+                Err(_) => {
+                    problems.push(format!("malformed numeric field {k}: {v:?}"));
+                    None
+                }
+            },
+        }
+    };
+    let recorded_peak = parse_num("peak_rss_bytes", &mut problems);
+    let recorded_ws = parse_num("max_working_set_bytes", &mut problems);
+    let recorded_budget = parse_num("memory_budget_mb", &mut problems);
+
+    // Re-check the recorded realized peak against the budget (CLI overrides manifest).
+    let budget_mb = opts.budget_mb.or(recorded_budget);
+    match (budget_mb, recorded_peak) {
+        (Some(mb), Some(peak)) => {
+            if crate::core::MemoryBudget::from_mb(mb).admits(peak) {
+                notes.push(format!(
+                    "peak {} MiB within budget {mb} MiB",
+                    peak / (1 << 20)
+                ));
+            } else {
+                problems.push(format!(
+                    "recorded peak {} MiB exceeded budget {mb} MiB",
+                    peak / (1 << 20)
+                ));
+            }
+        }
+        (None, _) => notes.push("no budget to check (none supplied or recorded)".to_string()),
+        (Some(_), None) => problems.push("manifest has no recorded peak_rss_bytes".to_string()),
+    }
+
+    // Internal-consistency cross-checks: the working set cannot exceed peak RSS.
+    if let (Some(ws), Some(peak)) = (recorded_ws, recorded_peak) {
+        if ws > peak {
+            problems.push(format!(
+                "internally inconsistent: max_working_set_bytes ({ws}) exceeds peak_rss_bytes ({peak})"
+            ));
+        }
+    }
+    // A recorded verdict must agree with the recorded peak vs the recorded budget.
+    if let (Some(verdict), Some(mb), Some(peak)) = (
+        manifest
+            .get_recorded("contract_verdict")
+            .map(String::as_str),
+        recorded_budget,
+        recorded_peak,
+    ) {
+        let actually_within = crate::core::MemoryBudget::from_mb(mb).admits(peak);
+        if verdict == "within" && !actually_within {
+            problems.push(format!(
+                "internally inconsistent: contract_verdict='within' but recorded peak {} MiB \
+                 exceeds recorded budget {mb} MiB",
+                peak / (1 << 20)
+            ));
+        }
+        if verdict == "over" && actually_within {
+            problems.push(format!(
+                "internally inconsistent: contract_verdict='over' but recorded peak {} MiB \
+                 is within recorded budget {mb} MiB",
+                peak / (1 << 20)
+            ));
+        }
+    }
+
+    // Claim self-hash: catches any post-write edit to the claim. A pre-1.2 receipt has none.
+    match manifest.self_hash_ok() {
+        Some(true) => {}
+        Some(false) => problems.push(
+            "manifest_blake3 mismatch: the receipt was modified after it was written".to_string(),
+        ),
+        None => {
+            notes.push("no manifest_blake3 (a pre-1.2 receipt); skipping self-hash".to_string())
+        }
+    }
+
+    // Measurement self-hash: catches an edit to a measured field the claim hash can't see.
+    match manifest.measurement_hash_ok() {
+        Some(true) => {}
+        Some(false) => problems.push(
+            "measurement_blake3 mismatch: a measured field was modified after the run".to_string(),
+        ),
+        None => {
+            if manifest.claims_measurements() {
+                problems.push(
+                    "measurement block missing: the claim records a measurement block but \
+                     the receipt has none (stripped after the run?)"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    // Build-identity: assert the receipt came from exactly the expected commit.
+    if let Some(expected) = &opts.expect_code {
+        let code_problems = manifest.check_expected_code(expected);
+        if code_problems.is_empty() {
+            notes.push(format!("code matches {expected} (clean build)"));
+        } else {
+            problems.extend(code_problems);
+        }
+    }
+
+    VerifyReport {
+        ok: problems.is_empty(),
+        notes,
+        manifest: Some(manifest),
+        problems,
+    }
+}
+
 /// Write `<output_path>.manifest.json` next to the output, returning its path.
 pub fn write_manifest(output_path: &Path, manifest: &RunManifest) -> io::Result<PathBuf> {
     let mut name = output_path.as_os_str().to_os_string();
@@ -609,6 +786,37 @@ pub fn write_manifest(output_path: &Path, manifest: &RunManifest) -> io::Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn verify_receipt_reports_a_tampered_claim() {
+        let mut m = RunManifest::new("variants");
+        m.inputs.push(FileHash {
+            path: "a".into(),
+            blake3: "aa".into(),
+        });
+        m.finalize();
+        // Flip a byte of a recorded input digest without re-sealing — the claim
+        // self-hash must catch it.
+        let text = m.to_canonical_json().replace("\"aa\"", "\"ab\"");
+        let report = verify_receipt(&text, &VerifyOpts::default());
+        assert!(!report.ok, "tampered claim must not verify");
+        assert!(
+            report
+                .problems
+                .iter()
+                .any(|p| p.contains("manifest_blake3")),
+            "{:?}",
+            report.problems
+        );
+    }
+
+    #[test]
+    fn verify_receipt_passes_a_clean_receipt() {
+        let mut m = RunManifest::new("variants");
+        m.finalize();
+        let report = verify_receipt(&m.to_canonical_json(), &VerifyOpts::default());
+        assert!(report.ok, "{:?}", report.problems);
+    }
 
     #[test]
     fn blake3_is_deterministic_and_sensitive() {

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -30,8 +30,10 @@ pub use command::CommandCapture;
 /// cross-machine content-address — the same data at different paths hashes identically.
 /// v4: the claim records build-identity (`code_git_sha`/`code_dirty`/`rustc_version`/
 /// `target_triple`/`deps_lock_blake3`), committing to exactly which code, toolchain, and
-/// dependencies produced the run.
-pub const MANIFEST_SCHEMA_VERSION: u32 = 4;
+/// dependencies produced the run. v5: the claim records a normalized, replayable
+/// `command` recipe (via [`CommandCapture`]) plus the discrete output-affecting params and
+/// `mode`, so `reproduce` can re-derive the exact invocation.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 5;
 
 /// Keys whose values are machine-/run-dependent measurements, not part of the
 /// deterministic claim. `finalize` relocates these out of `params` into the

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -23,6 +23,9 @@ use std::path::{Path, PathBuf};
 mod command;
 pub use command::CommandCapture;
 
+mod repro;
+pub use repro::{ReproOutput, ReproReceipt};
+
 /// Current receipt/feature schema version. Bump on any breaking schema change.
 /// v2: split into a deterministic *claim* and a machine-dependent *measurement* block;
 /// the self-hash (`manifest_blake3`) covers the claim only. v3: the claim hashes

--- a/src/provenance/mod.rs
+++ b/src/provenance/mod.rs
@@ -20,6 +20,9 @@ use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
+mod command;
+pub use command::CommandCapture;
+
 /// Current receipt/feature schema version. Bump on any breaking schema change.
 /// v2: split into a deterministic *claim* and a machine-dependent *measurement* block;
 /// the self-hash (`manifest_blake3`) covers the claim only. v3: the claim hashes

--- a/src/provenance/repro.rs
+++ b/src/provenance/repro.rs
@@ -1,0 +1,163 @@
+//! `ReproReceipt` — the reproduction certificate written by `rosalind reproduce`.
+//!
+//! A small, content-addressed attestation that an independent party re-derived a
+//! recorded result. It **chains to the original** by recording the parent receipt's
+//! `content_hash` (`parent_claim`): N certificates that name the same `parent_claim` are
+//! N independent confirmations — a serverless "reproducibility web".
+//!
+//! It is backed by a [`RunManifest`] (`subcommand = "reproduce"`) so it inherits the
+//! proven canonical-JSON + self-hash + build-identity machinery: the certificate is
+//! tamper-evident (a `manifest_blake3` self-hash), records the reproducing binary's
+//! build-identity for free (via `finalize`), is signing-ready for the later Ed25519
+//! track, and is itself checkable with `rosalind verify`.
+
+use super::{ManifestError, RunManifest};
+
+/// One output's recorded-vs-observed comparison, as carried by a certificate.
+#[derive(Debug, Clone)]
+pub struct ReproOutput {
+    /// Output role label (e.g. `output[0]`).
+    pub role: String,
+    /// The hash the original receipt recorded.
+    pub recorded_blake3: String,
+    /// The hash this reproduction observed.
+    pub observed_blake3: String,
+    /// Whether they matched.
+    pub matched: bool,
+}
+
+/// A reproduction certificate. Construct with [`ReproReceipt::build`]; serialize with
+/// [`ReproReceipt::to_canonical_json`]; reload with [`ReproReceipt::from_canonical_json`].
+#[derive(Debug, Clone)]
+pub struct ReproReceipt {
+    inner: RunManifest,
+}
+
+impl ReproReceipt {
+    /// Build (and seal) a certificate for one reproduction.
+    ///
+    /// `parent_claim` is the original receipt's `content_hash()`. `peak_rss_bytes` is the
+    /// reproducing machine's realized peak (a machine-dependent *measurement*, excluded
+    /// from the certificate's content-address); `declared_budget_mb` is the original's
+    /// declared budget. The reproducing binary's build-identity is stamped automatically.
+    pub fn build(
+        parent_claim: &str,
+        parent_subcommand: &str,
+        verdict: &str,
+        chain_depth: u32,
+        outputs: &[ReproOutput],
+        peak_rss_bytes: Option<u64>,
+        declared_budget_mb: Option<u64>,
+    ) -> Self {
+        let mut m = RunManifest::new("reproduce");
+        m.params
+            .insert("parent_claim".to_string(), parent_claim.to_string());
+        m.params.insert(
+            "parent_subcommand".to_string(),
+            parent_subcommand.to_string(),
+        );
+        m.params.insert("verdict".to_string(), verdict.to_string());
+        m.params
+            .insert("chain_depth".to_string(), chain_depth.to_string());
+        m.params
+            .insert("out_count".to_string(), outputs.len().to_string());
+        for (i, o) in outputs.iter().enumerate() {
+            m.params.insert(format!("out{i}_role"), o.role.clone());
+            m.params
+                .insert(format!("out{i}_recorded"), o.recorded_blake3.clone());
+            m.params
+                .insert(format!("out{i}_observed"), o.observed_blake3.clone());
+            m.params
+                .insert(format!("out{i}_matched"), o.matched.to_string());
+        }
+        if let Some(mb) = declared_budget_mb {
+            m.params
+                .insert("declared_budget_mb".to_string(), mb.to_string());
+        }
+        // The reproducing machine's peak is a measurement (excluded from the claim hash),
+        // so the certificate's content-address is cross-machine stable.
+        if let Some(peak) = peak_rss_bytes {
+            m.record_measurement("peak_rss_bytes", peak.to_string());
+        }
+        m.finalize(); // stamps reproducer build-identity, schema_version, the self-hash
+        Self { inner: m }
+    }
+
+    /// The certificate's canonical JSON (what `<manifest>.repro.json` holds).
+    pub fn to_canonical_json(&self) -> String {
+        self.inner.to_canonical_json()
+    }
+
+    /// Parse a certificate from its canonical JSON.
+    pub fn from_canonical_json(s: &str) -> Result<Self, ManifestError> {
+        Ok(Self {
+            inner: RunManifest::from_canonical_json(s)?,
+        })
+    }
+
+    /// Whether the certificate's self-hash matches (tamper-evidence).
+    pub fn self_hash_ok(&self) -> bool {
+        self.inner.self_hash_ok() == Some(true)
+    }
+
+    /// The parent receipt's `content_hash` this certificate chains to.
+    pub fn parent_claim(&self) -> Option<&str> {
+        self.inner.params.get("parent_claim").map(String::as_str)
+    }
+
+    /// The recorded verdict (`REPRODUCED` / `DIVERGED`).
+    pub fn verdict(&self) -> Option<&str> {
+        self.inner.params.get("verdict").map(String::as_str)
+    }
+
+    /// The chain depth (1 for a reproduction of an original run receipt).
+    pub fn chain_depth(&self) -> u32 {
+        self.inner
+            .params
+            .get("chain_depth")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_outputs() -> Vec<ReproOutput> {
+        vec![ReproOutput {
+            role: "output[0]".to_string(),
+            recorded_blake3: "h".to_string(),
+            observed_blake3: "h".to_string(),
+            matched: true,
+        }]
+    }
+
+    #[test]
+    fn certificate_self_hashes_and_roundtrips() {
+        let c = ReproReceipt::build(
+            "a1b2",
+            "variants",
+            "REPRODUCED",
+            1,
+            &sample_outputs(),
+            Some(22 * 1024 * 1024),
+            Some(256),
+        );
+        let json = c.to_canonical_json();
+        let back = ReproReceipt::from_canonical_json(&json).unwrap();
+        assert_eq!(back.parent_claim(), Some("a1b2"));
+        assert_eq!(back.verdict(), Some("REPRODUCED"));
+        assert_eq!(back.chain_depth(), 1);
+        assert!(back.self_hash_ok());
+    }
+
+    #[test]
+    fn tamper_breaks_the_self_hash() {
+        let c = ReproReceipt::build("a1b2", "variants", "REPRODUCED", 1, &[], None, None);
+        // Edit a claim field without re-sealing — the self-hash must catch it.
+        let json = c.to_canonical_json().replace("REPRODUCED", "DIVERGED");
+        let back = ReproReceipt::from_canonical_json(&json).unwrap();
+        assert!(!back.self_hash_ok());
+    }
+}

--- a/src/reproduce.rs
+++ b/src/reproduce.rs
@@ -1,0 +1,485 @@
+//! `reproduce` — re-derive a recorded result and compare it byte-for-byte. Standalone:
+//! filesystem + blake3 + subprocess only (no htslib). The verdict is over OUTPUT bytes;
+//! code / inputs / resource are diagnostic context. v1 supports the deterministic text
+//! outputs Rosalind emits (VCF, TSV); BAM/bgzf is reported INCONCLUSIVE, never a false
+//! DIVERGED.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::provenance::{blake3_file, CommandCapture, FileHash, RunManifest};
+
+/// The output-byte verdict. Exit codes are stable: a stranger's CI can branch on them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Every recorded output re-derived byte-identically.
+    Reproduced,
+    /// At least one output differs from what the receipt recorded.
+    Diverged,
+    /// Could not run the comparison (pre-schema-5, input not located, unsupported output).
+    Inconclusive,
+}
+
+impl Verdict {
+    /// The process exit code for this verdict (0 / 6 / 7).
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Verdict::Reproduced => 0,
+            Verdict::Diverged => 6,
+            Verdict::Inconclusive => 7,
+        }
+    }
+    /// The human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            Verdict::Reproduced => "REPRODUCED",
+            Verdict::Diverged => "DIVERGED",
+            Verdict::Inconclusive => "INCONCLUSIVE",
+        }
+    }
+}
+
+/// The result of comparing produced outputs against the recorded ones.
+#[derive(Debug)]
+pub struct Outcome {
+    /// REPRODUCED iff every recorded output matched; DIVERGED otherwise.
+    pub verdict: Verdict,
+    /// One human-readable line per mismatch (empty when REPRODUCED).
+    pub diffs: Vec<String>,
+}
+
+/// Pure: compare produced `(role, hash)` pairs against the recorded outputs. REPRODUCED
+/// iff every recorded output has a positional produced match; DIVERGED otherwise, naming
+/// each mismatch.
+pub fn classify_outputs(recorded: &[FileHash], produced: &[(String, String)]) -> Outcome {
+    let mut diffs = Vec::new();
+    for (i, rec) in recorded.iter().enumerate() {
+        match produced.get(i) {
+            Some((_, got)) if *got == rec.blake3 => {}
+            Some((role, got)) => {
+                diffs.push(format!("output {role}: recorded {} got {got}", rec.blake3))
+            }
+            None => diffs.push(format!(
+                "output {i}: recorded {} but not produced",
+                rec.blake3
+            )),
+        }
+    }
+    let verdict = if diffs.is_empty() {
+        Verdict::Reproduced
+    } else {
+        Verdict::Diverged
+    };
+    Outcome { verdict, diffs }
+}
+
+/// Per-output comparison detail (carried for the reproduction certificate).
+#[derive(Debug, Clone)]
+pub struct OutputCmp {
+    /// Output role label (e.g. `output[0]`).
+    pub role: String,
+    /// The hash the receipt recorded.
+    pub recorded: String,
+    /// The hash the re-derivation produced.
+    pub observed: String,
+    /// Whether they match.
+    pub matched: bool,
+}
+
+/// Machine-local resource observation of the re-run (explicitly NOT cross-machine).
+#[derive(Debug, Clone, Default)]
+pub struct ResourceHere {
+    /// Realized peak RSS of the re-run on this machine, if its receipt was readable.
+    pub peak_rss_bytes: Option<u64>,
+    /// The budget the original declared (MiB), if any.
+    pub declared_budget_mb: Option<u64>,
+    /// Whether the re-run's peak fit the declared budget here.
+    pub fit: Option<bool>,
+}
+
+/// The full result of a `reproduce` run: the printable report, the exit code, and the
+/// structured data the reproduction certificate is minted from.
+#[derive(Debug)]
+pub struct ReproReport {
+    /// `REPRODUCED` | `DIVERGED` | `INCONCLUSIVE` | `TAMPERED`.
+    pub verdict_label: String,
+    /// Process exit code: 0 | 6 | 7 | 5 (tamper).
+    pub exit_code: i32,
+    /// Aligned, human-readable report lines.
+    pub lines: Vec<String>,
+    /// The parent receipt's `content_hash()` — the cross-machine id the certificate chains to.
+    pub parent_claim: String,
+    /// The parent receipt's subcommand.
+    pub parent_subcommand: String,
+    /// Per-output comparison (populated for REPRODUCED / DIVERGED).
+    pub outputs: Vec<OutputCmp>,
+    /// Machine-local resource observation of the re-run.
+    pub resource_here: ResourceHere,
+    /// The build-identity of the binary that performed this reproduction.
+    pub reproducer_code: BTreeMap<String, String>,
+    /// True only for REPRODUCED / DIVERGED (an actual byte comparison happened).
+    pub compared: bool,
+}
+
+/// Output types `reproduce` can byte-compare in v1. BAM/bgzf is out of scope (a C zlib
+/// not captured by `deps_lock_blake3`).
+fn output_is_text(path: &str) -> bool {
+    let p = path.to_ascii_lowercase();
+    p.ends_with(".vcf") || p.ends_with(".tsv") || p.ends_with(".txt") || p.ends_with(".gvcf")
+}
+
+/// Build a content-hash → path index of every file directly under `inputs_dir`.
+fn index_inputs(inputs_dir: &Path) -> Result<BTreeMap<String, PathBuf>> {
+    let mut idx = BTreeMap::new();
+    let rd = std::fs::read_dir(inputs_dir)
+        .with_context(|| format!("failed to read --inputs dir {}", inputs_dir.display()))?;
+    for entry in rd {
+        let p = entry?.path();
+        if p.is_file() {
+            if let Ok(h) = blake3_file(&p) {
+                idx.entry(h).or_insert(p);
+            }
+        }
+    }
+    Ok(idx)
+}
+
+/// A fresh, unique temp directory for the re-run's outputs.
+fn make_temp_dir() -> Result<PathBuf> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let d = std::env::temp_dir().join(format!("rosalind-reproduce-{}-{n}", std::process::id()));
+    std::fs::create_dir_all(&d)
+        .with_context(|| format!("failed to create temp dir {}", d.display()))?;
+    Ok(d)
+}
+
+/// The build-identity of the *current* binary (the one performing the reproduction),
+/// read by finalizing a throwaway manifest (which stamps build-identity from `build.rs`).
+fn current_build_identity() -> BTreeMap<String, String> {
+    let mut m = RunManifest::new("reproduce-probe");
+    m.finalize();
+    let mut out = BTreeMap::new();
+    for k in [
+        "code_git_sha",
+        "code_dirty",
+        "rustc_version",
+        "target_triple",
+        "deps_lock_blake3",
+    ] {
+        if let Some(v) = m.params.get(k) {
+            out.insert(k.to_string(), v.clone());
+        }
+    }
+    out
+}
+
+/// Read `peak_rss_bytes` from the receipt the re-run wrote next to `output_temp`.
+fn read_rerun_peak(output_temp: &Path) -> Option<u64> {
+    let mut name = output_temp.as_os_str().to_os_string();
+    name.push(".manifest.json");
+    let text = std::fs::read_to_string(PathBuf::from(name)).ok()?;
+    let m = RunManifest::from_canonical_json(&text).ok()?;
+    m.get_recorded("peak_rss_bytes")
+        .and_then(|v| v.parse().ok())
+}
+
+/// Re-derive the result recorded in `manifest_path` from inputs content-located under
+/// `inputs_dir`, and compare byte-for-byte. See the module docs for scope.
+pub fn reproduce(manifest_path: &Path, inputs_dir: &Path) -> Result<ReproReport> {
+    let text = std::fs::read_to_string(manifest_path)
+        .with_context(|| format!("failed to read receipt {}", manifest_path.display()))?;
+    let manifest = RunManifest::from_canonical_json(&text)
+        .map_err(|e| anyhow!("malformed receipt {}: {e}", manifest_path.display()))?;
+
+    let parent_claim = manifest.content_hash();
+    let parent_subcommand = manifest.subcommand.clone();
+    let reproducer_code = current_build_identity();
+
+    let report =
+        |verdict_label: &str, exit_code: i32, lines: Vec<String>, compared: bool| ReproReport {
+            verdict_label: verdict_label.to_string(),
+            exit_code,
+            lines,
+            parent_claim: parent_claim.clone(),
+            parent_subcommand: parent_subcommand.clone(),
+            outputs: Vec::new(),
+            resource_here: ResourceHere::default(),
+            reproducer_code: reproducer_code.clone(),
+            compared,
+        };
+
+    // 1. Integrity gate (tamper-evidence). Budget-fit is verify's job, NOT reproduce's —
+    //    a receipt that honestly records an over-budget run is still reproducible.
+    if manifest.self_hash_ok() == Some(false) || manifest.measurement_hash_ok() == Some(false) {
+        return Ok(report(
+            "TAMPERED",
+            5,
+            vec![
+                "  the receipt's self-hash does not match — it was modified after it was written"
+                    .to_string(),
+                "  VERDICT     : TAMPERED".to_string(),
+            ],
+            false,
+        ));
+    }
+
+    // 2. Need a recorded command (schema >= 5) to replay.
+    let command = match manifest.params.get("command") {
+        Some(c) => c.clone(),
+        None => {
+            return Ok(report(
+                "INCONCLUSIVE",
+                7,
+                vec![
+                    "  pre-schema-5 receipt: no recorded command to replay".to_string(),
+                    "  VERDICT     : INCONCLUSIVE".to_string(),
+                ],
+                false,
+            ))
+        }
+    };
+
+    // 3. Supported, comparable outputs (text only in v1; at least one to compare).
+    if manifest.outputs.is_empty() {
+        return Ok(report(
+            "INCONCLUSIVE",
+            7,
+            vec![
+                "  receipt records no outputs to compare (e.g. a stdout run)".to_string(),
+                "  VERDICT     : INCONCLUSIVE".to_string(),
+            ],
+            false,
+        ));
+    }
+    if let Some(o) = manifest.outputs.iter().find(|o| !output_is_text(&o.path)) {
+        return Ok(report(
+            "INCONCLUSIVE",
+            7,
+            vec![
+                format!(
+                    "  output {} is not byte-comparable in v1 (BAM/bgzf rests on a C zlib outside the contract)",
+                    o.path
+                ),
+                "  VERDICT     : INCONCLUSIVE".to_string(),
+            ],
+            false,
+        ));
+    }
+
+    // 4. Content-locate inputs; bind outputs to fresh temp paths.
+    let index = index_inputs(inputs_dir)?;
+    let located = index.len();
+    let locate = |h: &str| index.get(h).map(|p| p.display().to_string());
+
+    let work = make_temp_dir()?;
+    let mut out_temp: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for (i, o) in manifest.outputs.iter().enumerate() {
+        let ext = Path::new(&o.path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("out");
+        out_temp.insert(o.blake3.clone(), work.join(format!("out_{i}.{ext}")));
+    }
+    let temp_output = |h: &str| {
+        out_temp
+            .get(h)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| work.join("out_unknown").display().to_string())
+    };
+
+    // 5. Reconstruct the argv; an unlocatable input is INCONCLUSIVE (not DIVERGED).
+    let argv = match CommandCapture::argv_from_command(&command, &locate, &temp_output) {
+        Ok(a) => a,
+        Err(e) => {
+            return Ok(report(
+                "INCONCLUSIVE",
+                7,
+                vec![
+                    format!("  cannot reproduce: {e}"),
+                    "  (pass --inputs pointing at a directory holding the recorded files)"
+                        .to_string(),
+                    "  VERDICT     : INCONCLUSIVE".to_string(),
+                ],
+                false,
+            ))
+        }
+    };
+
+    // 6. Re-execute the same binary.
+    let exe = std::env::current_exe().context("locating the rosalind binary to re-run")?;
+    let child = std::process::Command::new(&exe)
+        .args(&argv)
+        .output()
+        .context("re-running the recorded command")?;
+    if !child.status.success() {
+        return Ok(report(
+            "INCONCLUSIVE",
+            7,
+            vec![
+                format!(
+                    "  the re-run did not complete cleanly (exit {:?})",
+                    child.status.code()
+                ),
+                format!(
+                    "  stderr: {}",
+                    String::from_utf8_lossy(&child.stderr).trim()
+                ),
+                "  VERDICT     : INCONCLUSIVE".to_string(),
+            ],
+            false,
+        ));
+    }
+
+    // 7. Hash produced outputs and classify.
+    let mut produced: Vec<(String, String)> = Vec::new();
+    let mut cmps: Vec<OutputCmp> = Vec::new();
+    for (i, o) in manifest.outputs.iter().enumerate() {
+        let temp = out_temp
+            .get(&o.blake3)
+            .expect("temp path per recorded output");
+        let observed = blake3_file(temp).with_context(|| {
+            format!(
+                "the re-run did not produce the expected output {}",
+                temp.display()
+            )
+        })?;
+        produced.push((format!("output[{i}]"), observed.clone()));
+        cmps.push(OutputCmp {
+            role: format!("output[{i}]"),
+            recorded: o.blake3.clone(),
+            observed: observed.clone(),
+            matched: observed == o.blake3,
+        });
+    }
+    let outcome = classify_outputs(&manifest.outputs, &produced);
+
+    // 8. Machine-local resource + code context (diagnostic; never fatal).
+    let declared_budget_mb = manifest
+        .get_recorded("memory_budget_mb")
+        .and_then(|v| v.parse().ok());
+    let peak_here = manifest
+        .outputs
+        .first()
+        .and_then(|o| out_temp.get(&o.blake3))
+        .and_then(|p| read_rerun_peak(p));
+    let fit = match (peak_here, declared_budget_mb) {
+        (Some(peak), Some(mb)) => Some(crate::core::MemoryBudget::from_mb(mb).admits(peak)),
+        _ => None,
+    };
+    let resource_here = ResourceHere {
+        peak_rss_bytes: peak_here,
+        declared_budget_mb,
+        fit,
+    };
+
+    // 9. Build the report.
+    let recorded_sha = manifest.params.get("code_git_sha").map(String::as_str);
+    let here_sha = reproducer_code.get("code_git_sha").map(String::as_str);
+    let code_line = match (recorded_sha, here_sha) {
+        (Some(r), Some(h)) if r == h => format!("  code        : git {} — matches", short(h)),
+        (Some(r), Some(h)) => format!(
+            "  code        : git {} — DIFFERS from recorded {} (byte-match still counts)",
+            short(h),
+            short(r)
+        ),
+        _ => "  code        : (build-identity unavailable)".to_string(),
+    };
+
+    let mut lines = vec![
+        format!("  claim       : {} (re-derived)", short(&parent_claim)),
+        code_line,
+        format!("  inputs      : {located} file(s) indexed by content hash"),
+    ];
+    for c in &cmps {
+        if c.matched {
+            lines.push(format!(
+                "  output      : {}  OK byte-identical (blake3 {})",
+                c.role,
+                short(&c.observed)
+            ));
+        } else {
+            lines.push(format!(
+                "  output      : {}  DIVERGED (recorded {} got {})",
+                c.role,
+                short(&c.recorded),
+                short(&c.observed)
+            ));
+        }
+    }
+    if let (Some(peak), Some(mb)) = (
+        resource_here.peak_rss_bytes,
+        resource_here.declared_budget_mb,
+    ) {
+        lines.push(format!(
+            "  resource    : peak {} MiB vs declared {} MiB (here: this machine)",
+            peak / (1 << 20),
+            mb
+        ));
+    }
+    lines.push(format!("  VERDICT     : {}", outcome.verdict.label()));
+
+    // Clean up the temp work dir (best-effort).
+    std::fs::remove_dir_all(&work).ok();
+
+    Ok(ReproReport {
+        verdict_label: outcome.verdict.label().to_string(),
+        exit_code: outcome.verdict.exit_code(),
+        lines,
+        parent_claim,
+        parent_subcommand,
+        outputs: cmps,
+        resource_here,
+        reproducer_code,
+        compared: true,
+    })
+}
+
+/// First 10 hex chars of a digest for compact display.
+fn short(hex: &str) -> &str {
+    &hex[..hex.len().min(10)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provenance::FileHash;
+
+    fn fh(hash: &str) -> FileHash {
+        FileHash {
+            path: "x".into(),
+            blake3: hash.into(),
+        }
+    }
+
+    #[test]
+    fn classify_reproduced_when_all_outputs_match() {
+        let recorded = vec![fh("h1")];
+        let produced = vec![("o0".to_string(), "h1".to_string())];
+        let v = classify_outputs(&recorded, &produced);
+        assert!(matches!(v.verdict, Verdict::Reproduced));
+        assert!(v.diffs.is_empty());
+    }
+
+    #[test]
+    fn classify_diverged_names_the_first_mismatch() {
+        let recorded = vec![fh("h1")];
+        let produced = vec![("o0".to_string(), "DIFFERENT".to_string())];
+        let v = classify_outputs(&recorded, &produced);
+        assert!(matches!(v.verdict, Verdict::Diverged));
+        assert!(v
+            .diffs
+            .iter()
+            .any(|d| d.contains("h1") && d.contains("DIFFERENT")));
+    }
+
+    #[test]
+    fn exit_codes_are_stable() {
+        assert_eq!(Verdict::Reproduced.exit_code(), 0);
+        assert_eq!(Verdict::Diverged.exit_code(), 6);
+        assert_eq!(Verdict::Inconclusive.exit_code(), 7);
+    }
+}

--- a/tests/pack.rs
+++ b/tests/pack.rs
@@ -1,6 +1,6 @@
 //! `rosalind pack` — the contract's prediction turned into a placement decision.
-//! Each job's peak is read from its index header (no run); the schedule proves
-//! every node fits before any job launches, or refuses (exit 3).
+//! Each job's peak is read from its index header (no run); the schedule shows
+//! every node fits (by predicted peak) before any job launches, or refuses (exit 3).
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -39,7 +39,7 @@ fn build_index(dir: &std::path::Path, name: &str) -> PathBuf {
 }
 
 #[test]
-fn pack_proves_a_co_location_fits_and_refuses_when_it_cannot() {
+fn pack_shows_a_co_location_fits_and_refuses_when_it_cannot() {
     let dir = unique_dir("rosalind-pack");
     let a = build_index(&dir, "a");
     let b = build_index(&dir, "b");
@@ -54,7 +54,7 @@ fn pack_proves_a_co_location_fits_and_refuses_when_it_cannot() {
     )
     .unwrap();
 
-    // A generous node fits both jobs on one node, proven up front.
+    // A generous node fits both jobs on one node, shown up front.
     let out = Command::new(bin())
         .args(["pack", "--jobs"])
         .arg(&jobs)
@@ -64,8 +64,8 @@ fn pack_proves_a_co_location_fits_and_refuses_when_it_cannot() {
     assert!(out.status.success(), "generous node should pack: {out:?}");
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("every node proven within capacity"),
-        "missing proof line: {stdout}"
+        stdout.contains("every node within capacity by predicted peak"),
+        "missing capacity line: {stdout}"
     );
 
     // JSON form is machine-readable.

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -221,7 +221,7 @@ fn stdout_run_persists_a_self_describing_receipt() {
     let json = std::fs::read_to_string(&manifest).expect("manifest written");
     for needle in [
         "\"contract_verdict\":\"within\"",
-        "\"enforced\":\"true\"",
+        "\"enforce\":\"true\"",
         "\"max_depth\":\"1000\"",
         "\"memory_budget_mb\":\"4096\"",
         "\"peak_rss_bytes\":",
@@ -775,7 +775,7 @@ fn receipt_is_self_hashing_and_schema_versioned() {
         "no measurement self-hash: {text}"
     );
     assert!(
-        text.contains("\"schema_version\":\"4\""),
+        text.contains("\"schema_version\":\"5\""),
         "no schema_version: {text}"
     );
     // An untampered receipt verifies.

--- a/tests/reproduce.rs
+++ b/tests/reproduce.rs
@@ -1,0 +1,206 @@
+//! Track D gates: `rosalind reproduce` — third-party byte re-derivation from a receipt.
+//! Exercised through the real `index -> align -> sort -> variants -> reproduce` CLI
+//! pipeline (no rust-htslib dev-dependency). The DIVERGED classification is unit-tested
+//! in `reproduce::tests` (a same-binary same-input run cannot non-deterministically
+//! diverge by design); here we cover REPRODUCED + the INCONCLUSIVE preconditions.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rosalind")
+}
+
+fn tmpdir() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let d = env::temp_dir().join(format!("rosalind-repro-{nanos}-{n}"));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("spawn rosalind")
+}
+
+fn write_fasta(dir: &Path, name: &str, seq: &str) -> PathBuf {
+    let p = dir.join("ref.fa");
+    std::fs::write(&p, format!(">{name}\n{seq}\n")).unwrap();
+    p
+}
+
+fn write_fastq(dir: &Path, seq: &str, starts: &[usize], len: usize) -> PathBuf {
+    let p = dir.join("reads.fq");
+    let mut s = String::new();
+    for (i, &start) in starts.iter().enumerate() {
+        let read = &seq[start..start + len];
+        let qual: String = std::iter::repeat_n('I', len).collect();
+        s.push_str(&format!("@r{i}\n{read}\n+\n{qual}\n"));
+    }
+    std::fs::write(&p, s).unwrap();
+    p
+}
+
+/// `index` -> `align --format bam` -> `sort` -> `(idx, sorted.bam)`.
+fn build_index_and_sorted_bam(dir: &Path, fa: &Path, fq: &Path) -> (PathBuf, PathBuf) {
+    let idx = dir.join("ref.idx");
+    let raw = dir.join("raw.bam");
+    let sorted = dir.join("sorted.bam");
+    assert!(run(&[
+        "index",
+        "--reference",
+        fa.to_str().unwrap(),
+        "--output",
+        idx.to_str().unwrap()
+    ])
+    .status
+    .success());
+    assert!(run(&[
+        "align",
+        "--reference",
+        fa.to_str().unwrap(),
+        "--reads",
+        fq.to_str().unwrap(),
+        "--format",
+        "bam",
+        "--output",
+        raw.to_str().unwrap(),
+    ])
+    .status
+    .success());
+    assert!(run(&[
+        "sort",
+        "--input",
+        raw.to_str().unwrap(),
+        "--output",
+        sorted.to_str().unwrap()
+    ])
+    .status
+    .success());
+    (idx, sorted)
+}
+
+#[test]
+fn reproduces_a_variants_index_vcf_byte_for_byte() {
+    let dir = tmpdir();
+    let seq = "ACGTACGTACGTACGTACGTACGTACGTACGT";
+    let fa = write_fasta(&dir, "chr1", seq);
+    let fq = write_fastq(&dir, seq, &[0, 0, 8], 16);
+    let (idx, bam) = build_index_and_sorted_bam(&dir, &fa, &fq);
+    let vcf = dir.join("calls.vcf");
+
+    let made = run(&[
+        "variants",
+        "--index",
+        idx.to_str().unwrap(),
+        "--alignments",
+        bam.to_str().unwrap(),
+        "-o",
+        vcf.to_str().unwrap(),
+    ]);
+    assert!(
+        made.status.success(),
+        "make: {}",
+        String::from_utf8_lossy(&made.stderr)
+    );
+
+    let manifest = format!("{}.manifest.json", vcf.display());
+    let out = run(&[
+        "reproduce",
+        "--manifest",
+        &manifest,
+        "--inputs",
+        dir.to_str().unwrap(),
+    ]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "reproduce should exit 0 (REPRODUCED). stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("REPRODUCED"), "verdict line: {stdout}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn inconclusive_when_an_input_is_missing() {
+    let dir = tmpdir();
+    let seq = "ACGTACGTACGTACGTACGTACGTACGTACGT";
+    let fa = write_fasta(&dir, "chr1", seq);
+    let fq = write_fastq(&dir, seq, &[0, 0, 8], 16);
+    let (idx, bam) = build_index_and_sorted_bam(&dir, &fa, &fq);
+    let vcf = dir.join("calls.vcf");
+    assert!(run(&[
+        "variants",
+        "--index",
+        idx.to_str().unwrap(),
+        "--alignments",
+        bam.to_str().unwrap(),
+        "-o",
+        vcf.to_str().unwrap(),
+    ])
+    .status
+    .success());
+
+    // Point --inputs at an EMPTY dir → the recorded inputs cannot be content-located.
+    let empty = tmpdir();
+    let manifest = format!("{}.manifest.json", vcf.display());
+    let out = run(&[
+        "reproduce",
+        "--manifest",
+        &manifest,
+        "--inputs",
+        empty.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "missing input must be INCONCLUSIVE (exit 7)"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("INCONCLUSIVE"), "{stdout}");
+    assert!(
+        stdout.contains("not located"),
+        "names the unlocatable input: {stdout}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::remove_dir_all(&empty).ok();
+}
+
+#[test]
+fn inconclusive_on_a_pre_schema_5_receipt() {
+    let dir = tmpdir();
+    // A minimal, well-formed receipt with no recorded `command` (pre-schema-5 shape) and
+    // no manifest_blake3 (so the integrity gate notes-and-skips rather than failing).
+    let receipt = dir.join("old.manifest.json");
+    std::fs::write(
+        &receipt,
+        r#"{"inputs":[],"outputs":[{"blake3":"aa","path":"x.vcf"}],"params":{},"subcommand":"variants","tool_version":"0.1.0"}"#,
+    )
+    .unwrap();
+    let out = run(&[
+        "reproduce",
+        "--manifest",
+        receipt.to_str().unwrap(),
+        "--inputs",
+        dir.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "pre-schema-5 receipt must be INCONCLUSIVE"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("pre-schema-5"), "explains why: {stdout}");
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/reproduce.rs
+++ b/tests/reproduce.rs
@@ -129,6 +129,78 @@ fn reproduces_a_variants_index_vcf_byte_for_byte() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(stdout.contains("REPRODUCED"), "verdict line: {stdout}");
+
+    // A reproduction certificate is written next to the receipt, self-hashes, and
+    // chains to the original by its content hash.
+    let repro_path = format!("{manifest}.repro.json");
+    let cert_text = std::fs::read_to_string(&repro_path).expect("certificate written");
+    let cert = rosalind::provenance::ReproReceipt::from_canonical_json(&cert_text)
+        .expect("certificate parses");
+    assert!(cert.self_hash_ok(), "certificate self-hash must verify");
+    assert_eq!(cert.verdict(), Some("REPRODUCED"));
+    let orig = rosalind::provenance::RunManifest::from_canonical_json(
+        &std::fs::read_to_string(&manifest).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        cert.parent_claim(),
+        Some(orig.content_hash().as_str()),
+        "certificate chains to the original receipt's claim hash"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn independent_reproductions_share_a_parent_claim() {
+    let dir = tmpdir();
+    let seq = "ACGTACGTACGTACGTACGTACGTACGTACGT";
+    let fa = write_fasta(&dir, "chr1", seq);
+    let fq = write_fastq(&dir, seq, &[0, 0, 8], 16);
+    let (idx, bam) = build_index_and_sorted_bam(&dir, &fa, &fq);
+    let vcf = dir.join("calls.vcf");
+    assert!(run(&[
+        "variants",
+        "--index",
+        idx.to_str().unwrap(),
+        "--alignments",
+        bam.to_str().unwrap(),
+        "-o",
+        vcf.to_str().unwrap(),
+    ])
+    .status
+    .success());
+    let manifest = format!("{}.manifest.json", vcf.display());
+
+    // Two independent reproductions → two certificates naming the same parent_claim.
+    let c1 = dir.join("a.repro.json");
+    let c2 = dir.join("b.repro.json");
+    for c in [&c1, &c2] {
+        assert!(run(&[
+            "reproduce",
+            "--manifest",
+            &manifest,
+            "--inputs",
+            dir.to_str().unwrap(),
+            "-o",
+            c.to_str().unwrap(),
+        ])
+        .status
+        .success());
+    }
+    let p1 = rosalind::provenance::ReproReceipt::from_canonical_json(
+        &std::fs::read_to_string(&c1).unwrap(),
+    )
+    .unwrap();
+    let p2 = rosalind::provenance::ReproReceipt::from_canonical_json(
+        &std::fs::read_to_string(&c2).unwrap(),
+    )
+    .unwrap();
+    assert!(p1.parent_claim().is_some());
+    assert_eq!(
+        p1.parent_claim(),
+        p2.parent_claim(),
+        "independent confirmations share the parent_claim (the reproducibility web)"
+    );
     std::fs::remove_dir_all(&dir).ok();
 }
 

--- a/tests/variants_index.rs
+++ b/tests/variants_index.rs
@@ -252,3 +252,45 @@ fn variants_index_memory_budget_reports_and_never_refuses() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn variants_index_receipt_records_a_replayable_command() {
+    let dir = tmpdir();
+    let seq = "ACGTACGTACGTACGTACGTACGTACGTACGT";
+    let fa = write_fasta(&dir, "chr1", seq);
+    let fq = write_fastq(&dir, seq, &[0, 0, 8], 16);
+    let (idx, bam) = build_index_and_sorted_bam(&dir, &fa, &fq);
+    let vcf = dir.join("calls.vcf");
+    let out = run(&[
+        "variants",
+        "--index",
+        idx.to_str().unwrap(),
+        "--alignments",
+        bam.to_str().unwrap(),
+        "-o",
+        vcf.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "variants --index -o: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let man = std::fs::read_to_string(format!("{}.manifest.json", vcf.display()))
+        .expect("receipt written next to the VCF");
+    // schema-5 records a normalized, replayable command (closes the arg-recording gap).
+    assert!(
+        man.contains("\"command\":\"variants --index @in:"),
+        "records a replayable command recipe: {man}"
+    );
+    assert!(
+        man.contains("-o @out:"),
+        "records the output operand: {man}"
+    );
+    assert!(
+        man.contains("\"mode\":\"index\""),
+        "records the mode: {man}"
+    );
+    assert!(man.contains("\"schema_version\":\"5\""), "schema 5: {man}");
+    assert!(!man.contains("\"gvcf\""), "a false flag is omitted: {man}");
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Lands the **Track D reproducibility** work plus a **clarity + honesty language pass**, bringing `main` up to date with the documented `[Unreleased]` state.

### Track D — a stranger can re-derive your result
- **`rosalind reproduce`** — byte-for-byte re-derivation from a receipt + content-located inputs (REPRODUCED / DIVERGED / INCONCLUSIVE / TAMPERED; exit 0 / 6 / 7 / 5). BAM/bgzf reported INCONCLUSIVE, never a false DIVERGED.
- **Chainable reproduction certificate** (`<receipt>.repro.json`) — content-addressed, self-hashing, names the parent claim → N independent confirmations with no server.
- **Schema-5 receipts** carry a normalized, replayable `command` (one `CommandCapture` chokepoint).
- **`rosalind badge`** — self-hosted shields endpoint JSON + static SVG ("reproducible · fits N MiB"), no shields.io runtime dependency.
- **CI reproduce fence** — re-derives on the GitHub runner and confirms a byte-changed input is reported INCONCLUSIVE. `verify_receipt` extracted into the library (one source of truth for `verify` + `reproduce`).

### Clarity + honesty language pass
Lead with what Rosalind **is** (a verifiable memory contract; the receipt is the product, variant calling the first workload), and drop claims the code doesn't back:
- somatic "simple indels" → **SNV-only**; pack "PROVES … fits" → **"shows … within capacity by predicted peak"** (conservative additive bound + runtime governor, not a proof of realized RAM); "calibrated" → **genotype-likelihood / probabilistically grounded**; "reservoir" → **content-hash downsampling / bottom-k cap**; absolutist competitor claims → **substantiated mechanism claims**.
- `OPEN_PROBLEMS`: removed the stale nonexistent "theory layer (algebra/ledger/…)" reference; tense-marked never-refusing / graceful degradation as the **Phase-D aim** (aligns with `CONTRACT.md`).
- √t kept as the **research north star** (the index build is `O(reference)` today), not a shipped headline. Legitimate hash-equality "prove" (bit-reproducibility) retained.

## Verification
`cargo fmt --all -- --check` ✓ · `cargo clippy --all-targets --all-features -- -D warnings` ✓ · full test suite ✓ (213 unit + all integration, incl. the renamed pack tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
