### PR TITLE
ci: add aarch64-unknown-linux-musl release target + installer support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Fully static Linux binary (no glibc/bzip2/lzma runtime dependency):
+          # Fully static Linux binaries (no glibc/bzip2/lzma runtime dependency):
           # the -sys crates build htslib/bzip2/lzma/zlib from bundled C source.
+          # Each builds NATIVELY on its arch's runner — no cross-compiler needed.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
           # macOS builds on Apple Silicon runners (macos-14, plentiful). The
           # aarch64 build is native; the x86_64 build is cross-compiled from arm64
           # (the SDK ships both arches; the cc crate adds `-arch x86_64`) so the
@@ -58,7 +61,9 @@ jobs:
       - name: Build (release, ${{ matrix.target }})
         env:
           # musl needs the musl C compiler for the bundled htslib/bzip2/lzma builds.
+          # On each musl runner `musl-gcc` is that arch's native musl compiler.
           CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
         run: cargo build --release --target ${{ matrix.target }} --bin rosalind
 
       - name: Stage the bundle

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,8 @@ case "$os" in
   Linux)
     case "$arch" in
       x86_64 | amd64) target="x86_64-unknown-linux-musl" ;;
-      *) die "unsupported Linux arch '$arch' (prebuilt: x86_64 only; build from source for others)" ;;
+      aarch64 | arm64) target="aarch64-unknown-linux-musl" ;;
+      *) die "unsupported Linux arch '$arch' (prebuilt: x86_64, aarch64; build from source for others)" ;;
     esac
     ;;
   Darwin)


### PR DESCRIPTION
An edge/field tool must install on ARM Linux. Adds a native `ubuntu-24.04-arm` build (no cross-compiler) + `install.sh` arch detection for aarch64/arm64. Windows deferred (htslib on MSVC is harder). Closes #54. Wave 1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)