### PR TITLE
ci: deploy the in-browser receipt verifier to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy verifier to Pages
+
+# Builds the in-browser "caught-you" receipt verifier (wasm) and publishes
+# web/verify/ to GitHub Pages, so it is a shareable link.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - "crates/receipt/**"
+      - "crates/receipt-wasm/**"
+      - "scripts/build-wasm-verifier.sh"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-progress run finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Add the wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+      - name: Build the verifier (wasm -> web/verify/pkg)
+        run: ./scripts/build-wasm-verifier.sh
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/verify
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Latest release](https://img.shields.io/github/v/release/logannye/rosalind?sort=semver&color=blue)](https://github.com/logannye/rosalind/releases/latest)
 [![Output: byte-reproducible](https://img.shields.io/badge/output-byte--reproducible-brightgreen)](CONTRACT.md)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](#license)
+[![Verify a receipt (live)](https://img.shields.io/badge/demo-verify%20a%20receipt-2f81f7)](https://logannye.github.io/rosalind/)
 
 **A deterministic, low-memory genomics engine in Rust, built around a different promise: memory is a contract — you see it before you commit, and verify it after.**
 
@@ -159,6 +160,8 @@ pack: 37 job(s) → 3 node(s) of 64000 MiB — every node within capacity by pre
 `rosalind plan --index ref.idx --budget-mb 64000 --json` emits the same predicted peak as one line of JSON for a workflow engine to read. This is what emergent-peak callers (GATK, DeepVariant) can't tell you up front: their peak is only known *after* a possible OOM-kill, so every co-location is a gamble. Here, `Packed` is a decision you can check before you launch — each node's summed *predicted* peak is `≤` its capacity, established up front, and the schedule is deterministic.
 
 ## Reproduce a result — a command a stranger can run
+
+> 🔍 **Try it in your browser:** [**verify a receipt live**](https://logannye.github.io/rosalind/) — drag in a `*.manifest.json` (or edit one byte of the bundled sample) and watch its tamper-evident hash flip to **TAMPERED**. 100% client-side, running the same Rust check that ships in the CLI, compiled to wasm.
 
 Hand someone a `*.vcf` and its `*.manifest.json`. On a *different machine*, with one offline command, they re-derive it byte-for-byte — no GATK, no Docker, no Nextflow, no re-aligning:
 


### PR DESCRIPTION
Builds the wasm verifier and publishes `web/verify/` to Pages on change → a shareable link at https://logannye.github.io/rosalind/ . Adds a live-demo badge + a reproduce-section callout to the README. Wave 1.3 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)