### PR TITLE
chore(crate): publish-ready on crates.io as `rosalind-genomics` (binary/lib stay `rosalind`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "rosalind"
+name = "rosalind-genomics"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rosalind"
+name = "rosalind-genomics"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.83"
@@ -9,6 +9,29 @@ repository = "https://github.com/logannye/rosalind"
 license = "MIT OR Apache-2.0"
 keywords = ["genomics", "alignment", "variant-calling", "bioinformatics", "bwt", "fm-index"]
 categories = ["science::bioinformatics", "algorithms"]
+readme = "README.md"
+documentation = "https://docs.rs/rosalind-genomics"
+# Keep the published .crate lean: ship source + licenses, not demo data, artifacts,
+# or internal planning docs (all remain in the git repo).
+exclude = [
+    "results/",
+    "docs/superpowers/",
+    "docs/findings/",
+    "examples/data/",
+    "tests/snapshots/",
+    ".github/",
+]
+
+# Published as `rosalind-genomics` (the bare `rosalind` crate is an unrelated, dormant
+# 2016 package). The library and the installed binary are both named `rosalind`, so
+# `use rosalind::...` and the `rosalind` CLI are unchanged.
+[lib]
+name = "rosalind"
+path = "src/lib.rs"
+
+[[bin]]
+name = "rosalind"
+path = "src/main.rs"
 
 [dependencies]
 # OS bindings (read-only mmap of large reference/index files; peak-RSS readout)


### PR DESCRIPTION
**Wave 1.1 of [`docs/GROWTH.md`](https://github.com/logannye/rosalind/blob/main/docs/GROWTH.md) — the highest-leverage adoption lever for the Rust audience.**

`cargo install rosalind` today installs an unrelated, dormant 2016 crate ("Project Rosalind" exercises) — the name is squatted, so we can't publish under it and the Rust crowd that drove the HN spike has no idiomatic install. This makes the crate publishable:

- `[package] name = "rosalind-genomics"`, with `[lib] name = "rosalind"` + `[[bin]] name = "rosalind"` so **`use rosalind::...` and the `rosalind` CLI are unchanged** — source, tests, examples, `install.sh`, and the Action all keep working.
- `readme`/`documentation` metadata + an `exclude` list so the published `.crate` is **261 KiB compressed** (source + licenses only; no demo data / artifacts / internal docs).

**Verified:** `cargo build --all-targets` + full test suite green (213 unit + all integration); `cargo publish --dry-run` packages + verification-builds cleanly, no data leakage.

### ⚠️ Not merged / not published yet — your call on two things:
1. **Confirm the package name.** I used `rosalind-genomics` (descriptive, keeps the brand, binary stays `rosalind`). Trivially changeable until publish — say the word for a different name.
2. **Publish needs your crates.io token.** Once you're happy: `cargo login <token>` then `cargo publish` (the dry-run above is the same path, minus the upload). I'll then add the `cargo install rosalind-genomics` line + a "the bare `rosalind` crate is unrelated" note to the README, and (optionally) wire `cargo binstall`.

Publishing also locks the name and auto-builds docs.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
