### PR TITLE
fix: emit_all_positions — bounded, reference-complete coverage (the flagship example was silently wrong)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-emit-all-positions.md
+++ b/docs/superpowers/plans/2026-06-09-emit-all-positions.md
@@ -1,0 +1,233 @@
+# emit_all_positions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `PileupParams::emit_all_positions` flag (default `false`) so a per-locus analyzer reports zero-coverage loci, and fix the flagship ColumnKit coverage example to use it — without changing the memory bound.
+
+**Architecture:** The engine already walks the region position-by-position and builds a column at every position; line `engine.rs:407` suppresses the empty ones. The flag makes that suppression conditional (one line). It never touches `advance_to`/`self.active`, so `current_working_set()` is byte-identical with the flag on or off. The whole-genome driver already threads `params` through, so no driver change is needed.
+
+**Tech Stack:** Rust 1.83. The bounded `PileupColumn` kernel (`src/pileup/engine.rs`), the ColumnKit example (`examples/columnkit_coverage.rs`). Tests: `#[cfg(test)] mod tests` in `engine.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-emit-all-positions-design.md`.
+
+**Verified:** all 11 `PileupParams { … }` literals in the tree use `..PileupParams::default()` (or `..Default::default()`) spread, so adding a defaulted field is non-breaking.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/pileup/engine.rs` | Modify `PileupParams` (line 45) + its `Default` (line 67) + the suppression at line 407; add 2 unit tests + an `engine_emit_all` helper in `#[cfg(test)] mod tests` | The flag + the conditional emit |
+| `examples/columnkit_coverage.rs` | Modify the `run_bounded_whole_genome` call (≈ line 88) to pass `emit_all_positions: true` | Make the flagship coverage track reference-complete |
+
+---
+
+## Task 1: the `emit_all_positions` flag
+
+**Files:**
+- Modify: `src/pileup/engine.rs` (`PileupParams`, its `Default`, line 407; tests in `mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/pileup/engine.rs`, inside `#[cfg(test)] mod tests` (after the `engine` helper at line 446), add an `engine_emit_all` helper and two tests:
+
+```rust
+    fn engine_emit_all(reads: Vec<AlignedRead>, reference: &[u8]) -> PileupEngine<SliceSource> {
+        PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..reference.len() as u32,
+            PileupParams {
+                emit_all_positions: true,
+                ..PileupParams::default()
+            },
+        )
+    }
+
+    #[test]
+    fn emit_all_positions_reports_gaps_at_depth_zero() {
+        // Same fixture as `deletion_leaves_a_reference_gap_with_no_observation`:
+        // 2M1D2M at ref 0 over an 8 bp reference. Observed: 0,1,3,4. Gaps: 2 (deleted),
+        // 5,6,7 (uncovered). With emit_all_positions EVERY position emits — gaps depth 0.
+        let reference = b"AAAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(0),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Deletion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"GGGG".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        };
+        let cols = columns(engine_emit_all(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![0, 1, 2, 3, 4, 5, 6, 7], "every position emits");
+        for p in [2u32, 5, 6, 7] {
+            let col = cols.iter().find(|c| c.locus.pos.0 == p).unwrap();
+            assert_eq!(col.depth(), 0, "gap position {p} must be depth 0");
+        }
+    }
+
+    #[test]
+    fn emit_all_positions_preserves_the_working_set_bound() {
+        // The flag only decides whether an already-built column is returned; it never
+        // touches the active set, so the peak working set is identical on/off.
+        let reference = b"AAAAAAAA";
+        let reads = || vec![mread(0, b"GG", false), mread(3, b"GG", false)];
+        let peak = |mut e: PileupEngine<SliceSource>| -> u64 {
+            let mut p = e.current_working_set().bytes;
+            while let Some(c) = e.next() {
+                c.expect("column");
+                p = p.max(e.current_working_set().bytes);
+            }
+            p
+        };
+        let off = peak(engine(reads(), reference));
+        let on = peak(engine_emit_all(reads(), reference));
+        assert_eq!(off, on, "emit_all_positions must not change the working-set bound");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p rosalind-bio --lib pileup::engine::tests::emit_all 2>&1 | tail -20`
+Expected: FAIL — a compile error, `struct PileupParams has no field named emit_all_positions` (the field does not exist yet).
+
+- [ ] **Step 3: Add the field, its default, and honor it at line 407**
+
+In `src/pileup/engine.rs`, add the field to `PileupParams` (after `max_read_len`, line 64):
+
+```rust
+    /// When `true`, emit a column at EVERY reference position in the region, including
+    /// zero-coverage loci (depth 0) — for reference-complete per-locus analytics
+    /// (coverage/QC). Default `false` (covered loci only). The working-set bound is
+    /// unchanged: the empty column is already built at each position; this only decides
+    /// whether it is returned. A volume tradeoff — a region/panel opt-in, not a
+    /// whole-genome default.
+    pub emit_all_positions: bool,
+```
+
+Add the default to the `Default` impl (after `max_read_len: None,`, line 76):
+
+```rust
+            emit_all_positions: false,
+```
+
+Make the suppression at line 407 conditional:
+
+```rust
+            if self.params.emit_all_positions || !column.obs.is_empty() {
+                return Some(Ok(column));
+            }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p rosalind-bio --lib pileup::engine::tests::emit_all 2>&1 | tail -12`
+Expected: PASS — `emit_all_positions_reports_gaps_at_depth_zero` and `emit_all_positions_preserves_the_working_set_bound` both pass.
+
+- [ ] **Step 5: Confirm default behavior is unchanged**
+
+Run: `cargo test -p rosalind-bio --lib pileup::engine 2>&1 | tail -6`
+Expected: PASS — all existing engine tests (including `deletion_leaves_a_reference_gap_with_no_observation`, which asserts `vec![0, 1, 3, 4]` under default params) stay green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pileup/engine.rs
+git commit -m "feat(pileup): emit_all_positions — bounded reference-complete output
+
+PileupParams.emit_all_positions (default false) makes engine.next() emit a
+column at every reference position, including zero-coverage loci (depth 0), for
+reference-complete per-locus analytics. The working-set bound is unchanged: the
+empty column is already built at each position; the flag only decides whether it
+is returned (test-pinned). Non-breaking (all literals use ..Default).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: fix the flagship coverage example
+
+**Files:**
+- Modify: `examples/columnkit_coverage.rs` (the `run_bounded_whole_genome` call, ≈ line 88)
+
+- [ ] **Step 1: Set `emit_all_positions: true` in the example**
+
+In `examples/columnkit_coverage.rs`, replace the `run_bounded_whole_genome` call's `PileupParams::default()` argument:
+
+```rust
+    // emit_all_positions makes the coverage track REFERENCE-COMPLETE: every locus
+    // emits, so uncovered positions (here ref 12–15, which no read reaches) report
+    // depth 0 instead of being silently dropped. The memory bound is unchanged.
+    let (ws, _skips) = run_bounded_whole_genome(
+        &mut analyzer,
+        SliceSource::new(reads),
+        &ref_view,
+        contigs,
+        PileupParams {
+            emit_all_positions: true,
+            ..PileupParams::default()
+        },
+        &mut out,
+    )?;
+```
+
+- [ ] **Step 2: Run the example and confirm the zero-depth tail is reported**
+
+Run: `cargo run --quiet --example columnkit_coverage 2>/dev/null | grep -cE '\t(13|14|15|16)\t0$'`
+Expected: `4` — the 16 bp reference's uncovered tail (1-based positions 13–16, which no read reaches) now reports depth 0 (before this change, the example printed nothing for them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/columnkit_coverage.rs
+git commit -m "fix(example): coverage track reports zero-coverage loci (emit_all_positions)
+
+The flagship ColumnKit coverage example silently dropped every uncovered base on
+sparse data (it only worked because the toy reads tiled most of the reference).
+emit_all_positions makes it reference-complete — uncovered loci report depth 0.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: full gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full suite + lint + format**
+
+Run:
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+Expected: PASS on all three. (If `cargo fmt --check` reports diffs, run `cargo fmt` and amend the relevant commit.)
+
+- [ ] **Step 2: No commit** (verification only).
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §3.1 the field + `Default` → **Task 1 Step 3**.
+- §3.2 honor at line 407 → **Task 1 Step 3**.
+- §3.3 fix the example → **Task 2**.
+- §4 bound preserved → **Task 1 Step 1/4** (`emit_all_positions_preserves_the_working_set_bound`).
+- §5 tests: new emit-all gap test (Task 1), default-unchanged (Task 1 Step 5), bound-preserved (Task 1), example runs + prints depth-0 tail (Task 2 Step 2), gates (Task 3).
+- §6 non-goals: no CLI flag, not wired into variants/gvcf, no driver change — respected (only `PileupParams` + `engine.rs:407` + the example are touched).
+
+**2. Placeholder scan:** No TBD/TODO. Every step has literal code or an exact command + expected output.
+
+**3. Type consistency:** `emit_all_positions` (the field) is defined in Task 1 Step 3 and used identically in the `engine_emit_all` helper, both tests, and the example (Task 2). The test helpers (`engine`, `columns`, `mread`, `PileupEngine::new`, `current_working_set`, `col.depth()`, `c.locus.pos.0`) all match the existing `mod tests` API. The example's `run_bounded_whole_genome` signature is unchanged (still takes `params: PileupParams` by value).

--- a/docs/superpowers/specs/2026-06-09-emit-all-positions-design.md
+++ b/docs/superpowers/specs/2026-06-09-emit-all-positions-design.md
@@ -1,0 +1,101 @@
+# Design: `emit_all_positions` — bounded, reference-complete per-locus output
+
+**Status:** Approved design — 2026-06-09. Audience: the implementer. Companion to
+[`CONTRACT.md`](../../../CONTRACT.md) (the bounded `PileupColumn` kernel) and the ColumnKit SDK.
+
+---
+
+## 1. The goal, in one sentence
+
+Let a per-locus analyzer report **zero-coverage loci** (depth 0) instead of silently dropping
+them — without changing the memory bound — retiring a standing honesty liability: the README's
+flagship ColumnKit coverage example omits every uncovered base on real sparse data.
+
+## 2. Why this, why now
+
+`PileupEngine::next` (`src/pileup/engine.rs:397`) already walks the region **position by position**
+(`while self.pos < self.region.end { … self.pos += 1; }`) and calls `build_column()` at **every**
+position. At a coverage gap the column is built with empty observations, and line 407 —
+`if !column.obs.is_empty()` — **suppresses** it (the `while` loop continues). So every uncovered
+locus is visited and constructed, then dropped.
+
+The shipped coverage example (`examples/columnkit_coverage.rs`) only *looks* correct because its toy
+reads happen to tile most of the reference: reads at positions 0 and 4 (length 8) cover 0–11 of a
+16 bp reference, so **positions 12–15 are silently omitted**. A real coverage/QC track must report
+those as depth 0. For an honesty-branded repo, a flagship example that is silently wrong on sparse
+input is a credibility liability.
+
+## 3. The change
+
+### 3.1 `PileupParams::emit_all_positions: bool` (default `false`)
+
+Add the field to `PileupParams` (`engine.rs:45`) and `emit_all_positions: false` to its `Default`
+(`engine.rs:67`). Behavior is unchanged for every existing caller (`PileupParams::default()` and any
+struct literal that uses `..Default::default()`); literals that name every field are not used in the
+codebase, so this is non-breaking.
+
+### 3.2 `engine.rs:407` honors the flag
+
+```rust
+        if self.params.emit_all_positions || !column.obs.is_empty() {
+            return Some(Ok(column));
+        }
+```
+
+`self.params` is the engine's stored `PileupParams` (`engine.rs:153`). A gap position then emits a
+valid `PileupColumn` with the correct `ref_base` (decoded from the reference at that position) and
+`depth() == 0`.
+
+### 3.3 Fix the flagship example
+
+In `examples/columnkit_coverage.rs`, pass `emit_all_positions: true` so the coverage track reports
+positions 12–15 as depth 0:
+
+```rust
+        PileupParams {
+            emit_all_positions: true,
+            ..Default::default()
+        },
+```
+
+(plus a one-line comment that this makes the track reference-complete, and an `eprintln!`/comment
+noting the uncovered tail now reports depth 0).
+
+## 4. The memory bound is provably preserved
+
+`emit_all_positions` never touches `advance_to` or `self.active` (the held read set); the column at
+each position is built **before** the line-407 check regardless of the flag. The flag only decides
+whether the already-built column is **returned** or **skipped**. Therefore `current_working_set()`
+is byte-identical with the flag on or off, at every position.
+
+**Honest scope note:** emit-all is a *volume* tradeoff — a whole-genome emit-all stream is large
+even though peak memory stays bounded by coverage — so it is a **region/panel-oriented opt-in**, not
+a whole-genome default. (Hence default `false`.)
+
+## 5. Testing
+
+In `src/pileup/engine.rs`'s `#[cfg(test)] mod tests` (mirroring the existing position-list tests):
+
+- **Emits a column at every position when set (NEW test):** over a region with a gap (reads leaving
+  an uncovered position), `emit_all_positions: true` yields a column at **every** position; the gap
+  column has `depth() == 0` and the correct `ref_base`. Where the existing default test asserts a
+  gapped position list (e.g. `vec![0, 1, 3, 4]`), the new emit-all variant asserts the complete list
+  (`vec![0, 1, 2, 3, 4]`).
+- **Default behavior unchanged:** the existing suppression tests are **left as-is** and stay green by
+  construction (`emit_all_positions: false` still suppresses the gap position).
+- **Bound preserved:** drive the same sparse fixture through two engines (flag on vs off) and assert
+  the **peak `current_working_set().bytes`** is identical — the provable claim, test-pinned.
+
+**Gates:** `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and
+`cargo run --example columnkit_coverage` (the example compiles and now prints depth-0 rows for the
+uncovered tail).
+
+## 6. Scope / non-goals
+
+- **In scope:** the `PileupParams` flag, the one-line `engine.rs` change, the example fix, tests.
+- **No CLI flag** (`features --all-positions` / a `variants` flag) in this PR — a separate decision;
+  exposing genome-wide emit-all is a volume footgun to gate carefully.
+- Not wired into `variants`/`gvcf` (empty rows in a VCF are wrong); the flag is for per-locus
+  analytics (ColumnKit / `features`).
+- No change to `run_bounded_whole_genome` — it already threads `params` through to the per-contig
+  engine, so setting the flag in the params it receives is sufficient.

--- a/examples/columnkit_coverage.rs
+++ b/examples/columnkit_coverage.rs
@@ -73,12 +73,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut analyzer = CoverageTrack;
     let mut out = io::stdout().lock();
+    // emit_all_positions makes the coverage track REFERENCE-COMPLETE: every locus
+    // emits, so uncovered positions (here ref 12–15, which no read reaches) report
+    // depth 0 instead of being silently dropped. The memory bound is unchanged.
     let (ws, _skips) = run_bounded_whole_genome(
         &mut analyzer,
         SliceSource::new(reads),
         &ref_view,
         contigs,
-        PileupParams::default(),
+        PileupParams {
+            emit_all_positions: true,
+            ..PileupParams::default()
+        },
         &mut out,
     )?;
     out.flush()?;

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -495,7 +495,11 @@ mod tests {
         };
         let cols = columns(engine_emit_all(vec![read], reference));
         let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
-        assert_eq!(positions, vec![0, 1, 2, 3, 4, 5, 6, 7], "every position emits");
+        assert_eq!(
+            positions,
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            "every position emits"
+        );
         for p in [2u32, 5, 6, 7] {
             let col = cols.iter().find(|c| c.locus.pos.0 == p).unwrap();
             assert_eq!(col.depth(), 0, "gap position {p} must be depth 0");
@@ -518,7 +522,10 @@ mod tests {
         };
         let off = peak(engine(reads(), reference));
         let on = peak(engine_emit_all(reads(), reference));
-        assert_eq!(off, on, "emit_all_positions must not change the working-set bound");
+        assert_eq!(
+            off, on,
+            "emit_all_positions must not change the working-set bound"
+        );
     }
 
     #[test]

--- a/src/pileup/engine.rs
+++ b/src/pileup/engine.rs
@@ -62,6 +62,13 @@ pub struct PileupParams {
     /// exceeds `m` aborts the run — the predicted memory envelope assumes `<= m`,
     /// so a longer read would silently void it. `None` = no check (default).
     pub max_read_len: Option<u32>,
+    /// When `true`, emit a column at EVERY reference position in the region, including
+    /// zero-coverage loci (depth 0) — for reference-complete per-locus analytics
+    /// (coverage/QC). Default `false` (covered loci only). The working-set bound is
+    /// unchanged: the empty column is already built at each position; this only decides
+    /// whether it is returned. A volume tradeoff — a region/panel opt-in, not a
+    /// whole-genome default.
+    pub emit_all_positions: bool,
 }
 
 impl Default for PileupParams {
@@ -74,6 +81,7 @@ impl Default for PileupParams {
             skip_duplicate: true,
             max_depth: None,
             max_read_len: None,
+            emit_all_positions: false,
         }
     }
 }
@@ -404,7 +412,7 @@ impl<S: ReadSource> Iterator for PileupEngine<S> {
             }
             let column = self.build_column();
             self.pos += 1;
-            if !column.obs.is_empty() {
+            if self.params.emit_all_positions || !column.obs.is_empty() {
                 return Some(Ok(column));
             }
         }
@@ -451,6 +459,66 @@ mod tests {
             out.push(c.expect("pileup column"));
         }
         out
+    }
+
+    fn engine_emit_all(reads: Vec<AlignedRead>, reference: &[u8]) -> PileupEngine<SliceSource> {
+        PileupEngine::new(
+            SliceSource::new(reads),
+            Arc::from(reference.to_vec().into_boxed_slice()),
+            0,
+            0..reference.len() as u32,
+            PileupParams {
+                emit_all_positions: true,
+                ..PileupParams::default()
+            },
+        )
+    }
+
+    #[test]
+    fn emit_all_positions_reports_gaps_at_depth_zero() {
+        // Same fixture as `deletion_leaves_a_reference_gap_with_no_observation`:
+        // 2M1D2M at ref 0 over an 8 bp reference. Observed: 0,1,3,4. Gaps: 2 (deleted),
+        // 5,6,7 (uncovered). With emit_all_positions EVERY position emits — gaps depth 0.
+        let reference = b"AAAAAAAA";
+        let read = AlignedRead {
+            contig: 0,
+            pos: Position(0),
+            mapq: 60,
+            flags: SamFlags::default(),
+            cigar: vec![
+                CigarOp::new(CigarOpKind::Match, 2),
+                CigarOp::new(CigarOpKind::Deletion, 1),
+                CigarOp::new(CigarOpKind::Match, 2),
+            ],
+            seq: Arc::from(b"GGGG".to_vec().into_boxed_slice()),
+            qual: Arc::from(vec![30u8; 4].into_boxed_slice()),
+        };
+        let cols = columns(engine_emit_all(vec![read], reference));
+        let positions: Vec<u32> = cols.iter().map(|c| c.locus.pos.0).collect();
+        assert_eq!(positions, vec![0, 1, 2, 3, 4, 5, 6, 7], "every position emits");
+        for p in [2u32, 5, 6, 7] {
+            let col = cols.iter().find(|c| c.locus.pos.0 == p).unwrap();
+            assert_eq!(col.depth(), 0, "gap position {p} must be depth 0");
+        }
+    }
+
+    #[test]
+    fn emit_all_positions_preserves_the_working_set_bound() {
+        // The flag only decides whether an already-built column is returned; it never
+        // touches the active set, so the peak working set is identical on/off.
+        let reference = b"AAAAAAAA";
+        let reads = || vec![mread(0, b"GG", false), mread(3, b"GG", false)];
+        let peak = |mut e: PileupEngine<SliceSource>| -> u64 {
+            let mut p = e.current_working_set().bytes;
+            while let Some(c) = e.next() {
+                c.expect("column");
+                p = p.max(e.current_working_set().bytes);
+            }
+            p
+        };
+        let off = peak(engine(reads(), reference));
+        let on = peak(engine_emit_all(reads(), reference));
+        assert_eq!(off, on, "emit_all_positions must not change the working-set bound");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The README sells a coverage/QC track as **the** flagship ColumnKit plugin, and ships `examples/columnkit_coverage.rs` — but it **silently drops every zero-coverage locus** (`engine.rs:407`, `if !column.obs.is_empty()`). The example only *looked* correct because its toy reads happen to tile most of the reference; on real sparse data every uncovered base is omitted. For an honesty-branded repo, a flagship example that's silently wrong on sparse input is a standing credibility liability. This fixes it.

- **`PileupParams::emit_all_positions: bool` (default `false`).** When set, `PileupEngine::next` emits a column at **every** reference position, including zero-coverage loci (depth 0), for reference-complete per-locus analytics. The engine already steps position-by-position and builds the empty column at each gap; the flag just makes the line-407 suppression conditional (one line).
- **The flagship example is fixed** — `examples/columnkit_coverage.rs` now passes `emit_all_positions: true`, so the 16 bp reference's uncovered tail (positions 13–16, which no read reaches) reports depth 0 instead of being dropped.

```
$ cargo run --example columnkit_coverage
#contig	pos	depth
chr1	1	2
...
chr1	12	1
chr1	13	0   ← previously omitted
chr1	14	0
chr1	15	0
chr1	16	0
```

**The memory bound is provably preserved.** `emit_all_positions` never touches `advance_to` or the active read set — the column at each position is built *before* the line-407 check regardless of the flag; the flag only decides whether the already-built column is **returned** or **skipped**. So `current_working_set()` is byte-identical with the flag on or off (test-pinned). It's a *volume* tradeoff (a whole-genome emit-all stream is large though memory stays bounded), so it's a region/panel opt-in — hence default `false`.

## Scope / non-goals

- **No CLI flag** (`features --all-positions`) in this PR — exposing genome-wide emit-all is a volume footgun to gate carefully; a separate decision.
- Not wired into `variants`/`gvcf` (empty rows in a VCF are wrong); the flag is for per-locus analytics (ColumnKit / `features`).
- No change to `run_bounded_whole_genome` (it already threads `params` through). Non-breaking: all 11 `PileupParams { … }` literals in the tree use `..Default::default()`.

## What changed

- `src/pileup/engine.rs`: the `emit_all_positions` field + its `Default` + the conditional at line 407; 2 unit tests (gaps-at-depth-0; **working-set-bound-preserved**).
- `examples/columnkit_coverage.rs`: pass `emit_all_positions: true`.
- Spec + plan under `docs/superpowers/`.

## Test plan

- [x] `cargo test` — full suite green (2 new engine tests; existing suppression tests unchanged and green)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo run --example columnkit_coverage` prints the depth-0 tail (positions 13–16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)