### PR TITLE
ci(release): fix x86_64-linux-musl build (cmake + g++); defer aarch64-linux (#69)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
           # Each builds NATIVELY on its arch's runner — no cross-compiler needed.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-24.04-arm
+          # aarch64-unknown-linux-musl is deferred: rust-htslib 0.44.1 fails to compile
+          # on aarch64 (a c_char signedness mismatch, E0308 — an upstream bug). Tracked
+          # as a separate issue; re-add the runner once rust-htslib builds on aarch64.
           # macOS builds on Apple Silicon runners (macos-14, plentiful). The
           # aarch64 build is native; the x86_64 build is cross-compiled from arm64
           # (the SDK ships both arches; the cc crate adds `-arch x86_64`) so the
@@ -62,14 +63,11 @@ jobs:
       - name: Build (release, ${{ matrix.target }})
         env:
           # musl needs the musl C compiler for the bundled htslib/bzip2/lzma builds.
-          # On each musl runner `musl-gcc` is that arch's native musl compiler.
           CC_x86_64_unknown_linux_musl: musl-gcc
-          CC_aarch64_unknown_linux_musl: musl-gcc
           # hts-sys 2.2.0 forces libz-sys/zlib-ng, whose CMake build probes for a C++
           # compiler. zlib-ng's sources are C (built with the musl CC above); the host
-          # `g++` is the right arch on these NATIVE runners and satisfies CMake's probe.
+          # `g++` is the right arch on this native runner and satisfies CMake's probe.
           CXX_x86_64_unknown_linux_musl: g++
-          CXX_aarch64_unknown_linux_musl: g++
         run: cargo build --release --target ${{ matrix.target }} --bin rosalind
 
       - name: Stage the bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install musl toolchain (Linux)
+      - name: Install musl toolchain + cmake (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        # cmake: hts-sys 2.2.0 forces libz-sys/zlib-ng, whose build uses CMake.
+        run: sudo apt-get update && sudo apt-get install -y musl-tools cmake
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -64,6 +65,11 @@ jobs:
           # On each musl runner `musl-gcc` is that arch's native musl compiler.
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
+          # hts-sys 2.2.0 forces libz-sys/zlib-ng, whose CMake build probes for a C++
+          # compiler. zlib-ng's sources are C (built with the musl CC above); the host
+          # `g++` is the right arch on these NATIVE runners and satisfies CMake's probe.
+          CXX_x86_64_unknown_linux_musl: g++
+          CXX_aarch64_unknown_linux_musl: g++
         run: cargo build --release --target ${{ matrix.target }} --bin rosalind
 
       - name: Stage the bundle

--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ case "$os" in
   Linux)
     case "$arch" in
       x86_64 | amd64) target="x86_64-unknown-linux-musl" ;;
-      aarch64 | arm64) target="aarch64-unknown-linux-musl" ;;
-      *) die "unsupported Linux arch '$arch' (prebuilt: x86_64, aarch64; build from source for others)" ;;
+      # aarch64-linux prebuilt is deferred (rust-htslib aarch64 build bug) — build from source.
+      *) die "unsupported Linux arch '$arch' (prebuilt: x86_64; build from source for others)" ;;
     esac
     ;;
   Darwin)


### PR DESCRIPTION
x86_64-linux-musl had never built with htslib (v0.1.0 predated rust-htslib); hts-sys 2.2.0 forces libz-sys/zlib-ng (CMake + C++). Fixed with `cmake` + host `g++`. aarch64-linux deferred (#69, rust-htslib E0308). **Dry-run validated: x86_64-musl + both macOS green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)