### PR TITLE
feat(contract): predicted_working_set in the claim + offline soundness re-check in verify

### DIFF
--- a/crates/receipt/src/lib.rs
+++ b/crates/receipt/src/lib.rs
@@ -753,6 +753,32 @@ pub fn verify_receipt(text: &str, opts: &VerifyOpts) -> VerifyReport {
             ));
         }
     }
+
+    // Offline soundness re-check: the deterministic working-set PREDICTION must upper-bound the
+    // realized working set. Both are machine-independent (shared cost constants), so it is a true
+    // cross-machine claim — HARD under --enforce (the prediction is a guaranteed upper bound there:
+    // max_read_len is enforced at ingest, depth is always capped), advisory otherwise (a longer read
+    // on a record-only run can legitimately exceed the assumed max_read_len).
+    let predicted_ws = parse_num("predicted_working_set_bytes", &mut problems);
+    let enforced = manifest.params.get("enforce").map(String::as_str) == Some("true");
+    match (predicted_ws, recorded_ws) {
+        (Some(pred), Some(real)) if pred >= real => notes.push(format!(
+            "predicted working set {} MiB >= realized {} MiB",
+            pred / (1 << 20),
+            real / (1 << 20)
+        )),
+        (Some(pred), Some(real)) if enforced => problems.push(format!(
+            "unsound prediction: predicted working set {pred} bytes < realized {real} bytes (enforced run)"
+        )),
+        (Some(pred), Some(real)) => notes.push(format!(
+            "predicted working set {} MiB < realized {} MiB (advisory; run was not enforced)",
+            pred / (1 << 20),
+            real / (1 << 20)
+        )),
+        _ => notes.push(
+            "no predicted_working_set_bytes to re-check (a pre-soundness-check receipt)".to_string(),
+        ),
+    }
     // A recorded verdict must agree with the recorded peak vs the recorded budget.
     if let (Some(verdict), Some(mb), Some(peak)) = (
         manifest
@@ -1031,6 +1057,98 @@ mod tests {
         m.finalize();
         let report = verify_receipt(&m.to_canonical_json(), &VerifyOpts::default());
         assert!(report.ok, "{:?}", report.problems);
+    }
+
+    /// Build + finalize a receipt exercising the working-set soundness check.
+    fn soundness_receipt(
+        predicted: Option<&str>,
+        realized: Option<&str>,
+        enforced: bool,
+    ) -> String {
+        let mut m = RunManifest::new("variants");
+        if let Some(p) = predicted {
+            m.params
+                .insert("predicted_working_set_bytes".to_string(), p.to_string());
+        }
+        if let Some(r) = realized {
+            m.params
+                .insert("max_working_set_bytes".to_string(), r.to_string());
+        }
+        if enforced {
+            m.params.insert("enforce".to_string(), "true".to_string());
+        }
+        m.finalize();
+        m.to_canonical_json()
+    }
+
+    #[test]
+    fn soundness_ok_when_enforced_and_prediction_bounds_realized() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("2000000"), Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(report.ok, "{:?}", report.problems);
+        assert!(
+            report.notes.iter().any(|n| n.contains(">= realized")),
+            "{:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn soundness_fails_when_enforced_and_prediction_underbounds_realized() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("500000"), Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(!report.ok, "an enforced under-prediction must fail verify");
+        assert!(
+            report
+                .problems
+                .iter()
+                .any(|p| p.contains("unsound prediction")),
+            "{:?}",
+            report.problems
+        );
+    }
+
+    #[test]
+    fn soundness_is_advisory_when_not_enforced() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("500000"), Some("1000000"), false),
+            &VerifyOpts::default(),
+        );
+        assert!(
+            report.ok,
+            "a record-only under-prediction must NOT fail: {:?}",
+            report.problems
+        );
+        assert!(
+            report.notes.iter().any(|n| n.contains("advisory")),
+            "{:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn soundness_skipped_when_no_prediction_recorded() {
+        let report = verify_receipt(
+            &soundness_receipt(None, Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(
+            report.ok,
+            "a pre-change receipt must verify: {:?}",
+            report.problems
+        );
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|n| n.contains("no predicted_working_set_bytes")),
+            "{:?}",
+            report.notes
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-06-09-predicted-working-set-claim.md
+++ b/docs/superpowers/plans/2026-06-09-predicted-working-set-claim.md
@@ -1,0 +1,344 @@
+# predicted_working_set Claim + verify Soundness Re-check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the memory contract's core inequality — the prediction upper-bounds reality — a content-addressed, offline-auditable receipt property: record the deterministic `predicted_working_set_bytes` in the claim, and have `verify` re-check `predicted ≥ realized` offline (hard under `--enforce`, advisory otherwise).
+
+**Architecture:** Part 1 adds one claim param in `run_variants_index`'s receipt block, computed by the existing pure `estimate_variants_working_set` (no baseline → cross-machine stable; not in `MEASUREMENT_KEYS` → stays in the claim). Part 2 adds a four-arm match to `verify_receipt` that re-derives the inequality from the recorded claim + measurement, failing only an enforced violation. Pure-`std`; no schema bump.
+
+**Tech Stack:** Rust 1.83, the `rosalind-receipt` leaf crate (hand-rolled canonical JSON, `blake3`). Tests: `#[cfg(test)]` unit tests in the receipt crate + a CLI integration test in `tests/plan_enforce.rs` (`env!("CARGO_BIN_EXE_rosalind")`).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-predicted-working-set-claim-design.md`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/main.rs` | Modify `run_variants_index` receipt block (≈ line 2260, after the `max_working_set_bytes` insert) | Record `predicted_working_set_bytes` as a claim param |
+| `crates/receipt/src/lib.rs` | Modify `verify_receipt` (≈ line 755, after the `max_working_set ≤ peak_rss` check) + add unit tests in `#[cfg(test)] mod tests` | The offline soundness re-check |
+| `tests/plan_enforce.rs` | Append one integration test | Prove the field lands in the claim, is deterministic, and `verify` passes |
+
+**Key facts (verified in the code):**
+- `estimate_variants_working_set(largest_contig_len, max_depth, max_read_len) -> WorkingSet` is a pure fn at `src/call/plan.rs:23`; call it as `rosalind::call::plan::estimate_variants_working_set(...)` (same path style as the existing `predicted_peak_rss_bytes` use). `.bytes` is the `u64`.
+- In `run_variants_index`, `largest`, `max_depth`, `max_read_len` are all in scope at the receipt block.
+- `MEASUREMENT_KEYS` (`lib.rs:100`) does NOT include `predicted_working_set_bytes`, so it stays in the claim through `finalize()`.
+- In `verify_receipt`: `recorded_ws` (= `max_working_set_bytes`, `Option<u64>`) is already parsed (≈ line 725); `parse_num(key, &mut problems)` is the strict in-scope closure; `notes`/`problems` are the accumulators; `manifest.params.get("enforce")` reads the enforce flag (a claim param, set only under `--enforce`).
+
+---
+
+## Task 1: record `predicted_working_set_bytes` in the variants claim
+
+**Files:**
+- Modify: `src/main.rs` (`run_variants_index` receipt block, after `max_working_set_bytes`)
+- Test: `tests/plan_enforce.rs` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/plan_enforce.rs` (reuses the in-file `bin()`, `unique_dir`, `run`, and `build_big_contig_fixture` helpers):
+
+```rust
+#[test]
+fn variants_enforce_records_predicted_working_set_in_the_claim() {
+    use rosalind::provenance::RunManifest;
+
+    let (dir, idx, bam) = build_big_contig_fixture(1024 * 1024);
+
+    // Run the enforced call twice → two receipts. The deterministic working-set
+    // prediction must be identical (that determinism is what makes it a claim).
+    let run_once = |vcf: &std::path::Path| {
+        let out = Command::new(bin())
+            .args(["variants", "--index"])
+            .arg(&idx)
+            .arg("--alignments")
+            .arg(&bam)
+            .args(["--max-depth", "1000", "--max-read-len", "250"])
+            .args(["--memory-budget-mb", "512", "--enforce", "-o"])
+            .arg(vcf)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "enforced run failed: {out:?}");
+        let text = std::fs::read_to_string(format!("{}.manifest.json", vcf.display())).unwrap();
+        RunManifest::from_canonical_json(&text).unwrap()
+    };
+
+    let a = run_once(&dir.join("a.vcf"));
+    let b = run_once(&dir.join("b.vcf"));
+
+    // It is a CLAIM field (in params), not a measurement.
+    let pred_a = a
+        .params
+        .get("predicted_working_set_bytes")
+        .expect("predicted_working_set_bytes must be a claim param");
+    assert!(
+        !a.measurements.contains_key("predicted_working_set_bytes"),
+        "predicted_working_set_bytes must live in the claim, not the measurement block"
+    );
+    // Deterministic across runs (the cross-machine claim property).
+    assert_eq!(
+        pred_a,
+        b.params.get("predicted_working_set_bytes").unwrap(),
+        "the predicted working set must be identical across runs"
+    );
+
+    // The receipt verifies (an enforced run satisfies predicted >= realized).
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(dir.join("a.vcf.manifest.json"))
+        .output()
+        .unwrap();
+    assert!(
+        v.status.success(),
+        "verify must pass on the enforced receipt: {}",
+        String::from_utf8_lossy(&v.stderr)
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --test plan_enforce variants_enforce_records_predicted_working_set_in_the_claim`
+Expected: FAIL — `predicted_working_set_bytes must be a claim param` panics (the field is not recorded yet).
+
+- [ ] **Step 3: Record the claim param**
+
+In `src/main.rs`, in `run_variants_index`'s receipt block, find the `max_working_set_bytes` insert and add the new param immediately after it:
+
+```rust
+        manifest.params.insert(
+            "max_working_set_bytes".to_string(),
+            max_ws.bytes.to_string(),
+        );
+        // The deterministic working-set PREDICTION (index header + declared caps, no
+        // baseline) — a CLAIM field (not in MEASUREMENT_KEYS), so it is cross-machine
+        // stable and `verify` can re-check `predicted >= realized` offline.
+        manifest.params.insert(
+            "predicted_working_set_bytes".to_string(),
+            rosalind::call::plan::estimate_variants_working_set(largest, max_depth, max_read_len)
+                .bytes
+                .to_string(),
+        );
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --test plan_enforce variants_enforce_records_predicted_working_set_in_the_claim`
+Expected: PASS — the field is in `params` (not `measurements`), identical across runs, and `verify` exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs tests/plan_enforce.rs
+git commit -m "feat(contract): record predicted_working_set_bytes in the variants claim
+
+The deterministic working-set prediction (estimate_variants_working_set: index
+header + declared caps, no baseline) now lands in the content-addressed claim
+(not MEASUREMENT_KEYS), making the contract's prediction cross-machine stable
+and offline-auditable. Additive; schema unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: the offline soundness re-check in `verify_receipt`
+
+**Files:**
+- Modify: `crates/receipt/src/lib.rs` (`verify_receipt`, after the `max_working_set ≤ peak_rss` check; unit tests in `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+In `crates/receipt/src/lib.rs`, inside `#[cfg(test)] mod tests` (next to `verify_receipt_passes_a_clean_receipt`), add a helper and four tests:
+
+```rust
+    /// Build + finalize a receipt exercising the working-set soundness check.
+    fn soundness_receipt(predicted: Option<&str>, realized: Option<&str>, enforced: bool) -> String {
+        let mut m = RunManifest::new("variants");
+        if let Some(p) = predicted {
+            m.params
+                .insert("predicted_working_set_bytes".to_string(), p.to_string());
+        }
+        if let Some(r) = realized {
+            m.params
+                .insert("max_working_set_bytes".to_string(), r.to_string());
+        }
+        if enforced {
+            m.params.insert("enforce".to_string(), "true".to_string());
+        }
+        m.finalize();
+        m.to_canonical_json()
+    }
+
+    #[test]
+    fn soundness_ok_when_enforced_and_prediction_bounds_realized() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("2000000"), Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(report.ok, "{:?}", report.problems);
+        assert!(
+            report.notes.iter().any(|n| n.contains(">= realized")),
+            "{:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn soundness_fails_when_enforced_and_prediction_underbounds_realized() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("500000"), Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(!report.ok, "an enforced under-prediction must fail verify");
+        assert!(
+            report.problems.iter().any(|p| p.contains("unsound prediction")),
+            "{:?}",
+            report.problems
+        );
+    }
+
+    #[test]
+    fn soundness_is_advisory_when_not_enforced() {
+        let report = verify_receipt(
+            &soundness_receipt(Some("500000"), Some("1000000"), false),
+            &VerifyOpts::default(),
+        );
+        assert!(
+            report.ok,
+            "a record-only under-prediction must NOT fail: {:?}",
+            report.problems
+        );
+        assert!(
+            report.notes.iter().any(|n| n.contains("advisory")),
+            "{:?}",
+            report.notes
+        );
+    }
+
+    #[test]
+    fn soundness_skipped_when_no_prediction_recorded() {
+        let report = verify_receipt(
+            &soundness_receipt(None, Some("1000000"), true),
+            &VerifyOpts::default(),
+        );
+        assert!(report.ok, "a pre-change receipt must verify: {:?}", report.problems);
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|n| n.contains("no predicted_working_set_bytes")),
+            "{:?}",
+            report.notes
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p rosalind-receipt soundness_`
+Expected: FAIL — `soundness_fails_when_enforced_and_prediction_underbounds_realized` passes verify (no check yet) so its `assert!(!report.ok)` fails; the note-based assertions also fail (notes absent). The check is not implemented.
+
+- [ ] **Step 3: Implement the check**
+
+In `crates/receipt/src/lib.rs::verify_receipt`, immediately after the `max_working_set ≤ peak_rss` consistency block (the `if let (Some(ws), Some(peak)) = (recorded_ws, recorded_peak) { ... }`), insert:
+
+```rust
+    // Offline soundness re-check: the deterministic working-set PREDICTION must upper-bound the
+    // realized working set. Both are machine-independent (shared cost constants), so it is a true
+    // cross-machine claim — HARD under --enforce (the prediction is a guaranteed upper bound there:
+    // max_read_len is enforced at ingest, depth is always capped), advisory otherwise (a longer read
+    // on a record-only run can legitimately exceed the assumed max_read_len).
+    let predicted_ws = parse_num("predicted_working_set_bytes", &mut problems);
+    let enforced = manifest.params.get("enforce").map(String::as_str) == Some("true");
+    match (predicted_ws, recorded_ws) {
+        (Some(pred), Some(real)) if pred >= real => notes.push(format!(
+            "predicted working set {} MiB >= realized {} MiB",
+            pred / (1 << 20),
+            real / (1 << 20)
+        )),
+        (Some(pred), Some(real)) if enforced => problems.push(format!(
+            "unsound prediction: predicted working set {pred} bytes < realized {real} bytes (enforced run)"
+        )),
+        (Some(pred), Some(real)) => notes.push(format!(
+            "predicted working set {} MiB < realized {} MiB (advisory; run was not enforced)",
+            pred / (1 << 20),
+            real / (1 << 20)
+        )),
+        _ => notes.push(
+            "no predicted_working_set_bytes to re-check (a pre-soundness-check receipt)".to_string(),
+        ),
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p rosalind-receipt soundness_`
+Expected: PASS — all four `soundness_*` tests pass (OK+note / hard-fail+problem / advisory+note / skip+note).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/receipt/src/lib.rs
+git commit -m "feat(verify): offline re-check that predicted >= realized working set
+
+verify_receipt now re-derives the contract's core inequality from the recorded
+claim (predicted_working_set_bytes) + measurement (max_working_set_bytes): a
+hard FAIL (exit 5) on an enforced under-prediction, an advisory note on a
+record-only run, and a clean skip for pre-change receipts. Tamper-protected from
+both sides (claim self-hash + measurement self-hash).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: full gate + end-to-end smoke
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite + lint + format**
+
+Run:
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+Expected: PASS on all three. (If `cargo fmt --check` reports diffs, run `cargo fmt` and amend the last commit.)
+
+- [ ] **Step 2: End-to-end smoke — verify surfaces the soundness line**
+
+Run (a real enforced call, then read the receipt + run verify):
+```bash
+BIN=target/debug/rosalind; D=$(mktemp -d)
+printf '>chr1\n' > "$D/ref.fa"; head -c 1000000 /dev/zero | tr '\0' 'A' >> "$D/ref.fa"; echo >> "$D/ref.fa"
+printf '@r0\nAAAAAAAAAAAAAAAAAAAA\n+\nIIIIIIIIIIIIIIIIIIII\n' > "$D/reads.fq"
+$BIN index --reference "$D/ref.fa" --output "$D/ref.idx" >/dev/null 2>&1
+$BIN align --reference "$D/ref.fa" --reads "$D/reads.fq" --format bam --output "$D/raw.bam" >/dev/null 2>&1
+$BIN sort --input "$D/raw.bam" --output "$D/s.bam" >/dev/null 2>&1
+$BIN variants --index "$D/ref.idx" --alignments "$D/s.bam" --memory-budget-mb 512 --enforce -o "$D/c.vcf" >/dev/null 2>&1
+grep -o '"predicted_working_set_bytes":"[0-9]*"' "$D/c.vcf.manifest.json"
+$BIN verify --manifest "$D/c.vcf.manifest.json"
+rm -rf "$D"
+```
+Expected: the `grep` prints a `predicted_working_set_bytes` line (the field is in the claim), and `verify` prints a `predicted working set … >= realized …` line and exits 0.
+
+- [ ] **Step 3: No commit** (verification only; nothing changed).
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §4 record `predicted_working_set_bytes` in the claim (not in `MEASUREMENT_KEYS`, deterministic, no baseline) → **Task 1**.
+- §5 the four-arm `verify_receipt` check (OK note / hard-if-enforced / advisory / skip), reusing `recorded_ws`/`parse_num`, `enforce` from claim params, exit 5 via `problems` → **Task 2**.
+- §6 soundness argument → encoded as the enforced-vs-advisory split (Task 2 Step 3 + the two enforced/non-enforced unit tests).
+- §7 tests: unit OK/hard/advisory/skip → Task 2 Step 1; integration claim-location + determinism + verify-passes → Task 1 Step 1; gates → Task 3.
+- §8 non-goals (no peak-RSS hard check, no schema bump, don't move `max_working_set_bytes`, no `features`) → respected: only an additive claim param + a working-set-level check; nothing touches `predicted_peak_rss_bytes`, `MEASUREMENT_KEYS`, schema, or `features`.
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases". Every step has literal code or an exact command + expected result.
+
+**3. Type consistency:** `predicted_working_set_bytes` (claim param, string) is written in Task 1 and read in Task 2's check + tests + Task 1's integration test — same key everywhere. `estimate_variants_working_set(largest, max_depth, max_read_len).bytes` matches the real signature (`plan.rs:23`). `parse_num`, `recorded_ws`, `notes`, `problems`, `manifest.params` match the in-scope names in `verify_receipt`. The unit-test helper `soundness_receipt` builds via the documented `RunManifest` API (`new`/`params.insert`/`finalize`/`to_canonical_json`) used by the adjacent tests. MiB rendering uses `/ (1 << 20)` to match the file's existing style.

--- a/docs/superpowers/specs/2026-06-09-predicted-working-set-claim-design.md
+++ b/docs/superpowers/specs/2026-06-09-predicted-working-set-claim-design.md
@@ -1,0 +1,155 @@
+# Design: `predicted_working_set` as a claim + an offline soundness re-check in `verify`
+
+**Status:** Approved design — 2026-06-09. Companion to [`CONTRACT.md`](../../../CONTRACT.md) and
+[`docs/ROADMAP.md`](../../ROADMAP.md) (Phase-0 soundness spirit). Audience: the implementer.
+
+---
+
+## 1. The goal, in one sentence
+
+Make the memory contract's core inequality — **the prediction upper-bounds reality** — a
+**content-addressed, offline-auditable** property of the receipt, instead of only a runtime
+governor side-effect.
+
+## 2. Why this, why now
+
+The headline claim is *"predict your peak before you commit a byte."* Today `verify_receipt`
+(`crates/receipt/src/lib.rs`) re-checks `max_working_set ≤ peak_rss` and verdict-vs-budget
+consistency, but it **never re-checks the prediction against reality.** Soundness is asserted only
+*live* by the runtime governor and *in-process* by `tests/plan_enforce.rs` (which already proves
+`predicted ≥ realized`). The gap: a third party holding only the receipt **cannot re-prove** the
+prediction was sound — the deterministic half of the headline number isn't even in the
+content-addressed claim.
+
+Two facts in the code make this a clean, S-effort change:
+
+1. `estimate_variants_working_set(largest_contig_len, max_depth, max_read_len) -> WorkingSet`
+   (`src/call/plan.rs:23`) is **already a pure, deterministic function** of the index header +
+   declared caps, sharing cost constants with the realized accountant
+   (`PileupEngine::current_working_set`). It has **no baseline term**, so it is machine-independent.
+2. `MEASUREMENT_KEYS` (`crates/receipt/src/lib.rs:100`) =
+   `{peak_rss_bytes, max_working_set_bytes, predicted_peak_rss_bytes, baseline_rss_bytes,
+   rss_residual_bytes, governor, contract_verdict}`. A param **not** in that list stays in the
+   **claim** through `finalize()` — hash-protected and cross-machine stable.
+
+So the deterministic working-set prediction can become a claim field with no schema change, and
+`verify` can re-derive the inequality offline.
+
+## 3. Scope
+
+**In scope (this PR):**
+- Record `predicted_working_set_bytes` as a **claim** param in the `variants --index` receipt.
+- Add an offline re-check to `verify_receipt`: the prediction must upper-bound the realized working
+  set — **hard fail under `--enforce`, advisory note otherwise.**
+
+**Out of scope (named):**
+- `features --index` parity — it shares the estimator and is an identical ~1-line follow-on; kept
+  out to keep this PR focused (immediate fast-follow).
+- Promoting `max_working_set_bytes` from a measurement into the claim — it is data-deterministic,
+  but reclassifying it changes `content_hash()` and the reproduce/chain comparison surface; a
+  separate, riskier change.
+- Any hard check at the **peak-RSS** level — `predicted_peak_rss_bytes` folds in the measured
+  baseline + a fixed allocator-slack margin, so a hard `predicted_peak ≥ realized_peak` check would
+  false-fail; it stays a recorded advisory measurement.
+- No schema-version bump (the new claim field is additive).
+
+## 4. Part 1 — record `predicted_working_set_bytes` in the claim
+
+In `run_variants_index`'s receipt block (`src/main.rs`, alongside the existing
+`predicted_peak_rss_bytes` / `max_working_set_bytes` inserts), add one param. `largest`,
+`max_depth`, and `max_read_len` are already in scope (they feed `predicted_peak`):
+
+```rust
+manifest.params.insert(
+    "predicted_working_set_bytes".to_string(),
+    rosalind::call::plan::estimate_variants_working_set(largest, max_depth, max_read_len)
+        .bytes
+        .to_string(),
+);
+```
+
+- Deterministic (index header + declared caps), **no baseline** → cross-machine stable.
+- **Not** in `MEASUREMENT_KEYS`, so `finalize()` keeps it in the claim → covered by `manifest_blake3`,
+  part of `content_hash()`. The baseline-folded `predicted_peak_rss_bytes` stays a measurement.
+
+## 5. Part 2 — the offline check in `verify_receipt`
+
+In `crates/receipt/src/lib.rs::verify_receipt`, after the existing `max_working_set ≤ peak_rss`
+consistency check, add (reusing the already-parsed `recorded_ws` = `max_working_set_bytes` and the
+strict `parse_num` closure that flags a present-but-unparseable field):
+
+```rust
+// Offline soundness re-check: the deterministic working-set PREDICTION must upper-bound the
+// realized working set. Both are machine-independent (shared cost constants), so it is a true
+// cross-machine claim — HARD under --enforce (the prediction is a guaranteed upper bound there:
+// max_read_len is enforced at ingest, depth is always capped), advisory otherwise (a longer read
+// on a record-only run can legitimately exceed the assumed max_read_len).
+let predicted_ws = parse_num("predicted_working_set_bytes", &mut problems);
+let enforced = manifest.params.get("enforce").map(String::as_str) == Some("true");
+match (predicted_ws, recorded_ws) {
+    (Some(pred), Some(real)) if pred >= real => notes.push(format!(
+        "predicted working set {} MiB >= realized {} MiB",
+        pred >> 20,
+        real >> 20
+    )),
+    (Some(pred), Some(real)) if enforced => problems.push(format!(
+        "unsound prediction: predicted working set {pred} bytes < realized {real} bytes (enforced run)"
+    )),
+    (Some(pred), Some(real)) => notes.push(format!(
+        "predicted working set {} MiB < realized {} MiB (advisory; run was not enforced)",
+        pred >> 20,
+        real >> 20
+    )),
+    _ => notes.push(
+        "no predicted_working_set_bytes to re-check (a pre-soundness-check receipt)".to_string(),
+    ),
+}
+```
+
+- **Tamper-protected both ways:** the prediction lives in the claim (`manifest_blake3` catches
+  edits); the realized `max_working_set_bytes` lives in the measurement block (`measurement_blake3`
+  catches edits). A forger cannot lower either to fake a pass.
+- **`enforce`** is a claim param (recorded only when `--enforce`, via
+  `cmd.flag_if(enforce, "--enforce")`), so the hard/advisory split is itself hash-protected.
+- **Exit code:** a violation appends to `problems`, so `verify` exits **5** through its existing
+  path. No new exit code.
+- **Back-compat:** a pre-change receipt has no `predicted_working_set_bytes` → `parse_num` returns
+  `None` → the `_` arm records a skip note, never a false failure (the pre-1.2 self-hash-skip
+  pattern).
+
+## 6. Soundness argument (why hard-under-enforce is correct)
+
+Under `--enforce`: `max_read_len` is checked at ingest (a longer read aborts the run, exit 4), depth
+is always capped at `max_depth` by the pileup, and the contig term is bounded by the largest contig.
+The estimator and the realized accountant use the **same** per-base/per-read constants
+(`PILEUP_MAP_BYTES_PER_BASE`, `PILEUP_SEQQUAL_BYTES_PER_BASE`, `PILEUP_PER_READ_OVERHEAD`,
+`PILEUP_ENGINE_OVERHEAD`). Therefore `estimate_variants_working_set(...) ≥ realized working set` is a
+**true invariant** for an enforced run, and a violation is a genuine estimator/accountant bug worth
+failing on. Without `--enforce`, `max_read_len` is only an *assumption* (the run was record-only), so
+the same comparison is reported as advisory — failing it would punish a correct record-only run.
+
+## 7. Testing
+
+**Unit (`crates/receipt/src/lib.rs`, `verify_receipt`)** — build the manifest, then `finalize()` it
+so the claim self-hash is valid, then verify. *(The violation cases must be tested here, not via an
+integration receipt: editing a finalized receipt to violate the inequality would trip the self-hash
+first.)*
+- enforced + `predicted ≥ realized` → `ok`, the `>= realized` note present.
+- enforced + `predicted < realized` → **`ok == false`**, an `unsound prediction` problem present.
+- non-enforced + `predicted < realized` → `ok == true`, an `advisory` note (no problem).
+- no `predicted_working_set_bytes` → `ok == true`, the skip note (no false problem).
+
+**Integration (`tests/plan_enforce.rs`)** — through the real CLI:
+- `variants --index … --enforce -o calls.vcf` writes a receipt whose **claim** contains
+  `predicted_working_set_bytes`, and `verify` exits 0.
+- The recorded `predicted_working_set_bytes` is **byte-identical across two independent runs** (its
+  determinism is exactly what makes it a cross-machine claim).
+
+**Gates:** `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.
+
+## 8. Non-goals / guardrails (do not drift)
+
+- No hard check at the peak-RSS level (baseline-folded → false-fail landmine).
+- No schema bump; the new claim field is additive and pre-change receipts skip the check cleanly.
+- Do not move `max_working_set_bytes` into the claim in this PR.
+- `features` parity is a separate follow-on, not this PR.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2276,6 +2276,15 @@ fn run_variants_index(
             "io_rss_overhead_assumed_bytes".to_string(),
             PILEUP_IO_RSS_OVERHEAD.to_string(),
         );
+        // The deterministic working-set PREDICTION (index header + declared caps, no
+        // baseline) — a CLAIM field (not in MEASUREMENT_KEYS), so it is cross-machine
+        // stable and `verify` can re-check `predicted >= realized` offline.
+        manifest.params.insert(
+            "predicted_working_set_bytes".to_string(),
+            rosalind::call::plan::estimate_variants_working_set(largest, max_depth, max_read_len)
+                .bytes
+                .to_string(),
+        );
         manifest.params.insert(
             "over_max_depth".to_string(),
             skips.over_max_depth.to_string(),

--- a/tests/plan_enforce.rs
+++ b/tests/plan_enforce.rs
@@ -973,3 +973,61 @@ fn receipt_records_build_identity_and_verify_expect_code_catches_a_mismatch() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+#[test]
+fn variants_enforce_records_predicted_working_set_in_the_claim() {
+    use rosalind::provenance::RunManifest;
+
+    let (dir, idx, bam) = build_big_contig_fixture(1024 * 1024);
+
+    // Run the enforced call twice → two receipts. The deterministic working-set
+    // prediction must be identical (that determinism is what makes it a claim).
+    let run_once = |vcf: &std::path::Path| {
+        let out = Command::new(bin())
+            .args(["variants", "--index"])
+            .arg(&idx)
+            .arg("--alignments")
+            .arg(&bam)
+            .args(["--max-depth", "1000", "--max-read-len", "250"])
+            .args(["--memory-budget-mb", "512", "--enforce", "-o"])
+            .arg(vcf)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "enforced run failed: {out:?}");
+        let text = std::fs::read_to_string(format!("{}.manifest.json", vcf.display())).unwrap();
+        RunManifest::from_canonical_json(&text).unwrap()
+    };
+
+    let a = run_once(&dir.join("a.vcf"));
+    let b = run_once(&dir.join("b.vcf"));
+
+    // It is a CLAIM field (in params), not a measurement.
+    let pred_a = a
+        .params
+        .get("predicted_working_set_bytes")
+        .expect("predicted_working_set_bytes must be a claim param");
+    assert!(
+        !a.measurements.contains_key("predicted_working_set_bytes"),
+        "predicted_working_set_bytes must live in the claim, not the measurement block"
+    );
+    // Deterministic across runs (the cross-machine claim property).
+    assert_eq!(
+        pred_a,
+        b.params.get("predicted_working_set_bytes").unwrap(),
+        "the predicted working set must be identical across runs"
+    );
+
+    // The receipt verifies (an enforced run satisfies predicted >= realized).
+    let v = Command::new(bin())
+        .args(["verify", "--manifest"])
+        .arg(dir.join("a.vcf.manifest.json"))
+        .output()
+        .unwrap();
+    assert!(
+        v.status.success(),
+        "verify must pass on the enforced receipt: {}",
+        String::from_utf8_lossy(&v.stderr)
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Makes the memory contract's **headline inequality** — *the prediction upper-bounds reality* — a **content-addressed, offline-auditable** receipt property, instead of only a runtime governor side-effect. Until now `verify` re-checked `working_set ≤ peak` and verdict consistency, but **never re-checked the prediction against reality**; soundness was asserted only live (the governor) and in-process (`plan_enforce` tests). A third party holding just the receipt couldn't re-prove it.

**Part 1 — `predicted_working_set_bytes` in the claim.** `run_variants_index` now records the deterministic working-set prediction (`estimate_variants_working_set`: largest contig + depth-capped active set + engine overhead — **no baseline**, so machine-independent). It is **not** in `MEASUREMENT_KEYS`, so `finalize()` keeps it in the **claim** → covered by `manifest_blake3`, part of `content_hash()`, identical across machines. The baseline-folded `predicted_peak_rss_bytes` stays a measurement (it folds in the measured baseline + allocator slack — the false-fail quantity).

**Part 2 — the offline re-check in `verify_receipt`.** A four-arm check re-derives `predicted ≥ realized` from the recorded claim + measurement:
- **hard FAIL (exit 5)** on an `--enforce`d under-prediction (there it's a *true* invariant: `max_read_len` enforced at ingest, depth always capped, shared cost constants — a violation is a genuine estimator bug);
- **advisory note** on a record-only run (a longer read can legitimately exceed the assumed `max_read_len` — failing would punish a correct run);
- **clean skip** for pre-change receipts (additive; **no schema bump**).

Tamper-protected both ways: the prediction is in the claim (`manifest_blake3`), the realized working set is in the measurement block (`measurement_blake3`) — a forger can't lower either to fake a pass.

Live on a real enforced run:
```
"predicted_working_set_bytes":"5564256"          # in the claim
$ rosalind verify --manifest calls.vcf.manifest.json
verify: predicted working set 5 MiB >= realized 0 MiB
verify: OK
```

## Scope / non-goals (named)

- **Variants-only** this PR; `features --index` shares the estimator and is an identical ~1-line fast-follow.
- No hard check at the **peak-RSS** level (baseline-folded → false-fail landmine; stays advisory).
- `max_working_set_bytes` stays a measurement (reclassifying it would change `content_hash`/reproduce/chain — a separate change).

## What changed

- `src/main.rs`: one claim param in the variants receipt block (placed in the variants-unique region; sorted JSON keys make position irrelevant).
- `crates/receipt/src/lib.rs`: the four-arm soundness check in `verify_receipt` + 4 unit tests.
- `tests/plan_enforce.rs`: an integration test (field is in the claim not measurements, identical across two runs, `verify` exits 0).
- Spec + plan under `docs/superpowers/`.

## Test plan

- [x] `cargo test` — full suite green (4 new `soundness_*` unit tests + 1 integration test)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end smoke: claim field recorded; `verify` prints the `predicted working set … >= realized …` line and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)