### PR TITLE
Unify sample semantics and prepare the evidence-engine candidate

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -149,7 +149,9 @@ jobs:
           ref: ${{ needs.gates.outputs.commit }}
       - name: Install native build dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools cmake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools build-essential clang cmake pkg-config libbz2-dev liblzma-dev zlib1g-dev
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: 1.95.0
@@ -186,9 +188,8 @@ jobs:
       - name: Install-smoke staged bundle
         shell: bash
         run: |
-          install_root=$(mktemp -d)
-          tar -xzf "dist/rosalind-${{ matrix.target }}.tar.gz" -C "$install_root"
-          "$install_root/rosalind-${{ matrix.target }}/rosalind" --version
+          scripts/smoke-release.sh "dist/rosalind-${{ matrix.target }}.tar.gz" \
+            --candidate-source "$GITHUB_WORKSPACE"
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Generate SPDX SBOM
         run: syft 'dir:dist/rosalind-${{ matrix.target }}' -o 'spdx-json=dist/rosalind-${{ matrix.target }}.spdx.json'
@@ -202,16 +203,46 @@ jobs:
             dist/rosalind-${{ matrix.target }}.spdx.json
             dist/rosalind-${{ matrix.target }}.build.json
 
-  publish-wheels:
+  build-wheels:
     needs: [gates, build]
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/wheels.yml
     with:
       candidate_sha: ${{ needs.gates.outputs.commit }}
       package_version: ${{ inputs.version }}-rc.${{ inputs.number }}
-      destination: testpypi
+
+  # Trusted publishing requires a top-level workflow identity. Keep the reusable
+  # workflow limited to candidate-bound builds and fresh installation checks.
+  publish-wheels:
+    needs: [gates, build-wheels]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.gates.outputs.commit }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: wheel-*
+          path: artifacts
+          merge-multiple: true
+      - name: Verify candidate, target, version, and exact wheel bytes
+        env:
+          CANDIDATE_SHA: ${{ needs.gates.outputs.commit }}
+          PACKAGE_VERSION: ${{ inputs.version }}-rc.${{ inputs.number }}
+        run: |
+          python3 scripts/wheel-artifacts.py stage --artifacts artifacts --output dist \
+            --candidate-sha "$CANDIDATE_SHA" --version "$PACKAGE_VERSION" --index testpypi
+          python3 scripts/verify-wheel-upload.py --index testpypi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
+          skip-existing: true
 
   publish-container:
     needs: [gates, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,9 @@ jobs:
           ref: ${{ needs.authorize.outputs.commit }}
       - name: Install native build dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools cmake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools build-essential clang cmake pkg-config libbz2-dev liblzma-dev zlib1g-dev
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: 1.95.0
@@ -112,9 +114,8 @@ jobs:
       - name: Install-smoke staged bundle
         shell: bash
         run: |
-          install_root=$(mktemp -d)
-          tar -xzf "dist/rosalind-${{ matrix.target }}.tar.gz" -C "$install_root"
-          "$install_root/rosalind-${{ matrix.target }}/rosalind" --version
+          scripts/smoke-release.sh "dist/rosalind-${{ matrix.target }}.tar.gz" \
+            --candidate-source "$GITHUB_WORKSPACE"
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Generate SPDX SBOM
         run: syft 'dir:dist/rosalind-${{ matrix.target }}' -o 'spdx-json=dist/rosalind-${{ matrix.target }}.spdx.json'
@@ -177,16 +178,44 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: scripts/post-publish-smoke.sh "$VERSION"
 
-  publish-wheels:
+  build-wheels:
     needs: [authorize, build-assets, publish-crates, published-install-smoke]
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/wheels.yml
     with:
       candidate_sha: ${{ needs.authorize.outputs.commit }}
       package_version: ${{ inputs.version }}
-      destination: pypi
+
+  publish-wheels:
+    needs: [authorize, build-wheels]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.authorize.outputs.commit }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: wheel-*
+          path: artifacts
+          merge-multiple: true
+      - name: Verify candidate, target, version, and exact wheel bytes
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.commit }}
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: |
+          python3 scripts/wheel-artifacts.py stage --artifacts artifacts --output dist \
+            --candidate-sha "$CANDIDATE_SHA" --version "$PACKAGE_VERSION" --index pypi
+          python3 scripts/verify-wheel-upload.py --index pypi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: https://upload.pypi.org/legacy/
+          packages-dir: dist
+          skip-existing: true
 
   publish-container:
     needs: [authorize, build-assets, publish-crates, published-install-smoke]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,10 +13,6 @@ on:
         description: Base Cargo version or unique numbered RC version
         type: string
         default: ''
-      destination:
-        description: none, testpypi, or pypi
-        type: string
-        default: none
 
 permissions:
   contents: read
@@ -51,9 +47,7 @@ jobs:
         env:
           CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
           PACKAGE_VERSION: ${{ inputs.package_version }}
-          DESTINATION: ${{ inputs.destination || 'none' }}
         run: |
-          case "$DESTINATION" in none|testpypi|pypi) ;; *) exit 2 ;; esac
           python scripts/prepare-wheel-version.py --candidate-sha "$CANDIDATE_SHA" --version "$PACKAGE_VERSION" --output "$RUNNER_TEMP/wheel-build.json"
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
@@ -70,62 +64,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends build-essential clang cmake pkg-config libbz2-dev liblzma-dev zlib1g-dev
       - name: Fresh Python 3.11 wheel smoke
-        run: scripts/smoke-wheel.sh dist/*.whl
+        run: scripts/smoke-wheel.sh dist/*.whl --candidate-source "$GITHUB_WORKSPACE"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.9'
       - name: Fresh minimum-supported Python wheel smoke
-        run: scripts/smoke-wheel.sh dist/*.whl
+        run: scripts/smoke-wheel.sh dist/*.whl --candidate-source "$GITHUB_WORKSPACE"
       - name: Record candidate provenance beside wheel
-        run: cp "$RUNNER_TEMP/wheel-build.json" 'dist/wheel-build-${{ matrix.target }}.json'
+        run: |
+          python3 scripts/wheel-artifacts.py record --directory dist \
+            --build-report "$RUNNER_TEMP/wheel-build.json" --target '${{ matrix.target }}' \
+            --output 'dist/wheel-build-${{ matrix.target }}.json'
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheel-${{ matrix.target }}
           path: dist/*
           if-no-files-found: error
-
-  publish:
-    if: inputs.destination == 'testpypi' || inputs.destination == 'pypi'
-    needs: build
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ inputs.candidate_sha }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          pattern: wheel-*
-          path: artifacts
-          merge-multiple: true
-      - name: Verify candidate provenance before publishing only wheels
-        env:
-          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
-          PACKAGE_VERSION: ${{ inputs.package_version }}
-          DESTINATION: ${{ inputs.destination }}
-        run: |
-          python3 - <<'PY'
-          import json, os, pathlib
-          reports = list(pathlib.Path("artifacts").glob("wheel-build-*.json"))
-          assert len(reports) == 3
-          version = os.environ["PACKAGE_VERSION"]
-          assert bool("-rc." in version) == (os.environ["DESTINATION"] == "testpypi")
-          for path in reports:
-              report = json.loads(path.read_text())
-              assert report["source_commit"] == os.environ["CANDIDATE_SHA"]
-              assert report["rust_version"] == version
-          PY
-          mkdir dist
-          cp artifacts/*.whl dist/
-      - name: Verify exact bytes before an idempotent publication retry
-        env:
-          DESTINATION: ${{ inputs.destination }}
-        run: python3 scripts/verify-wheel-upload.py --index "$DESTINATION"
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          repository-url: ${{ inputs.destination == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-          packages-dir: dist
-          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Rosalind are recorded here. Versions follow Semantic Vers
 
 ## [Unreleased]
 
+### Evidence-engine candidate track (0.5.0)
+
+The feature-bearing evidence engine is being prepared as `0.5.0-rc.1`. No 0.4
+release was published. The existing seven-day RC soak, independent-user gates,
+protected publication review, and change-based caller evidence requirements apply.
+
+- Indexed exact SNV evidence and panel QC, bounded Rust/Python batches, verified
+  partition cache/resume, canonical workers, and dataset comparison are implemented.
+- Panel callability now defaults to 10x consistently through Rust, CLI, and Python.
+- Named, unknown, and explicitly pooled sample scope is recorded in evidence
+  receipts and cache identities. Ambiguous sample headers require explicit intent;
+  named runs refuse reads that cannot be assigned to a declared sample.
+- Development status and the ordered next implementation sequence are tracked in
+  `docs/ADOPTION_ROADMAP.md`; implementation does not imply publication or adoption.
+
 ### Analyzer-platform foundation
 
 - Repositioned Rosalind around deterministic per-locus analysis contracts; the
@@ -24,11 +39,12 @@ All notable changes to Rosalind are recorded here. Versions follow Semantic Vers
 - Changed the CLI variant quality threshold default to 30; the historical
   permissive behavior remains available with `--quality-threshold 10`.
 - Version-gated the design-partner and seven-day RC soak requirements from 0.5.0;
-  0.4.0 remains a stabilization release with internal release gates.
+  the subsequent feature-bearing candidate retains those gates.
 
-## [0.4.0] — pending publication
+## [0.4.0] — unpublished development checkpoint
 
-This is the first consolidated stable release after `0.1.0`. The repository's
+This was the planned consolidated stabilization checkpoint after `0.1.0`, now
+included in the feature-bearing 0.5 candidate track. The repository's
 former `0.1.1`–`0.3.1` labels were internal development checkpoints, not public
 GitHub or crates.io releases; their changes are consolidated here.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rosalind-bio"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosalind-bio"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Logan Nye <logannye@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ the same evidence reusable across consumers.
 
 **Development status:** exact evidence, panel QC, verified cache/resume, and dataset
 comparison are implemented, with local and CI validation. The source package still has
-version 0.4.0; this development work is unpublished, with staged 0.5/0.6/0.7
-releases planned. The [retained validation report](docs/findings/evidence-engine-2026-09-05/README.md)
+version 0.5.0, preparing its first feature-bearing release candidate; 0.4.0 was
+not published. Panel/cache APIs remain preview capabilities with independent
+validation and stabilization gates. The [retained validation report](docs/findings/evidence-engine-2026-09-05/README.md)
 records 467 passing Rust tests, eight Python tests on both Python 3.9 and 3.11,
 and fresh macOS arm64 wheel installs. Subsequent [wheel CI](https://github.com/logannye/rosalind/actions/runs/34009965756)
 also passed fresh Python 3.9/3.11 installations on Linux x86_64 and both macOS
@@ -63,6 +64,9 @@ rosalind reproduce --manifest evidence.arrow.manifest.json --inputs .
 Use `--regions targets.bed` instead of `--sites` to emit every selected locus,
 including zero-depth positions. See [SEMANTICS.md](docs/SEMANTICS.md) for coordinate,
 flag, quality, depth, and denominator definitions before comparing another tool.
+Sample identity is resolved from read-group metadata. For multiple declared
+samples use `--sample NAME` or deliberately pool with `--pool-samples`;
+receipts distinguish named, unknown, and pooled evidence.
 
 ## Panel QC and shared extraction
 
@@ -184,8 +188,9 @@ retains raw test, package, workflow, and benchmark evidence. On the small NA1850
 example, all 34 evidence fields matched an independent pysam oracle exactly across
 three budgets and three repetitions; cache resume preserved output while avoiding
 partition extraction. These checks establish the tested behavior on this dataset.
-Larger-data efficiency, Linux/macOS Intel packages, container enforcement, and
-independent adoption still have separate gates.
+Larger-data efficiency, public package installation, enforcement for the new
+evidence engine, and independent adoption still have separate gates. Candidate
+wheel CI and the legacy-extraction cgroup benchmark have passed independently.
 
 The [exact-evidence curve](benchmarks/evidence/) compares a semantically matched
 streaming pysam oracle with three repeated declared-budget runs, retaining raw

--- a/benchmarks/giab/happy/Dockerfile
+++ b/benchmarks/giab/happy/Dockerfile
@@ -6,6 +6,7 @@ ARG HAPPY_SHA256=838912f1ab805224110af3c1035849d5483b5ce4c565ae0f0db7f7284af0667
 ARG RTG_URL=https://github.com/RealTimeGenomics/rtg-tools/releases/download/3.12.1/rtg-tools-3.12.1-nojre.zip
 ARG RTG_SHA256=5efc8cb1a44019b97dce8d324e3a0b3dc3328d022fc9db13c80b09996757c4aa
 COPY requirements-py27.txt /opt/requirements-py27.txt
+COPY pin-version.py /opt/pin-version.py
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf build-essential bzip2 ca-certificates cmake curl cython git \
@@ -21,6 +22,7 @@ WORKDIR /build
 RUN curl --fail --location --retry 3 "$HAPPY_URL" -o happy.tar.gz && \
     echo "$HAPPY_SHA256  happy.tar.gz" | sha256sum --check --strict && \
     tar xzf happy.tar.gz --strip-components=1 && \
+    python /opt/pin-version.py /build && \
     python install.py /opt/hap.py --no-tests && \
     curl --fail --location --retry 3 "$RTG_URL" -o rtg.zip && \
     echo "$RTG_SHA256  rtg.zip" | sha256sum --check --strict && \
@@ -28,7 +30,8 @@ RUN curl --fail --location --retry 3 "$HAPPY_URL" -o happy.tar.gz && \
     mv /opt/rtg-tools-3.12.1 /opt/rtg-tools && \
     printf '%s\n' 'RTG_MEM=2G' 'RTG_JAVA_OPTS="-XX:-UseContainerSupport"' \
       'RTG_TALKBACK=false' 'RTG_USAGE=false' > /opt/rtg-tools/rtg.cfg && \
-    /opt/hap.py/bin/hap.py --version && \
+    test "$(/opt/hap.py/bin/hap.py --version)" = 'Hap.py 0.3.15' && \
+    test "$(/opt/hap.py/bin/xcmp --version)" = 'xcmp version 0.3.15' && \
     /opt/hap.py/bin/test_haplotypes && \
     /opt/rtg-tools/rtg version && \
     rm -rf /build

--- a/benchmarks/giab/happy/pin-version.py
+++ b/benchmarks/giab/happy/pin-version.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Pin archive builds to the checksum-locked hap.py 0.3.15 source version.
+
+The upstream CMake git-describe command produces an empty version outside a git
+checkout. Both the C++ and Python generated version files use this one variable.
+Compatible with the evaluator's Python 2.7 and host-side Python 3 tests.
+"""
+from __future__ import print_function
+
+import hashlib
+import os
+import sys
+
+VERSION = "0.3.15"
+EXPECTED_CMAKE_SHA256 = "ba8ef08b590eeb0b0e15756edf17167213db59c7d317795321964ca9b0f115d5"
+UPSTREAM_BLOCK = b'''execute_process(COMMAND git describe --tags --always
+    OUTPUT_VARIABLE HAPLOTYPES_VERSION
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)'''
+PINNED_BLOCK = b'''# Rosalind evaluator: version from the checksum-locked upstream release archive.
+set(HAPLOTYPES_VERSION "0.3.15")'''
+
+
+def pinned_cmake(source):
+    if hashlib.sha256(source).hexdigest() != EXPECTED_CMAKE_SHA256:
+        raise ValueError("hap.py CMakeLists.txt differs from the locked 0.3.15 source")
+    if source.count(UPSTREAM_BLOCK) != 1:
+        raise ValueError("expected exactly one upstream git-describe version block")
+    return source.replace(UPSTREAM_BLOCK, PINNED_BLOCK, 1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise ValueError("usage: pin-version.py EXTRACTED_HAPPY_SOURCE")
+    path = os.path.join(sys.argv[1], "CMakeLists.txt")
+    with open(path, "rb") as source:
+        patched = pinned_cmake(source.read())
+    with open(path, "wb") as output:
+        output.write(patched)
+    print("Pinned hap.py C++ and Python build version to " + VERSION)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (IOError, ValueError) as error:
+        sys.exit(str(error))

--- a/benchmarks/giab/happy/run.sh
+++ b/benchmarks/giab/happy/run.sh
@@ -8,12 +8,14 @@ if [[ ! "$IMAGE" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]]; then
   exit 2
 fi
 command -v docker >/dev/null || { echo "docker is required" >&2; exit 2; }
+python3 "$HERE/../preflight.py" "$DATA"
+DATA="$(cd "$DATA" && pwd)"
 
 prepared="$DATA/prepared"
 results="$DATA/results/happy"
 rm -rf "$results"
 mkdir -p "$results"
-for file in GRCh38.chr20.fa HG002.v5.0q.chr20.vcf HG002.v5.0q.chr20.bed stratifications.tsv; do
+for file in GRCh38.chr20.fa GRCh38.chr20.fa.fai HG002.v5.0q.chr20.vcf HG002.v5.0q.chr20.bed stratifications.tsv; do
   test -f "$prepared/$file" || { echo "missing prepared input: $prepared/$file" >&2; exit 2; }
 done
 test -f "$DATA/results/HG002.rosalind.chr20.vcf" || { echo "run the Rosalind GIAB workflow first" >&2; exit 2; }

--- a/benchmarks/giab/happy/smoke.sh
+++ b/benchmarks/giab/happy/smoke.sh
@@ -8,6 +8,8 @@ python3 - "$RESULTS" <<'PY'
 from pathlib import Path
 import sys
 root = Path(sys.argv[1])
+root = root / "inputs"
+root.mkdir(exist_ok=True)
 (root / "reference.fa").write_text(">chr20\n" + "A" * 1000 + "\n")
 vcf = ("##fileformat=VCFv4.2\n##contig=<ID=chr20,length=1000>\n"
        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
@@ -18,19 +20,24 @@ for name in ("truth.vcf", "query.vcf"):
 (root / "confident.bed").write_text("chr20\t0\t1000\n")
 PY
 docker run --rm --network none --platform linux/amd64 "$IMAGE" --version > "$RESULTS/happy-version.txt"
+docker run --rm --network none --platform linux/amd64 --entrypoint /opt/hap.py/bin/xcmp "$IMAGE" --version > "$RESULTS/xcmp-version.txt"
 docker run --rm --network none --platform linux/amd64 --entrypoint /opt/rtg-tools/rtg "$IMAGE" version > "$RESULTS/rtg-version.txt"
+test "$(cat "$RESULTS/happy-version.txt")" = 'Hap.py 0.3.15' || { echo 'wrong or missing hap.py Python version' >&2; exit 2; }
+test "$(cat "$RESULTS/xcmp-version.txt")" = 'xcmp version 0.3.15' || { echo 'wrong or missing hap.py C++ version' >&2; exit 2; }
+grep -F '3.12.1' "$RESULTS/rtg-version.txt" >/dev/null || { echo 'wrong or missing RTG version' >&2; exit 2; }
 # hap.py preprocessing requires an existing FAI. Build it with the evaluator's
 # installed pysam, keeping both fixture preparation and evaluation offline.
-docker run --rm --network none --platform linux/amd64 -v "$RESULTS:/data" \
+docker run --rm --network none --platform linux/amd64 -v "$RESULTS/inputs:/data" \
   --entrypoint python "$IMAGE" -c "import pysam; pysam.faidx('/data/reference.fa')"
-python3 - "$RESULTS/reference.fa.fai" <<'PY_INDEX'
+python3 - "$RESULTS/inputs/reference.fa.fai" <<'PY_INDEX'
 from pathlib import Path
 import sys
 assert Path(sys.argv[1]).read_text().splitlines() == ["chr20\t1000\t7\t1000\t1001"]
 PY_INDEX
-if docker run --rm --network none --platform linux/amd64 -v "$RESULTS:/data" "$IMAGE" \
-  /data/truth.vcf /data/query.vcf -r /data/reference.fa -f /data/confident.bed \
-  --engine=vcfeval --engine-vcfeval-path=/opt/rtg-tools/rtg --threads 1 -o /data/evaluation \
+if docker run --rm --network none --platform linux/amd64 \
+  -v "$RESULTS/inputs:/data/prepared:ro" -v "$RESULTS:/data/results" "$IMAGE" \
+  /data/prepared/truth.vcf /data/prepared/query.vcf -r /data/prepared/reference.fa -f /data/prepared/confident.bed \
+  --engine=vcfeval --engine-vcfeval-path=/opt/rtg-tools/rtg --threads 1 -o /data/results/evaluation \
   > "$RESULTS/evaluator.stdout.txt" 2> "$RESULTS/evaluator.stderr.txt"; then
   :
 else

--- a/benchmarks/giab/preflight.py
+++ b/benchmarks/giab/preflight.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify every manifested prepared GIAB input, including the evaluator's FAI."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REQUIRED_ARTIFACTS = {
+    "GRCh38.chr20.fa", "GRCh38.chr20.fa.fai",
+    "HG002.chr20.bam", "HG002.chr20.bam.bai",
+    "HG002.v5.0q.chr20.vcf", "HG002.v5.0q.chr20.bed", "stratifications.tsv",
+    "GRCh38_AllTandemRepeatsandHomopolymers_slop5.chr20.bed.gz",
+    "GRCh38_lowmappabilityall.chr20.bed.gz",
+    "GRCh38_segdups.chr20.bed.gz", "GRCh38_alldifficultregions.chr20.bed.gz",
+}
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_reference_index(reference, index):
+    """Derive the single-contig faidx layout with bounded lines, without writes."""
+    with reference.open("rb") as stream:
+        header = stream.readline(1 << 20)
+        if len(header) == 1 << 20 or not header.startswith(b">") or header[1:].split()[:1] != [b"chr20"]:
+            raise ValueError("prepared reference must contain exactly chr20")
+        offset = stream.tell()
+        total, line_bases, line_bytes, previous = 0, None, None, None
+        while True:
+            line = stream.readline(1 << 20)
+            if not line:
+                break
+            if len(line) == 1 << 20 or line.startswith(b">"):
+                raise ValueError("prepared reference has an oversized line or extra contig")
+            bases = len(line.rstrip(b"\r\n"))
+            if bases == 0:
+                raise ValueError("prepared reference has an empty sequence line")
+            if previous is not None and previous != (line_bases, line_bytes):
+                raise ValueError("prepared reference has inconsistent FASTA wrapping")
+            if line_bases is None:
+                line_bases, line_bytes = bases, len(line)
+            if bases > line_bases:
+                raise ValueError("prepared reference has inconsistent FASTA wrapping")
+            previous = bases, len(line)
+            total += bases
+    if total == 0:
+        raise ValueError("prepared reference is empty")
+    expected = "chr20\t{}\t{}\t{}\t{}".format(total, offset, line_bases, line_bytes)
+    with index.open() as stream:
+        first = stream.readline(4096)
+        if first.rstrip("\r\n") != expected or stream.read(1):
+            raise ValueError("prepared reference FAI does not match the FASTA layout")
+
+
+def verify_prepared(data):
+    root = Path(data)
+    manifest = json.loads((root / "data-manifest.json").read_text())
+    if not isinstance(manifest, dict) or manifest.get("schema") != 1:
+        raise ValueError("unsupported GIAB data-manifest schema")
+    artifacts = manifest.get("prepared_artifacts", {})
+    if not isinstance(artifacts, dict):
+        raise ValueError("prepared_artifacts must be an object")
+    missing = REQUIRED_ARTIFACTS - artifacts.keys()
+    if missing:
+        raise ValueError("prepared manifest is missing required artifacts: " + ", ".join(sorted(missing)))
+    for name, identity in sorted(artifacts.items()):
+        if not isinstance(identity, dict):
+            raise ValueError("prepared artifact identity must be an object: " + name)
+        if Path(name).name != name or name in {".", ".."}:
+            raise ValueError("invalid prepared artifact name: " + name)
+        path = root / "prepared" / name
+        if not path.is_file():
+            raise ValueError("missing prepared artifact: " + name)
+        if path.stat().st_size != identity.get("bytes") or sha256(path) != identity.get("sha256"):
+            raise ValueError("prepared artifact differs from data manifest: " + name)
+    verify_reference_index(root / "prepared/GRCh38.chr20.fa", root / "prepared/GRCh38.chr20.fa.fai")
+    return len(artifacts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("data", type=Path)
+    args = parser.parse_args()
+    try:
+        count = verify_prepared(args.data)
+    except (OSError, ValueError, TypeError) as error:
+        parser.exit(2, "GIAB input preflight failed: {}\n".format(error))
+    print("Verified {} prepared GIAB artifacts and reference FAI".format(count))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/giab/prepare.sh
+++ b/benchmarks/giab/prepare.sh
@@ -46,6 +46,9 @@ samtools view -H "$reads" | grep -q $'^@SQ.*SN:chr20' || {
 samtools view --no-PG -b "$reads" chr20 -o "$prepared/HG002.chr20.bam"
 samtools index "$prepared/HG002.chr20.bam"
 samtools faidx "$reference" chr20 > "$prepared/GRCh38.chr20.fa"
+# The extracted FASTA has different offsets from the downloaded whole-reference
+# FAI. Build its own sidecar before manifesting or mounting prepared inputs read-only.
+samtools faidx "$prepared/GRCh38.chr20.fa"
 gzip -dc "$downloads/HG002_GRCh38_v5.0q_smvar.vcf.gz" \
   | awk 'BEGIN{FS=OFS="\t"} /^#/ || $1=="chr20"' > "$prepared/HG002.v5.0q.chr20.vcf"
 awk 'BEGIN{FS=OFS="\t"} $1=="chr20"' \
@@ -106,4 +109,5 @@ manifest = {
 (root / "data-manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 PY
 
+python3 "$HERE/preflight.py" "$DEST"
 echo "Prepared chr20 data and wrote $DEST/data-manifest.json"

--- a/benchmarks/giab/run.sh
+++ b/benchmarks/giab/run.sh
@@ -22,6 +22,7 @@ test -f "$DATA/data-manifest.json" || {
   echo "prepare the opt-in data first: benchmarks/giab/prepare.sh '$DATA'" >&2
   exit 2
 }
+python3 "$HERE/preflight.py" "$DATA"
 
 cd "$ROOT"
 BIN="${ROSALIND_BIN:-target/release/rosalind}"

--- a/benchmarks/giab/test_prerequisites.py
+++ b/benchmarks/giab/test_prerequisites.py
@@ -1,0 +1,178 @@
+"""Offline regressions for evaluator versioning and prepared read-only inputs."""
+import gzip
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from preflight import REQUIRED_ARTIFACTS, sha256, verify_prepared
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("happy_pin_version", HERE / "happy/pin-version.py")
+PIN = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PIN)
+
+
+class VersionTests(unittest.TestCase):
+    def test_source_drift_is_rejected_before_replacement(self):
+        with self.assertRaisesRegex(ValueError, "differs from the locked"):
+            PIN.pinned_cmake(PIN.UPSTREAM_BLOCK)
+
+    def test_one_guarded_assignment_populates_both_generated_versions(self):
+        source = b"# fixture\n" + PIN.UPSTREAM_BLOCK + b"\nconfigure_file(native python)\n"
+        with patch.object(PIN, "EXPECTED_CMAKE_SHA256", hashlib.sha256(source).hexdigest()):
+            result = PIN.pinned_cmake(source)
+            self.assertEqual(result.count(b'set(HAPLOTYPES_VERSION "0.3.15")'), 1)
+            self.assertNotIn(b"git describe", result)
+            self.assertIn(b"configure_file(native python)", result)
+            with self.assertRaises(ValueError):
+                PIN.pinned_cmake(result)
+        duplicate = PIN.UPSTREAM_BLOCK + b"\n" + PIN.UPSTREAM_BLOCK
+        with patch.object(PIN, "EXPECTED_CMAKE_SHA256", hashlib.sha256(duplicate).hexdigest()):
+            with self.assertRaisesRegex(ValueError, "exactly one"):
+                PIN.pinned_cmake(duplicate)
+
+    def test_candidate_smoke_rejects_missing_python_or_wrong_native_version(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            docker = root / "docker"
+            docker.write_text("#!/usr/bin/env python3\n" + """
+import os, sys
+args = sys.argv[1:]
+if '/opt/hap.py/bin/xcmp' in args:
+    print('xcmp version ' + ('0.3.14' if os.environ['BAD_VERSION'] == 'native' else '0.3.15'))
+elif '/opt/rtg-tools/rtg' in args:
+    print('RTG Tools 3.12.1')
+else:
+    print('Hap.py ' + ('' if os.environ['BAD_VERSION'] == 'python' else '0.3.15'))
+""")
+            docker.chmod(0o755)
+            for mode, message in [("python", "hap.py Python version"), ("native", "hap.py C++ version")]:
+                result = subprocess.run(
+                    ["bash", str(HERE / "happy/smoke.sh"), "local:test", str(root / mode)],
+                    env={**os.environ, "PATH": str(root) + os.pathsep + os.environ["PATH"], "BAD_VERSION": mode},
+                    text=True, capture_output=True, check=False,
+                )
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn(message, result.stderr)
+
+
+class PreparedInputTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.prepared = self.root / "prepared"
+        self.prepared.mkdir()
+        for name in REQUIRED_ARTIFACTS:
+            (self.prepared / name).write_bytes(b"fixture\n")
+        (self.prepared / "GRCh38.chr20.fa").write_bytes(b">chr20\nAAAA\nAA\n")
+        (self.prepared / "GRCh38.chr20.fa.fai").write_text("chr20\t6\t7\t4\t5\n")
+        self.write_manifest()
+
+    def write_manifest(self):
+        artifacts = {
+            path.name: {"bytes": path.stat().st_size, "sha256": sha256(path)}
+            for path in self.prepared.iterdir()
+        }
+        (self.root / "data-manifest.json").write_text(json.dumps({"schema": 1, "prepared_artifacts": artifacts}))
+
+    def test_complete_prepared_inputs_verify_without_writes(self):
+        before = {path.name: path.read_bytes() for path in self.prepared.iterdir()}
+        self.assertEqual(verify_prepared(self.root), len(REQUIRED_ARTIFACTS))
+        self.assertEqual(before, {path.name: path.read_bytes() for path in self.prepared.iterdir()})
+
+    def test_missing_fai_is_rejected_even_when_omitted_from_manifest(self):
+        (self.prepared / "GRCh38.chr20.fa.fai").unlink()
+        with self.assertRaisesRegex(ValueError, "missing prepared artifact"):
+            verify_prepared(self.root)
+        self.write_manifest()
+        with self.assertRaisesRegex(ValueError, "missing required artifacts.*fa.fai"):
+            verify_prepared(self.root)
+
+    def test_changed_or_stale_fai_cannot_pass_preflight(self):
+        (self.prepared / "GRCh38.chr20.fa.fai").write_text("chr20\t6\t99\t4\t5\n")
+        with self.assertRaisesRegex(ValueError, "differs from data manifest"):
+            verify_prepared(self.root)
+        self.write_manifest()
+        with self.assertRaisesRegex(ValueError, "FAI does not match"):
+            verify_prepared(self.root)
+
+    def test_other_prepared_artifact_changes_are_also_rejected(self):
+        (self.prepared / "HG002.chr20.bam").write_bytes(b"changed alignment")
+        with self.assertRaisesRegex(ValueError, "differs from data manifest.*bam"):
+            verify_prepared(self.root)
+
+
+class PreparationScriptTests(unittest.TestCase):
+    def test_preparation_builds_and_manifests_the_extracted_reference_fai(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            harness, data, tools = root / "harness", root / "data", root / "tools"
+            harness.mkdir()
+            tools.mkdir()
+            downloads = data / "downloads"
+            downloads.mkdir(parents=True)
+            for name in ["prepare.sh", "preflight.py"]:
+                shutil.copyfile(HERE / name, harness / name)
+            resources = []
+            for line in (HERE / "resources.tsv").read_text().splitlines():
+                if not line or line.startswith("#"):
+                    continue
+                identity, filename, _, url = line.split("\t")
+                content = b"chr20\t0\t8\n"
+                if filename.endswith(".vcf.gz"):
+                    content = b"##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\nchr20\t1\t.\tA\tC\n"
+                if filename.endswith(".gz"):
+                    content = gzip.compress(content, mtime=0)
+                (downloads / filename).write_bytes(content)
+                resources.append("\t".join([identity, filename, hashlib.sha256(content).hexdigest(), url]))
+            (harness / "resources.tsv").write_text("\n".join(resources) + "\n")
+            samtools = tools / "samtools"
+            samtools.write_text("#!" + sys.executable + "\n" + """
+import os, sys
+from pathlib import Path
+args = sys.argv[1:]
+with open(os.environ['SAMTOOLS_CALLS'], 'a') as log:
+    log.write(repr(args) + '\\n')
+if args[0] == 'quickcheck':
+    pass
+elif args[:2] == ['view', '-H']:
+    print('@SQ\\tSN:chr20\\tLN:8')
+elif args[0] == 'view':
+    Path(args[args.index('-o') + 1]).write_bytes(b'prepared alignment')
+elif args[0] == 'index':
+    Path(args[1] + '.bai').write_bytes(b'prepared index')
+elif args[0] == 'faidx' and len(args) == 3:
+    print('>chr20\\nACGTACGT')
+elif args[0] == 'faidx' and len(args) == 2:
+    assert Path(args[1]).read_bytes() == b'>chr20\\nACGTACGT\\n'
+    Path(args[1] + '.fai').write_text('chr20\\t8\\t7\\t8\\t9\\n')
+elif args[0] == '--version':
+    print('samtools fixture')
+else:
+    raise SystemExit('unexpected samtools invocation: ' + repr(args))
+""")
+            samtools.chmod(0o755)
+            calls = root / "samtools.calls"
+            result = subprocess.run(
+                ["bash", str(harness / "prepare.sh"), str(data)],
+                env={**os.environ, "PATH": str(tools) + os.pathsep + os.environ["PATH"], "SAMTOOLS_CALLS": str(calls)},
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("['faidx', '{}']".format(data / "prepared/GRCh38.chr20.fa"), calls.read_text())
+            manifest = json.loads((data / "data-manifest.json").read_text())
+            self.assertIn("GRCh38.chr20.fa.fai", manifest["prepared_artifacts"])
+            self.assertEqual(verify_prepared(data), len(REQUIRED_ARTIFACTS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ADOPTION_ROADMAP.md
+++ b/docs/ADOPTION_ROADMAP.md
@@ -1,0 +1,55 @@
+# Adoption and reusable evidence implementation
+
+This sequence follows the evidence-engine foundation merged in PR #97. Work remains
+ordered; external publication and adoption prerequisites are tracked separately
+from code and local verification. The original scientific invariant and historical
+artifact verification remain requirements throughout.
+
+| Order | Delivery | Status |
+|---|---|---|
+| 1 | Shared panel defaults and explicit named/unknown/pooled sample scope | Implemented; 11 sample tests, Rust/CLI threshold parity, Python/native parity, cache/replay and existing evidence regressions pass |
+| 2 | Installable evidence-engine RC, executable onboarding, candidate publication gates | Prerequisites inspected; publication not performed |
+| 3 | Physical field projection and bounded coalesced sparse fetches | Pending |
+| 4 | VCF.gz/BCF selection, record-preserving annotation, optional per-allele quality/position sums | Pending |
+| 5 | Verified subset/superset dataset reuse, persisted analysis, bounded Parquet and Python/R/SQL adapters | Pending |
+| 6 | Evidence-native artifact runner, scaffold, and conformance | Pending |
+| 7 | Representative BAM/CRAM resource measurements and independent user validation | Pending; external users have not been recruited |
+
+## Acceptance
+
+1. Default panel results agree through Rust, CLI, and Python at threshold
+   boundaries. Samples cannot silently mix: scope is explicit in receipts,
+   scientific identity, and cache identity. Selection/pooling replay correctly.
+2. One immutable candidate builds matching binaries, wheels, crates, and OCI.
+   Clean installations run the researcher tutorial, verification, and relocated
+   replay; external SDK builds use published dependencies without source patches.
+   Preserve protected review, credentials, relevant caller evidence, and the
+   seven-day RC soak for releases from 0.5 onward.
+3. Omitted capabilities allocate/encode no corresponding buffers. Present values
+   equal full evidence, with bytes invariant across admitted execution settings.
+   Nearby sparse loci share bounded fetches without widening scientific selection.
+4. Equivalent VCF encodings yield equal selected evidence; annotation preserves
+   records and allele correspondence. Unsupported variants and REF mismatches
+   remain explicit. Per-allele quality swaps are distinguishable with oracle
+   agreement and a declared memory model.
+5. Compatible persisted evidence answers subset requests without alignment
+   decoding. Incompatible filters/capabilities never reuse insufficient summaries.
+   Each reused artifact retains its producer, original byte identity, and verified
+   lineage. Export adapters have bounded buffers.
+6. A standalone analyzer implements its reducer/output while inheriting refusal,
+   cancellation, atomic publication, receipts, and relocated replay.
+7. High-depth panel and chromosome-scale sparse workloads vary effective tiles,
+   budgets, workers, input encoding, and cold/resumed cache state. Retain three
+   repetitions, correctness comparisons, full time/RSS/I/O costs, and new-engine
+   cgroup checks. Three non-authors complete real tasks; two teams return after
+   30 days. Record installation time, integration effort, and work avoided.
+
+## Publication prerequisites inspected 2026-09-06
+
+The `rc` and `release` environments retain required review and currently allow
+zero deployment refs. No repository/environment secret names are configured.
+PyPI/TestPyPI trusted-publisher mappings cannot be confirmed from their public
+project APIs. These prerequisites have not been changed or waived.
+
+The latest public release remains v0.1.0. Candidate builds and authored integration
+examples are not registry publication or independent adoption.

--- a/docs/ADOPTION_ROADMAP.md
+++ b/docs/ADOPTION_ROADMAP.md
@@ -8,7 +8,7 @@ artifact verification remain requirements throughout.
 | Order | Delivery | Status |
 |---|---|---|
 | 1 | Shared panel defaults and explicit named/unknown/pooled sample scope | Implemented; 11 sample tests, Rust/CLI threshold parity, Python/native parity, cache/replay and existing evidence regressions pass |
-| 2 | Installable evidence-engine RC, executable onboarding, candidate publication gates | Prerequisites inspected; publication not performed |
+| 2 | Installable evidence-engine RC, executable onboarding, candidate publication gates | Implemented for 0.5.0-rc.1; native bundle and fresh wheel onboarding pass locally; GitHub candidate build and protected publication pending |
 | 3 | Physical field projection and bounded coalesced sparse fetches | Pending |
 | 4 | VCF.gz/BCF selection, record-preserving annotation, optional per-allele quality/position sums | Pending |
 | 5 | Verified subset/superset dataset reuse, persisted analysis, bounded Parquet and Python/R/SQL adapters | Pending |
@@ -53,3 +53,19 @@ project APIs. These prerequisites have not been changed or waived.
 
 The latest public release remains v0.1.0. Candidate builds and authored integration
 examples are not registry publication or independent adoption.
+
+## Candidate preparation evidence
+
+Source version 0.5.0 is synchronized across Cargo, Python, release policy, and
+standalone examples. The local workspace suite passed 483 tests; the Python source
+suite passed 11 tests on fresh Python 3.9 and 3.11 environments. A native archive
+and Python 3.11 wheel were installed outside the checkout and completed documented
+analysis, byte verification, offline replay, scaffold conformance, and the bundled
+evidence reducer example. Candidate SDK checks used explicit source patches;
+registry-only SDK installation remains unverified until its crates are published.
+
+Publication workflows bind platform reports to the exact tested wheel bytes and
+candidate commit, and use top-level protected OIDC upload jobs. GIAB preparation
+validates its indexed reference and input hashes; evaluator source version pinning
+is regression-tested. The full evaluator container requires its CI smoke run.
+These local results are not public release or independent-user evidence.

--- a/docs/MAINTAINER_RELEASES.md
+++ b/docs/MAINTAINER_RELEASES.md
@@ -9,17 +9,57 @@ mutations remain protected by GitHub environments.
 
 ```sh
 cargo xtask doctor --json
-cargo install cargo-public-api --version 0.50.1
+cargo install cargo-public-api --version '=0.50.1' --locked
 rustup toolchain install 1.95.0 --profile minimal
 rustup toolchain install nightly-2026-04-15 --profile minimal
 gh secret set CARGO_REGISTRY_TOKEN --repo logannye/rosalind
 ```
 
-Create `rc` and `release` repository environments with required reviewers before
-dispatching. Keep the hap.py GHCR package public after its first successful build.
-The `release` environment protects crate uploads, image pushes, and automated
-baseline PRs; `rc` protects prerelease tag creation. `doctor` checks names only and
-never reads or prints secret values.
+Create `rc` and `release` repository environments with required reviewers and
+deployment rules allowing the intended dispatch branch, normally `main`, before
+dispatching. The control plane dispatches workflows from the default branch while
+their checkout is pinned to the planned candidate SHA. A custom deployment policy
+with no allowed refs blocks every protected job.
+
+Keep the hap.py GHCR package public after its first successful build. The `release`
+environment protects crate uploads, image pushes, both Python indexes, and
+automated baseline PRs; `rc` protects prerelease tag creation. `doctor` checks names
+only and never reads or prints secret values. Its local Docker/tool diagnostics
+are distinct from the prerequisites for a build on a GitHub-hosted runner.
+
+## Python trusted publishers
+
+Wheel builds and fresh-install checks run in reusable `wheels.yml` without OIDC
+or publication privileges. Final uploads run directly in `rc.yml` and
+`release.yml`, because PyPI currently does not support a reusable workflow as a
+[trusted publisher](https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github).
+Keep the protected `release` environment on both upload jobs.
+
+Configure these exact publisher fields in each index's authenticated project
+publishing settings, or as a pending publisher if `rosalind-bio` does not yet exist:
+
+| Field | TestPyPI candidate publisher | PyPI stable publisher |
+|---|---|---|
+| Project name | `rosalind-bio` | `rosalind-bio` |
+| Repository owner | `logannye` | `logannye` |
+| Repository name | `rosalind` | `rosalind` |
+| Workflow filename | `rc.yml` | `release.yml` |
+| Environment | `release` | `release` |
+
+The workflow filename is the top-level caller, not `wheels.yml`, and does not
+include `.github/workflows/`. Account settings are separate on
+[TestPyPI](https://test.pypi.org/manage/account/publishing/) and
+[PyPI](https://pypi.org/manage/account/publishing/). GitHub secret-name inspection
+and a public project API response cannot establish whether a private pending
+publisher is configured. No long-lived PyPI token is used by these workflows.
+
+Before upload, `wheel-artifacts.py` requires exactly the three supported target
+reports, verifies the requested commit/native/Python versions, checks platform and
+distribution metadata, and verifies each tested wheel's SHA-256 and size. It
+rejects missing, extra, changed, or mismatched wheels before staging upload files.
+`verify-wheel-upload.py` then permits retrying an existing filename only when the
+index reports identical bytes. GitHub release assets retain the candidate reports;
+PyPI's upload action retains its trusted-publishing attestation behavior.
 
 Every `plan` is create-new JSON with one common report schema. Its BLAKE3 `plan_id`
 authenticates the commit, gate outcomes, contract fingerprint, metadata, and intended
@@ -66,19 +106,31 @@ and every restored input is re-hashed by `prepare.sh`.
 ## RC and stable release
 
 ```sh
-cargo xtask rc plan --version 0.4.0 --number 1 --output rc-plan.json --json
-cargo xtask rc dispatch --plan rc-plan.json --confirm PLAN_ID
-cargo xtask rc status --tag v0.4.0-rc.1 --json
+cargo xtask rc plan --version 0.5.0 --number 1 --ref FULL_CANDIDATE_SHA \
+  --output /tmp/rosalind-rc-plan.json --json
+cargo xtask rc dispatch --plan /tmp/rosalind-rc-plan.json --confirm PLAN_ID
+cargo xtask rc status --tag v0.5.0-rc.1 --json
 
-cargo xtask release plan --version 0.4.0 --rc-tag v0.4.0-rc.1 \
-  --output release-plan.json --json
-cargo xtask release dispatch --plan release-plan.json --confirm PLAN_ID
+cargo xtask release plan --version 0.5.0 --rc-tag v0.5.0-rc.1 \
+  --ref FULL_CANDIDATE_SHA --output /tmp/rosalind-release-plan.json --json
+cargo xtask release dispatch --plan /tmp/rosalind-release-plan.json --confirm PLAN_ID
 ```
 
 The stable workflow enforces an identical public-contract fingerprint, idempotent
 publication, and fresh-cache downstream installation before creating the stable
-tag. The server-timestamped seven-day soak and three partner personas begin at
-0.5.0; they do not block 0.4.0 stabilization.
+tag. The requested version must match the committed root package and release
+policy, and the clean candidate must be reachable from the pushed default branch.
+Each `PLAN_ID` is the exact ID returned by the corresponding plan. Plans are kept
+outside the checkout so they do not make the release tree dirty.
+
+The feature-bearing evidence-engine candidate uses the 0.5.0 release sequence.
+The server-timestamped seven-day soak and three partner personas apply at 0.5.0
+and later. The soak begins when the GitHub prerelease is published, after its
+TestPyPI wheels and OCI image pass their protected jobs. The historical 0.4.0
+stabilization exemption does not justify relabeling the evidence-engine release.
+Changed caller/shared-processing source additionally requires the reviewed GIAB
+baseline described below before stable promotion. Missing crate credentials or
+that baseline do not prevent preparing an RC that is clearly labeled experimental.
 
 Publication can be rerun after interruption. Each package is recreated locally and
 the downloaded registry `.crate` must have identical SHA-256 bytes before it is
@@ -123,11 +175,13 @@ normalization. Persisted evidence is replayed through that installed binary with
 local inputs. The packaged scaffold is generated, built offline against the
 candidate SDK source, and checked by the packaged conformance runner. This source
 patch is explicit pre-publication validation; fresh registry SDK installation is
-still checked separately after crate publication. Candidate build dependencies
-must already be present in Cargo's cache for the offline scaffold build.
-RC build checkouts derive `0.4.0-rc.N` native and `0.4.0rcN` Python versions with
-recorded source/manifest hashes; the tracked source version stays 0.4.0. Generated
-build reports live outside the source checkout before compilation.
+still checked separately after crate publication. The candidate smoke explicitly
+prepares its dependency cache before the locked offline scaffold build. RC build
+checkouts derive numbered native and Python versions, for example `0.5.0-rc.N` and
+`0.5.0rcN`, from the committed stable base version. Derivation records source and
+manifest hashes; it does not change the committed candidate. Generated build
+reports live outside the source checkout before compilation, then wheel hashes
+are captured after testing. Reusable builds never publish by themselves.
 
 Caller evidence is change-based: the selected variants dispatch/defaults,
 transitive local helpers, watched caller/shared-input files, and dependency lock
@@ -145,10 +199,14 @@ HG002 execution still requires the reviewed published image and prepared data.
 Python 2.7 is required by pinned hap.py 0.3.15; compatible bx-python/six wheels are
 hash-locked rather than resolved from floating dependencies.
 
-Read-only prerequisite inspection on 2026-09-05 found no repository, rc, or release
+Read-only prerequisite inspection on 2026-09-06 found no repository, rc, or release
 secrets: CARGO_REGISTRY_TOKEN is absent. Both protected environments have the owner
 as required reviewer, but custom deployment policies contain zero allowed
 branch/tag rules. Configure the intended release workflow refs before dispatch.
-PyPI/TestPyPI trusted publishers must also be configured for the reusable workflow
-and protected release environment; GitHub secret-name inspection cannot establish
-that external state. No secret values were read and no settings were changed.
+PyPI/TestPyPI trusted publishers must be configured with the top-level caller and
+protected environment listed above; GitHub secret-name inspection cannot establish
+that external state. The public PyPI/TestPyPI project APIs returned 404, which does
+not rule out a pending publisher. GitHub's setting for Actions to create/approve
+pull requests was disabled, so automatic evaluator-lock/baseline PR creation also
+needs explicit maintainer handling. No secret values were read and no settings
+were changed by that inspection.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,9 +10,13 @@ worker counts**. Insufficient resources cause refusal or failure, never hidden
 downsampling. Speed, measured memory, biological accuracy, and adoption require
 different evidence and are reported separately.
 
-These are staged release targets. The development package remains **0.4.0** until
-a release is authorized and published. See [implementation status](implementation-status.md)
-for implemented, verified, released, and adopted states.
+These milestones describe the foundation now implemented in source. The first
+feature-bearing candidate is being prepared on the **0.5.0** track; 0.4.0 was not
+published. Implemented panel/cache interfaces are preview capabilities whose
+external validation and stabilization retain the 0.6/0.7 milestones. See
+[implementation status](implementation-status.md) for implemented, verified,
+released, and adopted states, and the ordered [adoption follow-up](ADOPTION_ROADMAP.md)
+for the current work. No candidate is public until its publication is recorded.
 
 ## M0 — 0.4.0 stabilization
 

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -26,6 +26,21 @@ valid empty artifact. Selection is scientific; execution tiles are not selection
 
 ## Observation and filtering rules
 
+Sample scope is resolved before locus filtering. By default, one unambiguous
+`@RG SM` sample is selected automatically; a header without sample names has
+explicitly unknown sample identity. Multiple declared samples, or a mixture of
+named and unnamed read groups, require `--sample NAME` or `--pool-samples`.
+Named selection counts only the selected sample's read groups and refuses reads
+whose group is missing, undeclared, or has no sample assignment. Multiple read
+groups for the same sample are combined. Explicit pooling includes all records,
+including unassigned records, and is recorded as pooled rather than named.
+
+Receipts record the resolved scope as versioned `evidence.sample_scope` JSON;
+scientific and cache identities include it. `--sample NAME` and automatic
+selection of the same named sample have the same scientific scope. Reads from
+other named samples contribute no locus counters. Skipped indexed record visits
+are execution diagnostics, not unique biological read counts.
+
 The unit is **one aligned read base**, not a fragment or UMI consensus. Overlapping
 mates count separately, and orphaned/improper pairs are not automatically removed.
 Only CIGAR M, =, and X contribute matched observations. D and N consume reference
@@ -84,6 +99,8 @@ remain in the denominator and minimum depth. Breadth counts positions reaching
 callable-position threshold. Without a reference, BAM dictionary coordinates are
 used and reference bases are N; no reference-dependent statistic is inferred.
 `--position-output` writes Arrow evidence from the same pass as the target summary.
+The Rust, CLI, and Python panel interfaces share the 10x default; Python delegates
+the default to its matching native executable and passes only explicit overrides.
 
 ## Execution and memory
 

--- a/docs/analyzer-sdk.md
+++ b/docs/analyzer-sdk.md
@@ -1,9 +1,35 @@
 # Analyzer SDK
 
+## Build prerequisites
+
+An installed native binary or wheel needs no Rust compiler. Building Rosalind or
+an analyzer needs Rust/Cargo, a C and C++ compiler, CMake, and pkg-config; htslib's
+compression dependencies also need development headers. Use a current stable
+Rust toolchain for a newly resolved analyzer dependency graph. The source checkout
+declares its minimum supported Rust version in `Cargo.toml` and tests it with the
+repository lockfile.
+
+On Debian/Ubuntu, install the native prerequisites before running Cargo:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y build-essential clang cmake pkg-config libbz2-dev liblzma-dev zlib1g-dev
+```
+
+On macOS, install Xcode Command Line Tools (`xcode-select --install`) and, with
+Homebrew, `brew install cmake pkg-config xz`. Python source wheel builds additionally
+need Python 3.9+ and Maturin; see [Python installation](../python/README.md).
+
+## Exact evidence consumers
+
 Use `rosalind::evidence` for new exact short-read evidence consumers. Open an
 `EvidenceRequest`, resolve its VCF/BED selection against the engine's contigs, and
 pass an `EvidenceAnalyzer` to `run`. The independent
 [example crate](../examples/evidence-analyzer/) demonstrates the full public path.
+The source checkout uses a local Cargo dependency. Native bundles include its
+manifest, lockfile, and Rust source, with the manifest rendered to the bundle's
+exact registry SDK version; `ONBOARDING-BUNDLE.json` records that transformation.
+An unpublished candidate still needs the explicit source patches described below.
 
 An analyzer declares `EvidenceRequirements`: field capabilities, whether real
 reference bases are required, flanking context, and a conservative peak retained
@@ -28,12 +54,37 @@ See [SEMANTICS.md](SEMANTICS.md) for depth/filter/coordinate rules.
 
 `ColumnAnalyzer` remains for existing pileup-column consumers and the scaffold:
 
+<!-- smoke:legacy-scaffold -->
 ```sh
 rosalind new analyzer locus-qc --output ./locus-qc
 cd locus-qc
 cargo test
-rosalind conformance analyzer --binary ./target/release/locus-qc --json
+cargo build --release --locked --offline
+rosalind conformance analyzer --binary ./target/release/locus-qc --json > conformance.json
 ```
+
+`cargo test` creates debug test artifacts; the explicit release build creates the
+binary used by conformance, using the dependencies already fetched by the tests.
+Run this sequence in a fresh directory with the desired `rosalind` on `PATH`,
+and leave `CARGO_TARGET_DIR` unset so the documented
+binary path is correct. The generated manifest pins the SDK version to the
+generating executable. It resolves from crates.io only after that exact version
+is published.
+
+For an unpublished checkout or candidate, add explicit local patches to the
+generated `locus-qc/Cargo.toml` before running Cargo. Replace the example paths
+with absolute paths to that same candidate checkout:
+
+```toml
+[patch.crates-io]
+rosalind-bio = { path = "/absolute/path/to/rosalind" }
+rosalind-build-info = { path = "/absolute/path/to/rosalind/crates/build-info" }
+```
+
+This validates the candidate SDK, not a registry installation. Remove those
+patches and regenerate the lockfile to validate a subsequently published SDK.
+The maintained package smokes distinguish `--candidate-source PATH` from
+`--registry-sdk`; only the latter tests registry-only resolution.
 
 `run_column_analysis(analyzer, spec)` owns reference/BAM validation, prediction,
 refusal, governance, atomic output, receipt sealing, and replay.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,7 +1,14 @@
 # Evidence engine implementation status
 
-Updated 2026-09-05 for `codex/evidence-engine-roadmap`. The tracked package remains
-**0.4.0**. M1–M3 version numbers are targets, not available releases.
+Updated 2026-09-06. The evidence-engine foundation was merged in PR #97. The current
+development package is **0.5.0**, preparing the first feature-bearing RC; no 0.4
+release was published. M1–M3 releases and independent adoption remain separate
+from implementation. Current follow-up work is recorded in
+[ADOPTION_ROADMAP.md](ADOPTION_ROADMAP.md).
+
+Sample-scope and panel-default corrections now pass focused Rust, CLI, Python,
+cache/replay, and existing engine conformance checks. No new candidate has been
+published by this follow-up work.
 
 | Phase | Code state | Verification state | Released | External adoption |
 |---|---|---|---|---|

--- a/examples/evidence-analyzer/Cargo.lock
+++ b/examples/evidence-analyzer/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rosalind-bio"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/python/README.md
+++ b/python/README.md
@@ -2,8 +2,14 @@
 
 The mixed Maturin wheel bundles the matching `rosalind` executable. The distribution
 is `rosalind-bio`; import `rosalind`. Python 3.9+ is declared and tested by candidate
-wheel CI. The source version remains 0.4.0; new evidence APIs are under development,
-and no future-version public wheel is implied.
+wheel CI. The source version is 0.5.0; these changes are unpublished until the
+release gates complete. A source version does not establish registry availability.
+
+Installing a prebuilt wheel needs Python, pip, and its declared PyArrow dependency;
+it does not need a compiler. Building a wheel from source needs Rust/Cargo and the
+[native build prerequisites](../docs/analyzer-sdk.md#build-prerequisites), including
+CMake and the C/C++ toolchain. The commands below also fetch build dependencies;
+the source build is not an offline installation procedure.
 
 Build and install from the repository root:
 
@@ -15,22 +21,31 @@ python3 -m venv /tmp/rosalind-python
 ```
 
 Run Python outside the repository to verify the installed package is being used.
-RC versions are normalized between native `0.4.0-rc.N` and Python `0.4.0rcN`;
+RC versions are normalized between native `0.5.0-rc.N` and Python `0.5.0rcN`;
 different RC numbers and stable versions do not count as a match.
 
+Supply an indexed `genome.fa`, indexed `sample.bam`, SNV-only `candidates.vcf`,
+and `targets.bed`. Start in a fresh output directory so create-new artifacts do
+not collide with a previous run. This example counts rows without retaining
+whole-genome Python state:
+
+<!-- smoke:python-evidence -->
 ```python
 from rosalind import iter_evidence, materialize_evidence, panel_qc
 
+rows = 0
 with iter_evidence("genome.fa", "sample.bam", sites="candidates.vcf",
                    memory_budget_mb=256) as run:
     for batch in run:
-        consume(batch)
+        rows += batch.num_rows
     assert run.result is not None
+print(f"Extracted {rows} candidate loci")
 
 result = materialize_evidence("genome.fa", "sample.bam", "evidence.arrow",
                               regions="targets.bed", memory_budget_mb=256)
 summary = panel_qc("sample.bam", "targets.bed", "panel.tsv",
                    reference="genome.fa", min_callable_depth=10)
+assert summary.returncode == 0
 ```
 
 `iter_evidence` yields canonical native Arrow batches of at most 1,024 rows and
@@ -45,6 +60,15 @@ excludes unavailable qualities, and never downsamples. See
 [SEMANTICS.md](../docs/SEMANTICS.md). Errors expose native exit codes through
 `EvidenceProcessError`. Cache/resume and workers are explicit execution options;
 all genomic processing stays local.
+
+Maintainers run `scripts/smoke-wheel.sh path/to/candidate.whl --candidate-source
+/absolute/path/to/rosalind` to install into a fresh environment, check exact
+native/Python version identity, and execute this README example outside the
+checkout. The generated analyzer is explicitly patched to that candidate source.
+After the matching SDK is published, `--registry-sdk` replaces the source option
+and requires a fresh registry-only analyzer build; a source-patched smoke is not
+evidence of registry installability. The smoke fetches dependencies before its
+locked offline SDK build and then performs local receipt verification/replay.
 
 Legacy `iter_features` and `collect_features` remain available with their original
 feature schema. `collect_features` explicitly materializes the whole result in

--- a/python/rosalind/__init__.py
+++ b/python/rosalind/__init__.py
@@ -10,7 +10,7 @@ try:
     __version__ = version("rosalind-bio")
 except PackageNotFoundError:
     # Source-tree fallback; release wheels derive this value from Cargo metadata.
-    __version__ = "0.4.0"
+    __version__ = "0.5.0"
 
 __all__ = [
     "EvidenceProcessError",

--- a/python/rosalind/evidence.py
+++ b/python/rosalind/evidence.py
@@ -125,7 +125,8 @@ def _command(
     max_read_len: int = 250, tile_bases: int = 16384, workers: int = 1,
     cache_dir: Optional[PathLike] = None, resume: bool = False,
     cram_reference: Optional[PathLike] = None, panel: bool = False,
-    min_callable_depth: int = 10,
+    min_callable_depth: Optional[int] = None,
+    sample: Optional[str] = None, pool_samples: bool = False,
 ) -> list[str]:
     if (sites is None) == (regions is None):
         raise ValueError("supply exactly one of sites (VCF) or regions (BED)")
@@ -133,6 +134,12 @@ def _command(
         raise ValueError("panel QC requires BED regions")
     if not panel and reference is None:
         raise ValueError("SNV evidence requires an explicit reference")
+    if sample is not None and pool_samples:
+        raise ValueError("sample and pool_samples are mutually exclusive")
+    if sample is not None and not sample:
+        raise ValueError("sample must be a nonempty declared sample name")
+    if not panel and min_callable_depth is not None:
+        raise ValueError("min_callable_depth is a panel QC option")
     executable = _resolve_binary(binary, allow_version_mismatch)
     command = [str(executable), "analyze", "panel-qc" if panel else "evidence",
                "--alignments", str(alignments), "--mapq-threshold", str(mapq),
@@ -150,7 +157,12 @@ def _command(
         command += ["--cache-dir", str(cache_dir)]
     if resume:
         command.append("--resume")
-    if panel:
+    if sample is not None:
+        command += ["--sample", sample]
+    if pool_samples:
+        command.append("--pool-samples")
+    # The native executable owns the shared default; Python only passes overrides.
+    if panel and min_callable_depth is not None:
         command += ["--min-callable-depth", str(min_callable_depth)]
     return command
 
@@ -164,6 +176,8 @@ def iter_evidence(
     Histograms, counts and sums use the versioned shortread-dna-readcount-v1
     profile. Default MAPQ and base quality thresholds are both 20. Overlapping
     mates count as separate reads. A supplied budget governs the native process.
+    Use ``sample="name"`` for a declared SM sample or ``pool_samples=True`` for
+    deliberate pooling. Ambiguous sample scope is refused by default.
     """
     command = _command(reference, alignments, **options)
     directory = Path(workdir) if workdir else Path(tempfile.mkdtemp(prefix="rosalind-evidence-"))
@@ -186,7 +200,11 @@ def panel_qc(
     alignments: PathLike, regions: PathLike, output: PathLike, *,
     reference: Optional[PathLike] = None, force: bool = False, **options: object,
 ) -> EvidenceResult:
-    """Persist per-target TSV summaries with explicit coverage denominators."""
+    """Persist per-target TSV summaries with explicit coverage denominators.
+
+    The matching native executable supplies the shared 10x callability default;
+    pass ``min_callable_depth`` to override it explicitly.
+    """
     command = _command(reference, alignments, regions=regions, panel=True, **options)
     return _materialize(command, output, "tsv", force)
 

--- a/python/tests/test_evidence_contract.py
+++ b/python/tests/test_evidence_contract.py
@@ -1,0 +1,100 @@
+"""Scientific contract parity through the real native CLI, not a mock producer."""
+
+import csv
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import pysam
+
+from rosalind import EvidenceProcessError, materialize_evidence, panel_qc
+
+
+class EvidenceContractTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.binary = Path(os.environ.get(
+            "ROSALIND_BINARY", Path(__file__).resolve().parents[2] / "target/debug/rosalind"
+        )).resolve()
+        if not self.binary.is_file():
+            self.fail("build rosalind and set ROSALIND_BINARY to test the native contract")
+        self.reference = self.root / "reference.fa"
+        self.reference.write_text(">chr1\n" + "A" * 64 + "\n")
+        pysam.faidx(str(self.reference))
+        self.bam = self.root / "reads.bam"
+        header = {"HD": {"VN": "1.6", "SO": "coordinate"},
+                  "SQ": [{"SN": "chr1", "LN": 64}],
+                  "RG": [{"ID": "a", "SM": "alpha"}, {"ID": "b", "SM": "beta"}]}
+        with pysam.AlignmentFile(str(self.bam), "wb", header=header) as writer:
+            for position, depth in enumerate((9, 10, 19, 20)):
+                for i in range(depth + 1):
+                    read = pysam.AlignedSegment(writer.header)
+                    read.query_name = f"r{position}-{i}"
+                    read.query_sequence = "A"
+                    read.query_qualities = [40]
+                    read.reference_id = 0
+                    read.reference_start = position
+                    read.mapping_quality = 60
+                    read.cigarstring = "1M"
+                    read.set_tag("RG", "a" if i < depth else "b")
+                    writer.write(read)
+        pysam.index(str(self.bam))
+        self.bed = self.root / "targets.bed"
+        self.bed.write_text("".join(f"chr1\t{p}\t{p+1}\tdepth-{d}\n"
+                                    for p, d in enumerate((9, 10, 19, 20))))
+
+    def panel(self, name, **options):
+        result = panel_qc(self.bam, self.bed, self.root / name,
+                          reference=self.reference, binary=self.binary, **options)
+        with result.artifact_path.open() as source:
+            rows = list(csv.DictReader(source, delimiter="\t"))
+        return result, rows
+
+    def test_python_and_cli_defaults_match_at_callability_boundaries(self):
+        result, rows = self.panel("python.tsv", sample="alpha")
+        self.assertEqual([r["callable_positions"] for r in rows], ["0", "1", "1", "1"])
+        self.assertEqual({r["callable_threshold"] for r in rows}, {"10"})
+        native = self.root / "native.tsv"
+        subprocess.run([str(self.binary), "analyze", "panel-qc", "--alignments", str(self.bam),
+                        "--reference", str(self.reference), "--regions", str(self.bed),
+                        "--sample", "alpha", "--output", str(native)], check=True,
+                       capture_output=True)
+        self.assertEqual(result.artifact_path.read_bytes(), native.read_bytes())
+        _, explicit = self.panel("explicit.tsv", sample="alpha", min_callable_depth=20)
+        self.assertEqual([r["callable_positions"] for r in explicit], ["0", "0", "0", "1"])
+
+    def test_multiple_samples_require_explicit_scope_and_cache_keeps_it(self):
+        with self.assertRaises(EvidenceProcessError) as caught:
+            self.panel("implicit.tsv")
+        self.assertEqual(caught.exception.returncode, 2)
+        self.assertFalse((self.root / "implicit.tsv").exists())
+        cache = self.root / "cache"
+        alpha, alpha_rows = self.panel("alpha.tsv", sample="alpha", cache_dir=cache)
+        beta, beta_rows = self.panel("beta.tsv", sample="beta", cache_dir=cache, resume=True)
+        pooled, pooled_rows = self.panel("pooled.tsv", pool_samples=True)
+        self.assertEqual([int(r["callable_depth_sum"]) for r in alpha_rows], [9, 10, 19, 20])
+        self.assertEqual([int(r["callable_depth_sum"]) for r in beta_rows], [1, 1, 1, 1])
+        self.assertEqual([int(r["callable_depth_sum"]) for r in pooled_rows], [10, 11, 20, 21])
+        receipts = [json.loads(r.manifest_path.read_text()) for r in (alpha, beta, pooled)]
+        self.assertEqual(len({r["params"]["evidence.science_blake3"] for r in receipts}), 3)
+        for receipt in receipts:
+            self.assertIn("evidence.sample_scope", receipt["params"])
+        subprocess.run([str(self.binary), "reproduce", "--manifest", str(alpha.manifest_path),
+                        "--inputs", str(self.root), "--binary", str(self.binary), "--no-attest"],
+                       check=True, capture_output=True)
+
+    def test_conflicting_sample_options_fail_before_execution(self):
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            materialize_evidence(self.reference, self.bam, self.root / "conflict.arrow",
+                                 regions=self.bed, binary=self.binary,
+                                 sample="alpha", pool_samples=True)
+        self.assertFalse((self.root / "conflict.arrow").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/release/design-partners/README.md
+++ b/release/design-partners/README.md
@@ -6,4 +6,4 @@ This directory accepts only completed `feedback.json` records produced by
 Do not commit names, contact details, organizations, credentials, genomic data, or
 raw interview notes. Keep private material outside the repository or under the
 ignored `release/private-design-partners/` directory. One accepted record for each
-required persona is necessary before stable v0.4.0 promotion.
+required persona is necessary before stable promotion from v0.5.0 onward.

--- a/release/policy.toml
+++ b/release/policy.toml
@@ -29,7 +29,7 @@ required_secrets = ["CARGO_REGISTRY_TOKEN"]
 partner_personas = ["analyzer-builder", "workflow-hpc", "constrained-offline"]
 publish_order = ["rosalind-build-info", "rosalind-receipt", "rosalind-bio"]
 
-package_versions = { rosalind-build-info = "0.1.0", rosalind-receipt = "0.3.0", rosalind-bio = "0.4.0" }
+package_versions = { rosalind-build-info = "0.1.0", rosalind-receipt = "0.3.0", rosalind-bio = "0.5.0" }
 
 cli_help = [
   "",
@@ -37,6 +37,10 @@ cli_help = [
   "variants",
   "features",
   "analyze",
+  "analyze evidence",
+  "analyze panel-qc",
+  "analyze coverage",
+  "analyze features",
   "sort",
   "somatic",
   "eval-somatic",

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Stage/check offline guide links and execute maintained onboarding snippets."""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+GUIDES = ("README.md", "CONTRACT.md", "docs/analyzer-sdk.md", "python/README.md")
+EXCLUDED_PARTS = {".git", "target", "dist", "release", "private", "secrets", ".env",
+                  "__pycache__", ".venv", "venv", "node_modules"}
+MAX_GUIDE_BYTES = 8 << 20
+# Files used by maintained code blocks rather than Markdown hyperlinks. These
+# narrow reviewed paths are not permission to copy arbitrary example data.
+CODE_FILES = (
+    "examples/research-filter/prepare.py", "examples/research-filter/join.py",
+    "examples/research-filter/sources.json", "examples/evidence-analyzer/Cargo.toml",
+    "examples/evidence-analyzer/Cargo.lock", "examples/evidence-analyzer/src/main.rs",
+)
+CODE_DIRECTORIES = ("integrations/nextflow", "integrations/snakemake")
+
+
+def local_links(document, root):
+    """Resolve local Markdown destinations; anchors and remote URLs need no files."""
+    content = document.read_text(encoding="utf-8")
+    content = re.sub(r"^```[^\n]*\n.*?^```\s*$", "", content, flags=re.M | re.S)
+    for target in re.findall(r"\]\((<[^>]+>|[^\s)]+)(?:\s+\"[^\"]*\")?\)", content):
+        parsed = urlsplit(target.strip("<>"))
+        if parsed.scheme or parsed.netloc or not parsed.path:
+            continue
+        destination = (document.parent / unquote(parsed.path)).resolve()
+        try:
+            destination.relative_to(root)
+        except ValueError as error:
+            raise ValueError(f"{document}: link escapes bundle: {target}") from error
+        if not destination.exists():
+            raise ValueError(f"{document}: missing local link: {target}")
+        yield destination
+
+
+def guide_closure(root):
+    """Follow linked Markdown and directory READMEs, including their local assets."""
+    root = Path(root).resolve()
+    pending = [root / name for name in GUIDES]
+    documents = set()
+    assets = set(pending)
+    while pending:
+        document = pending.pop()
+        if document in documents:
+            continue
+        if not document.is_file():
+            raise ValueError(f"missing onboarding guide: {document}")
+        documents.add(document)
+        for destination in local_links(document, root):
+            assets.add(destination)
+            if destination.is_dir():
+                readme = destination / "README.md"
+                if readme.is_file():
+                    pending.append(readme)
+            elif destination.suffix.lower() == ".md":
+                pending.append(destination)
+    return documents, assets
+
+
+def stage_guides(source, destination):
+    source = Path(source).resolve()
+    destination = Path(destination).resolve()
+    _, assets = guide_closure(source)
+    files = set()
+    directories = set()
+
+    def validate(asset):
+        relative = asset.resolve().relative_to(source)
+        if not relative.parts or any(part in EXCLUDED_PARTS for part in relative.parts):
+            raise ValueError(f"onboarding link cannot package source/private/build directory: {asset}")
+        if asset.is_dir() and destination.is_relative_to(asset.resolve()):
+            raise ValueError(f"onboarding directory contains staging destination: {asset}")
+
+    for asset in assets:
+        validate(asset)
+        if not asset.is_dir():
+            files.add(asset)
+            continue
+        directories.add(asset)
+        if (asset / "README.md").is_file():
+            # A directory link navigates to its guide. Only explicitly linked
+            # assets are included; generated files and ignored inputs are not.
+            files.add(asset / "README.md")
+            continue
+        # Historical result/fixture directory links intentionally identify raw
+        # artifacts. Include only Git-tracked files, never arbitrary local files.
+        relative = asset.relative_to(source)
+        tracked = subprocess.check_output(
+            ["git", "-C", str(source), "ls-files", "-z", "--", str(relative) + "/"]
+        ).decode().split("\0")
+        if not any(tracked):
+            raise ValueError(f"linked artifact directory has no tracked files: {asset}")
+        for name in filter(None, tracked):
+            path = source / name
+            validate(path)
+            if path.is_file():
+                files.add(path)
+    for name in CODE_FILES:
+        path = source / name
+        if path.is_file():
+            validate(path)
+            files.add(path)
+    for name in CODE_DIRECTORIES:
+        if not (source / name).is_dir():
+            continue
+        tracked = subprocess.check_output(
+            ["git", "-C", str(source), "ls-files", "-z", "--", name + "/"]
+        ).decode().split("\0")
+        for name in filter(None, tracked):
+            path = source / name
+            validate(path)
+            if path.is_file():
+                files.add(path)
+    total = sum(path.stat().st_size for path in files)
+    if total > MAX_GUIDE_BYTES:
+        raise ValueError(f"offline guides total {total} bytes; link large results remotely instead of bundling them")
+    for directory in directories:
+        (destination / directory.relative_to(source)).mkdir(parents=True, exist_ok=True)
+    for asset in sorted(files):
+        output = destination / asset.relative_to(source)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(asset, output)
+    example_manifest = destination / "examples/evidence-analyzer/Cargo.toml"
+    if example_manifest.is_file():
+        source_manifest = (source / "Cargo.toml").read_text()
+        version = re.search(r'^version\s*=\s*"([^"]+)"', source_manifest, flags=re.M).group(1)
+        old = 'rosalind-bio = { path = "../.." }'
+        new = f'rosalind-bio = {{ version = "={version}" }}'
+        manifest = example_manifest.read_text()
+        if manifest.count(old) != 1:
+            raise ValueError("standalone example path dependency changed; review bundle rendering")
+        example_manifest.write_text(manifest.replace(old, new))
+        metadata = {
+            "source_commit": subprocess.check_output(
+                ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+            ).strip(),
+            "source_tree_dirty": bool(subprocess.check_output(
+                ["git", "-C", str(source), "status", "--porcelain"], text=True
+            ).strip()),
+            "sdk_registry_version": version,
+            "rendered_manifest": "examples/evidence-analyzer/Cargo.toml",
+            "original_dependency": old,
+            "bundled_dependency": new,
+            "note": "Source Cargo.lock is retained; the first registry resolution may update it. Candidate SDK validation requires explicit source patches.",
+        }
+        (destination / "ONBOARDING-BUNDLE.json").write_text(json.dumps(metadata, indent=2) + "\n")
+        example_readme = example_manifest.with_name("README.md")
+        if example_readme.is_file():
+            example_readme.write_text(
+                "> Bundle note: Cargo.toml now pins the exact registry SDK version recorded in "
+                "`../../ONBOARDING-BUNDLE.json`. For an unpublished candidate, configure the "
+                "explicit source patches in the SDK guide before invoking Cargo.\n\n"
+                + example_readme.read_text()
+            )
+        tutorial = destination / "examples/research-filter/README.md"
+        if tutorial.is_file():
+            text = tutorial.read_text().replace("target/debug/rosalind", "./rosalind")
+            text = text.replace(
+                "Build the current development CLI first (`cargo build --locked --bin rosalind`).\nFrom the repository root,",
+                "Use the executable included in this native bundle.\nFrom the extracted bundle root,",
+            )
+            tutorial.write_text(text)
+            metadata["rendered_tutorial"] = "examples/research-filter/README.md"
+            metadata["tutorial_binary"] = "./rosalind"
+            (destination / "ONBOARDING-BUNDLE.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    documents, _ = guide_closure(destination)
+    return len(documents)
+
+
+def snippet(markdown, name, language):
+    expression = r"<!-- smoke:" + re.escape(name) + r" -->\s*```" + language + r"\n(.*?)\n```"
+    matches = re.findall(expression, markdown, flags=re.S)
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name} onboarding snippet, found {len(matches)}")
+    return matches[0]
+
+
+def command(args, **kwargs):
+    subprocess.run([str(arg) for arg in args], check=True, **kwargs)
+
+
+def python_executable(path):
+    # Resolving the venv/bin/python symlink executes its base interpreter and
+    # loses the installed environment. Normalize cwd without following symlinks.
+    path = Path(os.path.abspath(path))
+    if not path.is_file():
+        raise ValueError(f"Python executable is missing: {path}")
+    return path
+
+
+def candidate_config(source, native_version):
+    """Return explicit Cargo patches after checking this is the matching source."""
+    manifest = (source / "Cargo.toml").read_text()
+    version = re.search(r'^version\s*=\s*"([^"]+)"', manifest, flags=re.M)
+    if version is None or version.group(1) != native_version:
+        raise ValueError("candidate source Cargo version does not match packaged executable")
+    return "[patch.crates-io]\n" + "".join(
+        f"{name} = {{ path = {json.dumps(str(path))} }}\n"
+        for name, path in (
+            ("rosalind-bio", source),
+            ("rosalind-build-info", source / "crates/build-info"),
+        )
+    )
+
+
+def smoke(args):
+    bundle = args.bundle.resolve()
+    binary = args.binary.resolve(strict=True)
+    documents, _ = guide_closure(bundle)
+    print(f"offline onboarding links: {len(documents)} reachable guides", flush=True)
+    native_version = subprocess.check_output([str(binary), "--version"], text=True).strip().split()[-1]
+    source = args.candidate_source.resolve(strict=True) if args.candidate_source else None
+    with tempfile.TemporaryDirectory(prefix="rosalind-onboarding-") as temporary:
+        work = Path(temporary).resolve()
+        environment = os.environ.copy()
+        environment.pop("CARGO_TARGET_DIR", None)
+        environment.pop("PYTHONPATH", None)
+        environment["PYTHONNOUSERSITE"] = "1"
+        environment["PATH"] = str(binary.parent) + os.pathsep + environment.get("PATH", "")
+        # Avoid inheriting user Cargo config/patches, including in registry mode.
+        environment["CARGO_HOME"] = str(work / "cargo-home")
+        if source is not None:
+            config = work / ".cargo/config.toml"
+            config.parent.mkdir()
+            config.write_text(candidate_config(source, native_version))
+            print(f"SDK origin: explicit candidate source {source}; not registry validation", flush=True)
+        else:
+            print(f"SDK origin: registry-only exact version {native_version}", flush=True)
+        sdk = snippet((bundle / "docs/analyzer-sdk.md").read_text(), "legacy-scaffold", "sh")
+        command(["bash", "-euo", "pipefail", "-c", sdk], cwd=work, env=environment)
+        report = json.loads((work / "locus-qc/conformance.json").read_text())
+        if report.get("passed") is not True:
+            raise ValueError(f"packaged scaffold conformance failed: {report}")
+        generated = (work / "locus-qc/Cargo.toml").read_text()
+        if f'version = "={native_version}"' not in generated:
+            raise ValueError("scaffold SDK version differs from packaged executable")
+        if not (work / "locus-qc/Cargo.lock").is_file():
+            raise ValueError("documented analyzer build did not retain a lockfile")
+        example = bundle / "examples/evidence-analyzer"
+        if example.is_dir():
+            for name in ("Cargo.toml", "Cargo.lock", "src/main.rs"):
+                if not (example / name).is_file():
+                    raise ValueError(f"bundled standalone analyzer is missing {name}")
+            standalone = work / "evidence-analyzer"
+            shutil.copytree(example, standalone)
+            # Resolve the retained source lockfile against the explicitly chosen
+            # SDK origin, then compile/test the actual packaged Rust example.
+            command(["cargo", "fetch", "--manifest-path", standalone / "Cargo.toml"],
+                    cwd=work, env=environment)
+            command(["cargo", "test", "--manifest-path", standalone / "Cargo.toml",
+                     "--locked", "--offline", "--target-dir", work / "locus-qc/target"],
+                    cwd=work, env=environment)
+        if args.python:
+            python = python_executable(args.python)
+            fixture = work / "python-example"
+            fixture.mkdir()
+            shutil.copy2(bundle / "examples/data/illumina_toy/reference.fa", fixture / "genome.fa")
+            command([binary, "sort", "--input", bundle / "examples/data/illumina_toy/alignments.bam",
+                     "--output", fixture / "sample.bam"], env=environment)
+            # Execute the README embedded in the installed wheel's metadata,
+            # not an import or example accidentally taken from the checkout.
+            program = r'''
+import importlib.metadata
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import sysconfig
+import pysam
+import rosalind
+from rosalind.features import _normalized_version
+
+binary = pathlib.Path(sysconfig.get_path("scripts")) / "rosalind"
+assert binary.resolve() == pathlib.Path(sys.argv[1]).resolve()
+native = subprocess.check_output([str(binary), "--version"], text=True).strip().split()[-1]
+assert _normalized_version(native) == _normalized_version(rosalind.__version__)
+assert pathlib.Path(rosalind.__file__).resolve().is_relative_to(pathlib.Path(sys.prefix).resolve())
+pysam.faidx("genome.fa")
+pysam.index("sample.bam")
+with pysam.FastaFile("genome.fa") as reference:
+    contig = reference.references[0]
+    length = min(100, reference.lengths[0])
+    base = reference.fetch(contig, 0, 1).upper()
+alternate = next(nucleotide for nucleotide in "ACGT" if nucleotide != base)
+pathlib.Path("targets.bed").write_text(f"{contig}\t0\t{length}\tfirst\n")
+pathlib.Path("candidates.vcf").write_text(
+    "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    f"{contig}\t1\t.\t{base}\t{alternate}\t.\tPASS\t.\n")
+readme = importlib.metadata.metadata("rosalind-bio").get_payload()
+blocks = re.findall(r"<!-- smoke:python-evidence -->\s*```python\n(.*?)\n```", readme, re.S)
+assert len(blocks) == 1, "installed wheel README lacks its executable onboarding example"
+namespace = {}
+exec(compile(blocks[0], "installed-wheel-README", "exec"), namespace)
+assert namespace["rows"] == 1
+assert namespace["result"].returncode == 0
+assert namespace["summary"].returncode == 0
+for result in (namespace["result"], namespace["summary"]):
+    subprocess.run([str(binary), "verify", "--manifest", str(result.manifest_path)], check=True)
+with pathlib.Path("replay.json").open("w") as output:
+    subprocess.run([str(binary), "reproduce", "--manifest", str(namespace["result"].manifest_path),
+                    "--inputs", str(pathlib.Path.cwd()), "--binary", str(binary), "--json"],
+                   stdout=output, check=True)
+print(f"installed wheel README passed with native/Python identity {native}")
+'''
+            command([python, "-c", program, binary], cwd=fixture, env=environment)
+    print("packaged onboarding snippets and conformance passed outside the checkout", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="action", required=True)
+    stage = commands.add_parser("stage")
+    stage.add_argument("source", type=Path)
+    stage.add_argument("destination", type=Path)
+    check = commands.add_parser("check")
+    check.add_argument("bundle", type=Path)
+    run = commands.add_parser("smoke")
+    run.add_argument("--bundle", type=Path, required=True)
+    run.add_argument("--binary", type=Path, required=True)
+    run.add_argument("--python", type=Path)
+    origin = run.add_mutually_exclusive_group(required=True)
+    origin.add_argument("--candidate-source", type=Path)
+    origin.add_argument("--registry-sdk", action="store_true")
+    args = parser.parse_args()
+    if args.action == "stage":
+        print(f"staged {stage_guides(args.source, args.destination)} linked onboarding guides")
+    elif args.action == "check":
+        documents, _ = guide_closure(args.bundle)
+        print(f"offline onboarding links: {len(documents)} reachable guides")
+    else:
+        smoke(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-release.sh
+++ b/scripts/smoke-release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if [[ "$#" -lt 2 ]]; then
+  echo "usage: $0 bundle.tar.gz (--candidate-source PATH | --registry-sdk)" >&2
+  exit 2
+fi
+ARCHIVE="$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' "$1")"
+shift
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+tar -xzf "$ARCHIVE" -C "$WORK"
+BUNDLES=("$WORK"/rosalind-*)
+if [[ "${#BUNDLES[@]}" -ne 1 || ! -x "${BUNDLES[0]}/rosalind" ]]; then
+  echo "expected one native Rosalind bundle" >&2
+  exit 2
+fi
+python3 "$ROOT/scripts/onboarding.py" smoke --bundle "${BUNDLES[0]}" \
+  --binary "${BUNDLES[0]}/rosalind" "$@"

--- a/scripts/smoke-wheel.sh
+++ b/scripts/smoke-wheel.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-if [[ "$#" -ne 1 ]]; then
-  echo "usage: $0 path/to/candidate.whl" >&2
+PYTHON="${PYTHON:-python3}"
+if [[ "$#" -lt 2 ]]; then
+  echo "usage: $0 candidate.whl (--candidate-source PATH | --registry-sdk)" >&2
   exit 2
 fi
+case "$2" in
+  --candidate-source)
+    [[ "$#" -eq 3 ]] || { echo "--candidate-source needs one path" >&2; exit 2; }
+    SOURCE="$("$PYTHON" -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' "$3")"
+    ORIGIN=(--candidate-source "$SOURCE")
+    ;;
+  --registry-sdk)
+    [[ "$#" -eq 2 ]] || { echo "--registry-sdk takes no path" >&2; exit 2; }
+    ORIGIN=(--registry-sdk)
+    ;;
+  *) echo "choose --candidate-source PATH or --registry-sdk" >&2; exit 2 ;;
+esac
 # Resolve before entering the isolated work directory; never install a different
 # candidate merely because the caller supplied a relative path.
-WHEEL="$(python -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' "$1")"
+WHEEL="$("$PYTHON" -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve(strict=True))' "$1")"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
-python -m venv "$WORK/venv"
+"$PYTHON" -m venv "$WORK/venv"
 "$WORK/venv/bin/pip" install "$WHEEL"
 "$WORK/venv/bin/pip" install 'pysam==0.23.3'
 "$WORK/venv/bin/rosalind" --version
@@ -18,10 +31,8 @@ python -m venv "$WORK/venv"
 "$WORK/venv/bin/rosalind" reference build --fasta "$ROOT/examples/data/illumina_toy/reference.fa" --output "$WORK/reference.rref"
 # Run outside the checkout so import cannot accidentally use source Python files.
 cd "$WORK"
-export ROSALIND_SMOKE_SOURCE_ROOT="$ROOT"
 "$WORK/venv/bin/python" - <<'PY'
 import json
-import os
 import rosalind
 import pysam
 import subprocess
@@ -54,30 +65,13 @@ summary = rosalind.panel_qc("sorted.bam", "targets.bed", "panel.tsv", reference=
 assert summary.returncode == 0
 print("installed version identity, evidence stream, materialization, offline replay and panel QC passed")
 
-# The packaged executable supplies every scaffold file and runs conformance.
-# Before registry publication, resolve its SDK dependencies to this candidate's
-# source checkout. Fetch the generated SDK consumer's dependencies explicitly:
-# on Linux maturin's container does not populate the host Cargo registry. The
-# subsequent locked offline build proves compilation needs no further network.
-source = Path(os.environ["ROSALIND_SMOKE_SOURCE_ROOT"])
-scaffold = Path("wheel-smoke-analyzer").resolve()
-subprocess.run([str(binary), "new", "analyzer", "wheel-smoke-analyzer", "--output", str(scaffold)], check=True)
-assert f'version = "={native_version}"' in (scaffold / "Cargo.toml").read_text()
-target = source / "target" / "wheel-sdk-smoke"
-sdk_args = [
-    "--manifest-path", str(scaffold / "Cargo.toml"),
-    "--config", "patch.crates-io.rosalind-bio.path=" + json.dumps(str(source)),
-    "--config", "patch.crates-io.rosalind-build-info.path=" + json.dumps(str(source / "crates/build-info")),
-]
-subprocess.run(["cargo", "fetch", *sdk_args], check=True)
-assert (scaffold / "Cargo.lock").is_file(), "dependency preparation must lock the scaffold"
-subprocess.run([
-    "cargo", "build", "--locked", "--offline", *sdk_args,
-    "--target-dir", str(target),
-], check=True)
-with Path("scaffold.conformance.json").open("w") as report:
-    subprocess.run([str(binary), "conformance", "analyzer", "--binary",
-                    str(target / "debug/wheel-smoke-analyzer"), "--json"], stdout=report, check=True)
-assert json.loads(Path("scaffold.conformance.json").read_text())["passed"]
-print("packaged scaffold built offline against candidate SDK and passed packaged conformance")
 PY
+# Stage the maintained SDK guide and validate its offline links, then execute the
+# Python example from the installed wheel metadata and the SDK guide verbatim.
+# Candidate source patches are an explicit option; registry mode has a fresh
+# Cargo home and never substitutes an unpublished local SDK.
+"$PYTHON" "$ROOT/scripts/onboarding.py" stage "$ROOT" "$WORK/bundle"
+mkdir -p "$WORK/bundle/examples/data"
+cp -R "$ROOT/examples/data/illumina_toy" "$WORK/bundle/examples/data/"
+"$PYTHON" "$ROOT/scripts/onboarding.py" smoke --bundle "$WORK/bundle" \
+  --binary "$WORK/venv/bin/rosalind" --python "$WORK/venv/bin/python" "${ORIGIN[@]}"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -15,6 +15,9 @@ cp docs/receipt-schema.md docs/receipt-trust.md docs/v0.4-migration.md "$STAGE/d
 cp docs/schema/receipt-v5.schema.json docs/schema/trust-report-v2.schema.json "$STAGE/docs/schema/"
 cp web/verify/schema/run-attestation-v1.schema.json "$STAGE/docs/schema/"
 cp -R examples/data/illumina_toy "$STAGE/examples/data/"
+# Keep the top-level README and its linked SDK, Python, semantics, workflow and
+# validation guides usable after extracting the archive outside the checkout.
+python3 scripts/onboarding.py stage "$ROOT" "$STAGE"
 tar -C dist -czf "dist/$NAME.tar.gz" "$NAME"
 if command -v sha256sum >/dev/null 2>&1; then
   (cd dist && sha256sum "$NAME.tar.gz" > "$NAME.tar.gz.sha256")

--- a/scripts/test_onboarding.py
+++ b/scripts/test_onboarding.py
@@ -1,0 +1,191 @@
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+import venv
+
+
+SPEC = importlib.util.spec_from_file_location("onboarding", Path(__file__).with_name("onboarding.py"))
+ONBOARDING = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ONBOARDING)
+REPOSITORY = Path(__file__).resolve().parents[1]
+
+
+class OnboardingTests(unittest.TestCase):
+    def fixture(self, root):
+        for guide in ONBOARDING.GUIDES:
+            path = root / guide
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("# Guide\n")
+        (root / "README.md").write_text("[SDK](docs/analyzer-sdk.md)\n[Python](python/README.md)\n")
+        (root / "docs/analyzer-sdk.md").write_text("[Schema](nested/schema.json)\n[Example](../example/)\n")
+        (root / "docs/nested").mkdir()
+        (root / "docs/nested/schema.json").write_text("{}")
+        (root / "example").mkdir()
+        (root / "example/README.md").write_text("[Semantics](../docs/semantics.md)\n[Script](run.py)\n")
+        (root / "example/run.py").write_text("print('example')\n")
+        (root / "docs/semantics.md").write_text("[SDK](analyzer-sdk.md)\n")
+
+    def test_staged_guides_keep_transitive_local_links_after_source_is_removed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            self.fixture(source)
+            bundle = root / "bundle"
+            self.assertEqual(ONBOARDING.stage_guides(source, bundle), 6)
+            source.rename(root / "unavailable-source")
+            self.assertEqual(len(ONBOARDING.guide_closure(bundle)[0]), 6)
+            self.assertTrue((bundle / "example/run.py").is_file())
+            (bundle / "docs/nested/schema.json").unlink()
+            with self.assertRaisesRegex(ValueError, "missing local link"):
+                ONBOARDING.guide_closure(bundle)
+
+    def test_checker_ignores_commands_remote_links_and_anchors_but_rejects_escape(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.fixture(root)
+            document = root / "README.md"
+            document.write_text("[web](https://example.invalid/missing) [section](#section)\n"
+                                "```sh\n[example](missing-command-path)\n```\n")
+            self.assertEqual(list(ONBOARDING.local_links(document, root)), [])
+            document.write_text("[outside](../outside.md)\n")
+            with self.assertRaisesRegex(ValueError, "escapes bundle"):
+                list(ONBOARDING.local_links(document, root))
+
+    def test_staging_does_not_copy_unlinked_files_or_recurse_into_source_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            self.fixture(source)
+            (source / "example/private-local-data.bam").write_bytes(b"private")
+            bundle = root / "bundle"
+            ONBOARDING.stage_guides(source, bundle)
+            self.assertFalse((bundle / "example/private-local-data.bam").exists())
+            (source / "docs/analyzer-sdk.md").write_text("[Repository](../)\n")
+            with self.assertRaisesRegex(ValueError, "source/private/build directory"):
+                ONBOARDING.stage_guides(source, source / "dist/stage")
+
+    def test_staging_rejects_private_paths_and_ancestor_of_destination(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            self.fixture(source)
+            (source / "private").mkdir()
+            (source / "private/password.txt").write_text("not for distribution")
+            (source / "README.md").write_text("[Private](private/password.txt)\n")
+            with self.assertRaisesRegex(ValueError, "source/private/build directory"):
+                ONBOARDING.stage_guides(source, source / "dist/stage")
+            (source / "README.md").write_text("[Example](example/)\n")
+            with self.assertRaisesRegex(ValueError, "contains staging destination"):
+                ONBOARDING.stage_guides(source, source / "example/stage")
+
+    def test_documented_sdk_commands_create_the_binary_consumed_by_conformance(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            bundle = root / "bundle"
+            bundle.mkdir()
+            self.fixture(bundle)
+            (bundle / "docs/analyzer-sdk.md").write_text(
+                (REPOSITORY / "docs/analyzer-sdk.md").read_text()
+                .replace("../examples/evidence-analyzer/", "../example/")
+                .replace("SEMANTICS.md", "semantics.md")
+            )
+            commands = root / "bin"
+            commands.mkdir()
+            binary = commands / "rosalind"
+            binary.write_text("#!/usr/bin/env python3\n" + r'''
+import json
+import pathlib
+import sys
+if sys.argv[1:] == ["--version"]:
+    print("rosalind 0.5.0")
+elif sys.argv[1:3] == ["new", "analyzer"]:
+    path = pathlib.Path(sys.argv[sys.argv.index("--output") + 1])
+    path.mkdir()
+    (path / "Cargo.toml").write_text('rosalind-bio = { version = "=0.5.0" }\n')
+elif sys.argv[1:3] == ["conformance", "analyzer"]:
+    path = pathlib.Path(sys.argv[sys.argv.index("--binary") + 1])
+    assert path.is_file(), f"documented binary was never built: {path}"
+    print(json.dumps({"passed": True}))
+else:
+    raise AssertionError(sys.argv)
+''')
+            cargo = commands / "cargo"
+            cargo.write_text("#!/usr/bin/env python3\n" + r'''
+import os
+import pathlib
+import sys
+assert pathlib.Path.cwd().name == "locus-qc"
+assert pathlib.Path(os.environ["CARGO_HOME"]).name == "cargo-home"
+assert "CARGO_TARGET_DIR" not in os.environ
+assert not (pathlib.Path.cwd().parent / ".cargo/config.toml").exists()
+pathlib.Path("Cargo.lock").write_text("lockfile")
+if sys.argv[1] == "build":
+    assert "--release" in sys.argv and "--locked" in sys.argv and "--offline" in sys.argv
+    path = pathlib.Path("target/release/locus-qc")
+    path.parent.mkdir(parents=True)
+    path.write_text("built binary")
+''')
+            binary.chmod(0o755)
+            cargo.chmod(0o755)
+            args = argparse.Namespace(bundle=bundle, binary=binary, python=None,
+                                      candidate_source=None, registry_sdk=True)
+            with patch.dict(os.environ, {"CARGO_TARGET_DIR": "must-not-leak"}):
+                ONBOARDING.smoke(args)
+
+    def test_candidate_source_version_must_match_packaged_cli(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            (source / "Cargo.toml").write_text('[package]\nversion = "0.5.0-rc.1"\n')
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                ONBOARDING.candidate_config(source, "0.5.0")
+            config = ONBOARDING.candidate_config(source, "0.5.0-rc.1")
+            self.assertIn("[patch.crates-io]", config)
+            self.assertIn(str(source / "crates/build-info"), config)
+
+    def test_python_launcher_preserves_the_installed_virtual_environment(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = Path(temporary) / "venv"
+            venv.EnvBuilder(with_pip=False, symlinks=True).create(environment)
+            executable = ONBOARDING.python_executable(environment / "bin/python")
+            prefix = subprocess.check_output(
+                [str(executable), "-c", "import sys; print(sys.prefix)"], text=True
+            ).strip()
+            self.assertEqual(Path(prefix).resolve(), environment.resolve())
+
+    def test_real_bundle_contains_documented_code_assets_and_registry_example_manifest(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            bundle = Path(temporary)
+            ONBOARDING.stage_guides(REPOSITORY, bundle)
+            for path in ONBOARDING.CODE_FILES + (
+                "integrations/nextflow/examples/evidence/main.nf",
+                "integrations/nextflow/modules/rosalind/evidence.nf",
+                "integrations/snakemake/Evidence.smk",
+            ):
+                self.assertTrue((bundle / path).is_file(), path)
+            metadata = json.loads((bundle / "ONBOARDING-BUNDLE.json").read_text())
+            manifest = (bundle / metadata["rendered_manifest"]).read_text()
+            self.assertIn(f'version = "={metadata["sdk_registry_version"]}"', manifest)
+            self.assertNotIn('path = "../.."', manifest)
+            self.assertEqual((bundle / "examples/evidence-analyzer/src/main.rs").read_bytes(),
+                             (REPOSITORY / "examples/evidence-analyzer/src/main.rs").read_bytes())
+            tutorial = (bundle / "examples/research-filter/README.md").read_text()
+            self.assertNotIn("target/debug/rosalind", tutorial)
+            self.assertIn("./rosalind analyze evidence", tutorial)
+
+    def test_maintained_python_snippet_has_defined_row_consumer(self):
+        readme = (REPOSITORY / "python/README.md").read_text()
+        program = ONBOARDING.snippet(readme, "python-evidence", "python")
+        compile(program, "python-README", "exec")
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            ONBOARDING.snippet("missing block", "python-evidence", "python")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_helpers.py
+++ b/scripts/test_release_helpers.py
@@ -18,6 +18,8 @@ def module(name):
 prepare = module('prepare-wheel-version').prepare
 readiness = module('giab-readiness').readiness
 verify = module('verify-wheel-upload').verify
+wheel_artifacts = module('wheel-artifacts')
+release_policy = module('verify-release-automation')
 
 
 class ReleaseHelpers(unittest.TestCase):
@@ -80,6 +82,108 @@ class ReleaseHelpers(unittest.TestCase):
             exact['urls'][0]['digests']['sha256'] = 'a' * 64
             with self.assertRaises(ValueError):
                 verify(root, 'testpypi', lambda _: exact)
+
+
+class WheelArtifacts(unittest.TestCase):
+    def fixture(self, version='0.5.0-rc.1'):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        artifacts = root / 'artifacts'
+        artifacts.mkdir()
+        candidate = 'b' * 40
+        for target, platform in [
+            ('aarch64-apple-darwin', 'macosx_11_0_arm64'),
+            ('x86_64-apple-darwin', 'macosx_10_12_x86_64'),
+            ('x86_64-unknown-linux-gnu', 'manylinux_2_28_x86_64'),
+        ]:
+            directory = root / target
+            directory.mkdir()
+            pyversion = version.replace('-rc.', 'rc')
+            wheel = directory / f'rosalind_bio-{pyversion}-py3-none-{platform}.whl'
+            with zipfile.ZipFile(wheel, 'w') as archive:
+                archive.writestr(f'rosalind_bio-{pyversion}.dist-info/METADATA', f'Name: rosalind-bio\nVersion: {pyversion}\n')
+            build = directory / 'build.json'
+            build.write_text(json.dumps({'source_commit': candidate, 'rust_version': version, 'python_version': pyversion}))
+            report = wheel_artifacts.record(directory, build, target)
+            (artifacts / wheel.name).write_bytes(wheel.read_bytes())
+            (artifacts / f'wheel-build-{target}.json').write_text(json.dumps(report))
+        return root, artifacts, candidate
+
+    def test_complete_stable_and_rc_sets_stage_only_the_recorded_bytes(self):
+        for version, index in [('0.5.0', 'pypi'), ('0.5.0-rc.1', 'testpypi')]:
+            root, artifacts, candidate = self.fixture(version)
+            output = root / 'dist'
+            identities = wheel_artifacts.stage(artifacts, output, candidate, version, index)
+            self.assertEqual(len(identities), 3)
+            self.assertEqual(len(list(output.iterdir())), 3)
+            for identity in identities:
+                self.assertEqual((output / identity['filename']).read_bytes(), (artifacts / identity['filename']).read_bytes())
+
+    def test_wrong_candidate_version_or_index_refuses_before_staging(self):
+        for candidate, version, index in [('a' * 40, '0.5.0-rc.1', 'testpypi'), ('b' * 40, '0.5.0-rc.2', 'testpypi'), ('b' * 40, '0.5.0-rc.1', 'pypi')]:
+            root, artifacts, _ = self.fixture()
+            with self.assertRaises(ValueError):
+                wheel_artifacts.stage(artifacts, root / 'dist', candidate, version, index)
+            self.assertFalse((root / 'dist').exists())
+
+    def test_missing_extra_or_tampered_artifacts_refuse_before_staging(self):
+        for mutation in ('missing-report', 'extra-wheel', 'changed-wheel', 'wrong-target', 'path-escape'):
+            root, artifacts, candidate = self.fixture()
+            report_path = next(artifacts.glob('wheel-build-*.json'))
+            report = json.loads(report_path.read_text())
+            if mutation == 'missing-report':
+                report_path.unlink()
+            elif mutation == 'extra-wheel':
+                (artifacts / 'unrecorded.whl').write_bytes(b'extra')
+            elif mutation == 'changed-wheel':
+                with (artifacts / report['wheel']['filename']).open('ab') as stream:
+                    stream.write(b'tampered')
+            else:
+                if mutation == 'wrong-target':
+                    report['target'] = 'x86_64-unknown-linux-gnu'
+                    if report_path.name == 'wheel-build-x86_64-unknown-linux-gnu.json':
+                        report['target'] = 'aarch64-apple-darwin'
+                else:
+                    report['wheel']['filename'] = '../escaped.whl'
+                report_path.write_text(json.dumps(report))
+            with self.assertRaises(ValueError):
+                wheel_artifacts.stage(artifacts, root / 'dist', candidate, '0.5.0-rc.1', 'testpypi')
+            self.assertFalse((root / 'dist').exists(), mutation)
+
+    def test_wheel_metadata_and_platform_must_match_report(self):
+        root, artifacts, _ = self.fixture()
+        report = json.loads((artifacts / 'wheel-build-aarch64-apple-darwin.json').read_text())
+        wheel = artifacts / report['wheel']['filename']
+        with self.assertRaises(ValueError):
+            wheel_artifacts.wheel_identity(wheel, 'x86_64-apple-darwin', '0.5.0-rc.1')
+        with zipfile.ZipFile(wheel, 'w') as archive:
+            archive.writestr('rosalind_bio-0.5.0rc1.dist-info/METADATA', 'Name: rosalind-bio\nVersion: 0.5.0rc2\n')
+        with self.assertRaises(ValueError):
+            wheel_artifacts.wheel_identity(wheel, 'aarch64-apple-darwin', '0.5.0-rc.1')
+
+
+class PublisherBoundaries(unittest.TestCase):
+    def workflows(self):
+        root = Path(__file__).resolve().parents[1] / '.github/workflows'
+        return {name: (root / name).read_text() for name in ('rc.yml', 'release.yml', 'wheels.yml')}
+
+    def test_actual_workflows_preserve_top_level_protected_publishers(self):
+        release_policy.verify_pypi_boundary(self.workflows())
+
+    def test_reusable_publishing_or_missing_protection_is_rejected(self):
+        for filename, old, new in [
+            ('wheels.yml', 'contents: read', 'contents: read\n  id-token: write'),
+            ('rc.yml', '    environment: release', '    environment: unprotected'),
+            ('release.yml', 'https://upload.pypi.org/legacy/', 'https://test.pypi.org/legacy/'),
+            ('rc.yml', 'python3 scripts/wheel-artifacts.py stage', 'python3 scripts/unverified-stage.py'),
+            ('release.yml', 'needs: [authorize, build-wheels]', 'needs: authorize'),
+        ]:
+            workflows = self.workflows()
+            self.assertIn(old, workflows[filename])
+            workflows[filename] = workflows[filename].replace(old, new)
+            with self.assertRaises(SystemExit, msg=(filename, old)):
+                release_policy.verify_pypi_boundary(workflows)
 
 
 if __name__ == '__main__':

--- a/scripts/verify-release-automation.py
+++ b/scripts/verify-release-automation.py
@@ -15,84 +15,139 @@ def fail(message: str) -> None:
     raise SystemExit(message)
 
 
-for path in ACTION_FILES:
-    text = path.read_text()
-    for line_number, line in enumerate(text.splitlines(), 1):
-        match = re.search(r"\buses:\s*([^\s#]+)", line)
-        if not match or match.group(1).startswith("./"):
-            continue
-        reference = match.group(1).rsplit("@", 1)[-1]
-        if not re.fullmatch(r"[0-9a-f]{40}", reference):
-            fail(f"{path}:{line_number}: Action is not pinned by full commit SHA")
+def job(text: str, name: str) -> str:
+    match = re.search(r"^  " + re.escape(name) + r":\s*\n(.*?)(?=^  [a-zA-Z0-9_-]+:\s*$|\Z)", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        fail(f"workflow lacks job {name}")
+    return match.group(1)
 
-release = (WORKFLOWS / "release.yml").read_text()
-if re.search(r"^\s+push:\s*$", release, re.MULTILINE) or "tags:" in release:
-    fail("stable release workflow must never publish from a pushed tag")
-for marker in (
-    "workflow_dispatch:",
-    "plan_id:",
-    "environment: release",
-    "release-publish.sh",
-    "cancel-in-progress: false",
-    "needs: [authorize, build-assets, publish-crates, published-install-smoke, publish-wheels, publish-container]",
-    "Create stable tag and GitHub Release last",
-):
-    if marker not in release:
-        fail(f"stable release workflow lacks {marker}")
 
-rc = (WORKFLOWS / "rc.yml").read_text()
-for marker in (
-    "workflow_dispatch:",
-    "plan_id:",
-    "environment: rc",
-    "contract-snapshot.json",
-    "cancel-in-progress: false",
-    "needs: [gates, build, publish-wheels, publish-container]",
-):
-    if marker not in rc:
-        fail(f"RC workflow lacks {marker}")
-
-for path in sorted(WORKFLOWS.glob("*.yml")):
-    text = path.read_text()
-    image_publishers = {"container.yml", "happy-image.yml", "rc.yml", "release.yml"}
-    if "packages: write" in text and path.name not in image_publishers:
-        fail(f"{path}: packages:write is reserved for controlled image workflows")
-    if "CARGO_REGISTRY_TOKEN" in text and path.name != "release.yml":
-        fail(f"{path}: crates.io token is reserved for release.yml")
-    if "workflow_dispatch:" in text and any(
-        mutation in text
-        for mutation in ("packages: write", "git push origin", "create-pull-request")
+def verify_pypi_boundary(workflows: dict[str, str]) -> None:
+    wheels = workflows["wheels.yml"]
+    for forbidden in ("id-token: write", "pypa/gh-action-pypi-publish@", "environment:", "destination:"):
+        if forbidden in wheels:
+            fail(f"reusable wheel builds must not publish or request publishing privileges: {forbidden}")
+    if "wheel-artifacts.py record" not in wheels:
+        fail("wheel builds must record the tested candidate wheel bytes")
+    for filename, gate, index, url in (
+        ("rc.yml", "gates", "testpypi", "https://test.pypi.org/legacy/"),
+        ("release.yml", "authorize", "pypi", "https://upload.pypi.org/legacy/"),
     ):
-        if "plan_id:" not in text:
-            fail(f"{path}: mutating manual workflow lacks authenticated plan_id")
+        workflow = workflows[filename]
+        if "workflow_call:" in workflow:
+            fail(f"{filename}: trusted publisher must be a top-level workflow")
+        build, publish = job(workflow, "build-wheels"), job(workflow, "publish-wheels")
+        if "uses: ./.github/workflows/wheels.yml" not in build or "id-token: write" in build:
+            fail(f"{filename}: reuse candidate-bound wheel builds without OIDC permissions")
+        candidate = "${{ needs." + gate + ".outputs.commit }}"
+        version = "${{ inputs.version }}" + ("-rc.${{ inputs.number }}" if index == "testpypi" else "")
+        for marker in ("candidate_sha: " + candidate, "package_version: " + version):
+            if marker not in build:
+                fail(f"{filename}: wheel build lacks {marker}")
+        for marker in (
+            f"needs: [{gate}, build-wheels]", "runs-on: ubuntu-latest",
+            "environment: release", "id-token: write", "contents: read",
+            "ref: " + candidate, "CANDIDATE_SHA: " + candidate,
+            "PACKAGE_VERSION: " + version, "pattern: wheel-*",
+            "wheel-artifacts.py stage", "--candidate-sha", "--version",
+            "verify-wheel-upload.py --index " + index,
+            "repository-url: " + url, "packages-dir: dist", "skip-existing: true",
+            "pypa/gh-action-pypi-publish@",
+        ):
+            if marker not in publish:
+                fail(f"{filename}: protected publisher lacks {marker}")
+        if publish.index("wheel-artifacts.py stage") > publish.index("pypa/gh-action-pypi-publish@"):
+            fail(f"{filename}: validate artifacts before publishing")
+        if publish.index("verify-wheel-upload.py") > publish.index("pypa/gh-action-pypi-publish@"):
+            fail(f"{filename}: validate registry retries before publishing")
+        if "uses: ./.github/workflows/" in publish:
+            fail(f"{filename}: OIDC upload cannot be delegated to a reusable workflow")
 
-for parent in (release, rc):
-    for child in ("wheels.yml", "container.yml"):
-        if f"uses: ./.github/workflows/{child}" not in parent:
-            fail(f"release parent must explicitly invoke {child}")
-for name in ("wheels.yml", "container.yml"):
-    text = (WORKFLOWS / name).read_text()
-    if "workflow_call:" not in text or "candidate_sha:" not in text:
-        fail(f"{name}: reusable publication must bind an exact candidate")
-    if re.search(r"^  release:", text, re.MULTILINE):
-        fail(f"{name}: cannot rely on a GITHUB_TOKEN-created release event")
-    if "ref: ${{ inputs.candidate_sha" not in text:
-        fail(f"{name}: candidate must control checkout")
 
-image = (WORKFLOWS / "happy-image.yml").read_text()
-for marker in ("platforms: linux/amd64", "push: true", "environment: release", "create-pull-request", "uses: ./.github/workflows/happy-candidate.yml", "needs: [resolve, candidate]"):
-    if marker not in image:
-        fail(f"hap.py image workflow lacks {marker}")
+def main() -> None:
+    for path in ACTION_FILES:
+        text = path.read_text()
+        for line_number, line in enumerate(text.splitlines(), 1):
+            match = re.search(r"\buses:\s*([^\s#]+)", line)
+            if not match or match.group(1).startswith("./"):
+                continue
+            reference = match.group(1).rsplit("@", 1)[-1]
+            if not re.fullmatch(r"[0-9a-f]{40}", reference):
+                fail(f"{path}:{line_number}: Action is not pinned by full commit SHA")
 
-candidate = (WORKFLOWS / "happy-candidate.yml").read_text()
-for marker in ("workflow_call:", "candidate_sha:", "--platform linux/amd64", "happy/smoke.sh", "if: always()"):
-    if marker not in candidate:
-        fail(f"evaluator candidate validation lacks {marker}")
-if "packages: write" in candidate or "push: true" in candidate or "environment: release" in candidate:
-    fail("evaluator candidate builds must run without publication permissions")
+    release = (WORKFLOWS / "release.yml").read_text()
+    if re.search(r"^\s+push:\s*$", release, re.MULTILINE) or "tags:" in release:
+        fail("stable release workflow must never publish from a pushed tag")
+    for marker in (
+        "workflow_dispatch:",
+        "plan_id:",
+        "environment: release",
+        "release-publish.sh",
+        "cancel-in-progress: false",
+        "needs: [authorize, build-assets, publish-crates, published-install-smoke, publish-wheels, publish-container]",
+        "Create stable tag and GitHub Release last",
+    ):
+        if marker not in release:
+            fail(f"stable release workflow lacks {marker}")
 
-giab = (WORKFLOWS / "giab.yml").read_text()
-if "baseline.json" in giab:
-    fail("routine GIAB workflow must not mutate baseline.json")
+    rc = (WORKFLOWS / "rc.yml").read_text()
+    for marker in (
+        "workflow_dispatch:",
+        "plan_id:",
+        "environment: rc",
+        "contract-snapshot.json",
+        "cancel-in-progress: false",
+        "needs: [gates, build, publish-wheels, publish-container]",
+    ):
+        if marker not in rc:
+            fail(f"RC workflow lacks {marker}")
 
-print("release workflow dry-run policy: OK (no remote operation performed)")
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text()
+        image_publishers = {"container.yml", "happy-image.yml", "rc.yml", "release.yml"}
+        if "packages: write" in text and path.name not in image_publishers:
+            fail(f"{path}: packages:write is reserved for controlled image workflows")
+        if "CARGO_REGISTRY_TOKEN" in text and path.name != "release.yml":
+            fail(f"{path}: crates.io token is reserved for release.yml")
+        if "workflow_dispatch:" in text and any(
+            mutation in text
+            for mutation in ("packages: write", "git push origin", "create-pull-request")
+        ):
+            if "plan_id:" not in text:
+                fail(f"{path}: mutating manual workflow lacks authenticated plan_id")
+
+    for parent in (release, rc):
+        for child in ("wheels.yml", "container.yml"):
+            if f"uses: ./.github/workflows/{child}" not in parent:
+                fail(f"release parent must explicitly invoke {child}")
+    for name in ("wheels.yml", "container.yml"):
+        text = (WORKFLOWS / name).read_text()
+        if "workflow_call:" not in text or "candidate_sha:" not in text:
+            fail(f"{name}: reusable publication must bind an exact candidate")
+        if re.search(r"^  release:", text, re.MULTILINE):
+            fail(f"{name}: cannot rely on a GITHUB_TOKEN-created release event")
+        if "ref: ${{ inputs.candidate_sha" not in text:
+            fail(f"{name}: candidate must control checkout")
+
+    image = (WORKFLOWS / "happy-image.yml").read_text()
+    for marker in ("platforms: linux/amd64", "push: true", "environment: release", "create-pull-request", "uses: ./.github/workflows/happy-candidate.yml", "needs: [resolve, candidate]"):
+        if marker not in image:
+            fail(f"hap.py image workflow lacks {marker}")
+
+    candidate = (WORKFLOWS / "happy-candidate.yml").read_text()
+    for marker in ("workflow_call:", "candidate_sha:", "--platform linux/amd64", "happy/smoke.sh", "if: always()"):
+        if marker not in candidate:
+            fail(f"evaluator candidate validation lacks {marker}")
+    if "packages: write" in candidate or "push: true" in candidate or "environment: release" in candidate:
+        fail("evaluator candidate builds must run without publication permissions")
+
+    giab = (WORKFLOWS / "giab.yml").read_text()
+    if "baseline.json" in giab:
+        fail("routine GIAB workflow must not mutate baseline.json")
+
+    verify_pypi_boundary({name: (WORKFLOWS / name).read_text() for name in ("rc.yml", "release.yml", "wheels.yml")})
+    print("release workflow dry-run policy: OK (no remote operation performed)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wheel-artifacts.py
+++ b/scripts/wheel-artifacts.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Bind tested wheel bytes to a candidate and stage only a complete release set."""
+
+import argparse
+import email.parser
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+import zipfile
+
+TARGETS = {
+    "aarch64-apple-darwin": r"macosx_\d+_\d+_arm64",
+    "x86_64-apple-darwin": r"macosx_\d+_\d+_x86_64",
+    "x86_64-unknown-linux-gnu": r"manylinux[^.]*_x86_64",
+}
+
+
+def python_version(version: str) -> str:
+    if not re.fullmatch(r"\d+\.\d+\.\d+(-rc\.[1-9]\d*)?", version):
+        raise ValueError("expected a stable version or numbered release candidate")
+    return version.replace("-rc.", "rc")
+
+
+def digest(path: Path) -> str:
+    value = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            value.update(block)
+    return value.hexdigest()
+
+
+def wheel_identity(path: Path, target: str, version: str) -> dict:
+    expected_version = python_version(version)
+    if target not in TARGETS or path.is_symlink() or not path.is_file():
+        raise ValueError("expected a regular wheel for a supported target")
+    parts = path.name.removesuffix(".whl").split("-")
+    if len(parts) != 5 or parts[:4] != ["rosalind_bio", expected_version, "py3", "none"]:
+        raise ValueError(f"{path.name}: unexpected package, version, or wheel tags")
+    if not all(re.fullmatch(TARGETS[target], tag) for tag in parts[4].split(".")):
+        raise ValueError(f"{path.name}: wheel platform does not match {target}")
+    with zipfile.ZipFile(path) as archive:
+        metadata_paths = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(metadata_paths) != 1:
+            raise ValueError(f"{path.name}: expected one distribution metadata record")
+        metadata = email.parser.Parser().parsestr(archive.read(metadata_paths[0]).decode("utf-8"))
+    if metadata["Name"] != "rosalind-bio" or metadata["Version"] != expected_version:
+        raise ValueError(f"{path.name}: distribution metadata does not match requested package/version")
+    return {"filename": path.name, "bytes": path.stat().st_size, "sha256": digest(path)}
+
+
+def record(directory: Path, build_report: Path, target: str) -> dict:
+    report = json.loads(build_report.read_text())
+    if not re.fullmatch(r"[0-9a-f]{40}", report.get("source_commit", "")):
+        raise ValueError("build report lacks an exact candidate commit")
+    version = report["rust_version"]
+    if report.get("python_version") != python_version(version):
+        raise ValueError("native and Python build versions differ")
+    wheels = list(directory.glob("*.whl"))
+    if len(wheels) != 1:
+        raise ValueError("each target build must produce exactly one wheel")
+    report["target"] = target
+    report["wheel"] = wheel_identity(wheels[0], target, version)
+    return report
+
+
+def stage(artifacts: Path, output: Path, candidate: str, version: str, index: str) -> list[dict]:
+    expected_version = python_version(version)
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate):
+        raise ValueError("candidate must be a full commit SHA")
+    if index not in {"pypi", "testpypi"} or ("-rc." in version) != (index == "testpypi"):
+        raise ValueError("numbered candidates publish to TestPyPI; stable versions publish to PyPI")
+    reports = {path.name: path for path in artifacts.glob("wheel-build-*.json")}
+    expected_reports = {f"wheel-build-{target}.json" for target in TARGETS}
+    if set(reports) != expected_reports:
+        raise ValueError("expected exactly one build report for each supported target")
+    verified, filenames = [], set()
+    for target in TARGETS:
+        report_path = reports[f"wheel-build-{target}.json"]
+        if report_path.is_symlink():
+            raise ValueError("build reports must be regular files")
+        report = json.loads(report_path.read_text())
+        if (report.get("source_commit"), report.get("rust_version"), report.get("python_version"), report.get("target")) != (
+            candidate, version, expected_version, target
+        ):
+            raise ValueError(f"{report_path.name}: candidate, version, or target differs")
+        identity = report.get("wheel", {})
+        filename = identity.get("filename", "")
+        if not filename or Path(filename).name != filename or filename in filenames:
+            raise ValueError("wheel identities must name distinct files inside the artifact directory")
+        actual = wheel_identity(artifacts / filename, target, version)
+        if identity != actual:
+            raise ValueError(f"{filename}: bytes differ from the tested candidate wheel")
+        filenames.add(filename)
+        verified.append(actual)
+    if {path.name for path in artifacts.glob("*.whl")} != filenames:
+        raise ValueError("unrecorded wheel found among release artifacts")
+    # Validate the complete set before creating any upload directory.
+    output.mkdir(parents=True, exist_ok=False)
+    for identity in verified:
+        shutil.copyfile(artifacts / identity["filename"], output / identity["filename"])
+    return verified
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    capture = commands.add_parser("record")
+    capture.add_argument("--directory", type=Path, required=True)
+    capture.add_argument("--build-report", type=Path, required=True)
+    capture.add_argument("--target", choices=TARGETS, required=True)
+    capture.add_argument("--output", type=Path, required=True)
+    publish = commands.add_parser("stage")
+    publish.add_argument("--artifacts", type=Path, required=True)
+    publish.add_argument("--output", type=Path, required=True)
+    publish.add_argument("--candidate-sha", required=True)
+    publish.add_argument("--version", required=True)
+    publish.add_argument("--index", choices=["pypi", "testpypi"], required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == "record":
+            report = record(args.directory, args.build_report, args.target)
+            with args.output.open("x") as stream:
+                stream.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        else:
+            print(json.dumps(stage(args.artifacts, args.output, args.candidate_sha, args.version, args.index), indent=2))
+    except (KeyError, ValueError, OSError, zipfile.BadZipFile) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -156,6 +156,7 @@ fn request_digest(engine: &EvidenceEngine) -> String {
     field(&crate::evidence::EvidenceFields::VERSION.to_le_bytes());
     field(&request.fields.bits().to_le_bytes());
     field(crate::evidence::EvidenceProfile::ID.as_bytes());
+    field(engine.sample_scope().canonical_json().as_bytes());
     let profile = &request.profile;
     field(&[
         profile.min_mapq,
@@ -750,6 +751,10 @@ fn add_stats(total: &mut EvidenceRunStats, part: &EvidenceRunStats) -> Result<()
         (
             &mut total.filtered_record_visits,
             part.filtered_record_visits,
+        ),
+        (
+            &mut total.sample_filtered_record_visits,
+            part.sample_filtered_record_visits,
         ),
         (&mut total.microtiles, part.microtiles),
     ] {

--- a/src/evidence/engine.rs
+++ b/src/evidence/engine.rs
@@ -5,6 +5,7 @@ use rust_htslib::bam::record::Cigar;
 use rust_htslib::bam::{self, Read};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 const DECODER_SLACK_BYTES: u64 = 8 << 20;
 
@@ -33,6 +34,8 @@ pub struct EvidencePlan {
     pub analyzer_bytes: u64,
     /// Conservative retained canonical selection and site annotation bytes.
     pub selection_bytes: u64,
+    /// Conservative retained sample scope, read-group header, and worker setup bytes.
+    pub sample_scope_bytes: u64,
 }
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 /// Aggregate execution measurements; fetch-level visits may include the same read in multiple windows.
@@ -43,6 +46,8 @@ pub struct EvidenceRunStats {
     pub record_visits: u64,
     /// Fetch-level records excluded by read-level filters; not unique reads.
     pub filtered_record_visits: u64,
+    /// Fetch-level records belonging to another declared sample, before locus filters.
+    pub sample_filtered_record_visits: u64,
     /// Number of indexed execution windows processed.
     pub microtiles: u64,
     /// Largest decoded BAM-record payload observed in bytes.
@@ -63,6 +68,7 @@ pub struct EvidenceEngine {
     tids: Vec<u32>,
     intervals: Vec<GenomicInterval>,
     sites: BTreeMap<(u32, u32), SnvSite>,
+    sample_scope: Arc<EvidenceSampleScope>,
     plan: EvidencePlan,
 }
 impl EvidenceEngine {
@@ -97,6 +103,13 @@ impl EvidenceEngine {
                 request.alignments.display()
             ))
         })?;
+        let sample_scope = Arc::new(EvidenceSampleScope::resolve(
+            reader.header(),
+            &request.sample_selection,
+        )?);
+        let sample_scope_bytes = sample_scope
+            .memory_bytes()
+            .saturating_add((reader.header().as_bytes().len() as u64).saturating_mul(2));
         let alignment_contigs = header_contigs(reader.header())?;
         let mut reference = match &request.reference {
             Some(path) => EvidenceReference::open_with_fai(path, request.reference_fai.as_deref())?,
@@ -182,6 +195,7 @@ impl EvidenceEngine {
             request.execution.analyzer_bytes,
             crate::util::rss::peak_rss_bytes(),
             selection_memory_bytes(&intervals, &sites),
+            sample_scope_bytes,
         )?;
         Ok(Self {
             request,
@@ -191,6 +205,7 @@ impl EvidenceEngine {
             tids,
             intervals,
             sites,
+            sample_scope,
             plan,
         })
     }
@@ -206,6 +221,10 @@ impl EvidenceEngine {
     pub fn request(&self) -> &EvidenceRequest {
         &self.request
     }
+    /// Resolved sample identity and assignment policy for every emitted row.
+    pub fn sample_scope(&self) -> &EvidenceSampleScope {
+        &self.sample_scope
+    }
     /// Make a worker factory that shares already-open reference storage. The
     /// caller must preserve input immutability for the lifetime of the run.
     pub fn worker_factory(&self) -> EvidenceWorkerFactory {
@@ -220,11 +239,13 @@ impl EvidenceEngine {
                 cram_reference: self.request.cram_reference.clone(),
                 cram_reference_fai: self.request.cram_reference_fai.clone(),
                 selection: EvidenceSelection::WholeGenome,
+                sample_selection: self.request.sample_selection.clone(),
                 fields: self.request.fields,
                 profile: self.request.profile.clone(),
                 execution: self.request.execution.clone(),
             },
             reference: self.reference.clone(),
+            sample_scope: self.sample_scope.clone(),
         }
     }
     /// Stable, explicit coordinate/annotation digest for scientific cache keys.
@@ -280,6 +301,7 @@ impl EvidenceEngine {
             self.plan.analyzer_bytes,
             self.plan.baseline_rss_bytes,
             selection_memory_bytes(&intervals, &sites),
+            self.plan.sample_scope_bytes,
         )?;
         self.request.selection = canonical_selection(&selection, &intervals, &sites);
         self.intervals = intervals;
@@ -324,6 +346,7 @@ impl EvidenceEngine {
             bytes,
             self.plan.baseline_rss_bytes,
             self.plan.selection_bytes,
+            self.plan.sample_scope_bytes,
         )?;
         Ok(&self.plan)
     }
@@ -410,6 +433,10 @@ impl EvidenceEngine {
                             "indexed fetch returned an invalid contig/coordinate".into(),
                         ));
                     }
+                    if !self.sample_scope.includes_record(&record)? {
+                        checked_add(&mut stats.sample_filtered_record_visits, 1)?;
+                        continue;
+                    }
                     let rejected = read_filter(&record, &self.request.profile);
                     if rejected.is_some() {
                         checked_add(&mut stats.filtered_record_visits, 1)?;
@@ -466,6 +493,7 @@ fn make_plan(
     analyzer_bytes: u64,
     baseline: u64,
     selection_bytes: u64,
+    sample_scope_bytes: u64,
 ) -> Result<EvidencePlan, EvidenceError> {
     // Capacity, site annotation and one-byte reference window included. One
     // reusable decoded BAM record and one CIGAR view each fit this envelope.
@@ -478,6 +506,7 @@ fn make_plan(
         )
         .and_then(|bytes| bytes.checked_add(analyzer_bytes))
         .and_then(|bytes| bytes.checked_add(selection_bytes))
+        .and_then(|bytes| bytes.checked_add(sample_scope_bytes))
         .ok_or(EvidenceError::CounterOverflow)?;
     let maximum = execution.max_microtile_bases.clamp(1, CANONICAL_TILE_BASES) as u64;
     let microtile = if let Some(budget) = execution.memory_budget_bytes {
@@ -495,7 +524,7 @@ fn make_plan(
         maximum
     };
     Ok(EvidencePlan {
-        model_id: "exact-summary-tiles-v1",
+        model_id: "exact-summary-tiles-v2",
         baseline_rss_bytes: baseline,
         fixed_bytes: fixed,
         bytes_per_locus,
@@ -507,6 +536,7 @@ fn make_plan(
         selected_loci,
         analyzer_bytes,
         selection_bytes,
+        sample_scope_bytes,
     })
 }
 
@@ -726,6 +756,7 @@ fn canonical_selection(
 pub struct EvidenceWorkerFactory {
     request: EvidenceRequest,
     reference: EvidenceReference,
+    sample_scope: Arc<EvidenceSampleScope>,
 }
 impl EvidenceWorkerFactory {
     /// Open a worker for one canonical selection without hashing the reference
@@ -748,6 +779,17 @@ impl EvidenceWorkerFactory {
             None => bam::IndexedReader::from_path(&request.alignments),
         }
         .map_err(|error| EvidenceError::InvalidInput(format!("open worker alignment: {error}")))?;
+        let sample_scope =
+            EvidenceSampleScope::resolve(reader.header(), &request.sample_selection)?;
+        if sample_scope != *self.sample_scope {
+            return Err(EvidenceError::InvalidInput(
+                "worker alignment sample metadata differs from the opened session".into(),
+            ));
+        }
+        let sample_scope_bytes = sample_scope
+            .memory_bytes()
+            .saturating_add((reader.header().as_bytes().len() as u64).saturating_mul(2));
+        drop(sample_scope);
         if alignment_is_cram(&request.alignments)? {
             let fasta = request
                 .cram_reference
@@ -778,6 +820,7 @@ impl EvidenceWorkerFactory {
             request.execution.analyzer_bytes,
             crate::util::rss::peak_rss_bytes(),
             0,
+            sample_scope_bytes,
         )?;
         let mut engine = EvidenceEngine {
             request,
@@ -787,6 +830,7 @@ impl EvidenceWorkerFactory {
             tids,
             intervals: Vec::new(),
             sites: BTreeMap::new(),
+            sample_scope: self.sample_scope.clone(),
             plan,
         };
         engine.set_selection(engine.request.selection.clone())?;

--- a/src/evidence/mod.rs
+++ b/src/evidence/mod.rs
@@ -8,14 +8,20 @@ mod encoding;
 mod engine;
 mod panel;
 mod reference;
+mod sample;
 mod selection;
 
 pub use encoding::{
     read_evidence_batches, EvidenceArrowWriter, EvidenceTsvWriter, EVIDENCE_ARROW_BATCH_ROWS,
 };
 pub use engine::{EvidenceEngine, EvidencePlan, EvidenceRunStats, EvidenceWorkerFactory};
-pub use panel::{FusedAnalyzers, PanelQcAnalyzer, PanelSummary, PanelTarget};
+pub use panel::{
+    FusedAnalyzers, PanelQcAnalyzer, PanelSummary, PanelTarget, DEFAULT_MIN_CALLABLE_DEPTH,
+};
 pub use reference::EvidenceReference;
+pub use sample::{
+    EvidenceReadGroup, EvidenceSampleMode, EvidenceSampleScope, EvidenceSampleSelection,
+};
 pub use selection::{EvidenceSelection, SnvSite};
 
 use crate::core::ContigSet;
@@ -221,6 +227,8 @@ pub struct EvidenceRequest {
     pub cram_reference: Option<PathBuf>,
     /// Requested loci, normalized before execution.
     pub selection: EvidenceSelection,
+    /// Resolve or explicitly select sample membership from alignment RG/SM metadata.
+    pub sample_selection: EvidenceSampleSelection,
     /// Physical output fields; schema v1 requires the complete field set.
     pub fields: EvidenceFields,
     /// Scientific filtering rules, independent of the memory budget.
@@ -246,6 +254,7 @@ impl EvidenceRequest {
             reference: None,
             cram_reference: None,
             selection: EvidenceSelection::WholeGenome,
+            sample_selection: EvidenceSampleSelection::Auto,
             fields: EvidenceFields::ALL,
             profile: EvidenceProfile::default(),
             execution: EvidenceExecution::default(),

--- a/src/evidence/panel.rs
+++ b/src/evidence/panel.rs
@@ -4,6 +4,9 @@ use crate::selection::GenomicInterval;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
+/// Default minimum callable read depth shared by panel QC interfaces.
+pub const DEFAULT_MIN_CALLABLE_DEPTH: u64 = 10;
+
 /// One original panel target; overlap with other targets is preserved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PanelTarget {
@@ -154,7 +157,7 @@ impl PanelQcAnalyzer {
                 })
                 .collect(),
             last_locus: None,
-            min_callable_depth: 20,
+            min_callable_depth: DEFAULT_MIN_CALLABLE_DEPTH,
             sorted_targets,
             next_target: 0,
             active_targets: Vec::new(),

--- a/src/evidence/sample.rs
+++ b/src/evidence/sample.rs
@@ -1,0 +1,252 @@
+//! Sample assignment is scientific selection, before any locus depth/filter count.
+
+use super::EvidenceError;
+use rust_htslib::bam::{record::Aux, HeaderView, Record};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Requested sample scope. The resolved scope, rather than Auto versus Named,
+/// defines scientific identity; callers may separately record the original argv.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum EvidenceSampleSelection {
+    /// Infer one unambiguous named sample, or explicitly unknown identity.
+    #[default]
+    Auto,
+    /// Include only read groups belonging to this declared SM identifier.
+    Named(String),
+    /// Deliberately aggregate all records, including unassigned read groups.
+    Pool,
+}
+
+/// Scientific interpretation of all evidence rows in a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceSampleMode {
+    /// No sample names are declared; records have unknown sample identity.
+    Unknown,
+    /// Every counted record is assigned to the selected named sample.
+    Named,
+    /// All eligible records are deliberately pooled, regardless of assignment.
+    Pooled,
+}
+
+/// One header-declared read group. Groups are sorted by ID in a resolved scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceReadGroup {
+    /// Unique alignment read-group ID.
+    pub id: String,
+    /// Declared SM identifier, or None when the header does not assign a sample.
+    pub sample: Option<String>,
+}
+
+/// Canonical, content-serializable sample scope resolved from the alignment header.
+/// Auto and Named produce identical scopes when they resolve to the same sample.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceSampleScope {
+    /// Resolved unknown, named, or explicitly pooled interpretation.
+    pub mode: EvidenceSampleMode,
+    /// Selected SM for named mode; None for unknown and pooled modes.
+    pub selected_sample: Option<String>,
+    /// All distinct declared SM identifiers, sorted lexically.
+    pub declared_samples: Vec<String>,
+    /// All declared read groups, sorted by ID, including unassigned groups.
+    pub read_groups: Vec<EvidenceReadGroup>,
+    /// Whether missing, undeclared, or unnamed read groups can contribute.
+    /// True records a possibility, not a claim that such records were observed.
+    pub allows_unassigned: bool,
+}
+
+impl EvidenceSampleScope {
+    /// Stable JSON for recipes, receipts, and cache identities. This versioned
+    /// representation includes resolved selection and all header assignments.
+    pub fn canonical_json(&self) -> String {
+        let mode = match self.mode {
+            EvidenceSampleMode::Unknown => "unknown",
+            EvidenceSampleMode::Named => "named",
+            EvidenceSampleMode::Pooled => "pooled",
+        };
+        let mut output = format!(
+            "{{\"version\":1,\"mode\":\"{mode}\",\"selected_sample\":{},\"declared_samples\":[",
+            optional_json(self.selected_sample.as_deref())
+        );
+        for (i, sample) in self.declared_samples.iter().enumerate() {
+            if i != 0 {
+                output.push(',');
+            }
+            output.push_str(&string_json(sample));
+        }
+        output.push_str("],\"read_groups\":[");
+        for (i, group) in self.read_groups.iter().enumerate() {
+            if i != 0 {
+                output.push(',');
+            }
+            output.push_str(&format!(
+                "{{\"id\":{},\"sample\":{}}}",
+                string_json(&group.id),
+                optional_json(group.sample.as_deref())
+            ));
+        }
+        output.push_str(&format!(
+            "],\"allows_unassigned\":{}}}",
+            self.allows_unassigned
+        ));
+        output
+    }
+
+    pub(crate) fn resolve(
+        header: &HeaderView,
+        selection: &EvidenceSampleSelection,
+    ) -> Result<Self, EvidenceError> {
+        let mut groups = BTreeMap::new();
+        for line in header.as_bytes().split(|byte| *byte == b'\n') {
+            if !line.starts_with(b"@RG\t") && line != b"@RG" {
+                continue;
+            }
+            let line = std::str::from_utf8(line).map_err(|_| {
+                EvidenceError::InvalidInput("alignment @RG header is not valid UTF-8".into())
+            })?;
+            let mut id = None;
+            let mut sample = None;
+            let mut saw_sample = false;
+            for field in line.trim_end_matches('\r').split('\t').skip(1) {
+                if let Some(value) = field.strip_prefix("ID:") {
+                    if id.replace(value.to_owned()).is_some() || value.is_empty() {
+                        return Err(EvidenceError::InvalidInput(
+                            "alignment @RG requires one nonempty ID".into(),
+                        ));
+                    }
+                } else if let Some(value) = field.strip_prefix("SM:") {
+                    if saw_sample {
+                        return Err(EvidenceError::InvalidInput(
+                            "alignment @RG contains duplicate SM fields".into(),
+                        ));
+                    }
+                    saw_sample = true;
+                    sample = (!value.is_empty()).then(|| value.to_owned());
+                }
+            }
+            let id = id.ok_or_else(|| {
+                EvidenceError::InvalidInput("alignment @RG is missing its ID".into())
+            })?;
+            if groups.insert(id.clone(), sample).is_some() {
+                return Err(EvidenceError::InvalidInput(format!(
+                    "alignment @RG ID {id:?} is declared more than once"
+                )));
+            }
+        }
+        let declared_samples: Vec<_> = groups
+            .values()
+            .filter_map(Option::as_ref)
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let has_unnamed = groups.values().any(Option::is_none);
+        let (mode, selected_sample) = match selection {
+            EvidenceSampleSelection::Auto if declared_samples.is_empty() => {
+                (EvidenceSampleMode::Unknown, None)
+            }
+            EvidenceSampleSelection::Auto if declared_samples.len() == 1 && !has_unnamed => {
+                (EvidenceSampleMode::Named, Some(declared_samples[0].clone()))
+            }
+            EvidenceSampleSelection::Auto => {
+                return Err(EvidenceError::InvalidRequest(
+                    "alignment sample scope is ambiguous (multiple SM samples or mixed named/unnamed read groups); choose --sample NAME or --pool-samples explicitly".into(),
+                ));
+            }
+            EvidenceSampleSelection::Named(name) => {
+                if !declared_samples.contains(name) {
+                    return Err(EvidenceError::InvalidRequest(format!(
+                        "sample {name:?} is not declared by alignment @RG SM metadata; select a declared --sample or use --pool-samples explicitly"
+                    )));
+                }
+                (EvidenceSampleMode::Named, Some(name.clone()))
+            }
+            EvidenceSampleSelection::Pool => (EvidenceSampleMode::Pooled, None),
+        };
+        Ok(Self {
+            mode,
+            selected_sample,
+            declared_samples,
+            read_groups: groups
+                .into_iter()
+                .map(|(id, sample)| EvidenceReadGroup { id, sample })
+                .collect(),
+            allows_unassigned: mode != EvidenceSampleMode::Named,
+        })
+    }
+
+    pub(crate) fn includes_record(&self, record: &Record) -> Result<bool, EvidenceError> {
+        if self.allows_unassigned {
+            return Ok(true);
+        }
+        let unassigned = |reason: &str| {
+            EvidenceError::InvalidInput(format!(
+                "read {:?} cannot be assigned to a named sample: {reason}; fix RG/SM metadata or use --pool-samples for deliberate pooling",
+                String::from_utf8_lossy(record.qname())
+            ))
+        };
+        let id = match record.aux(b"RG") {
+            Ok(Aux::String(id)) if !id.is_empty() => id,
+            Ok(_) => return Err(unassigned("RG must be a nonempty string tag")),
+            Err(rust_htslib::errors::Error::BamAuxTagNotFound) => {
+                return Err(unassigned("missing RG tag"));
+            }
+            Err(_) => return Err(unassigned("unreadable RG tag")),
+        };
+        let index = self
+            .read_groups
+            .binary_search_by(|group| group.id.as_str().cmp(id))
+            .map_err(|_| unassigned("RG is absent from the alignment header"))?;
+        let sample = self.read_groups[index]
+            .sample
+            .as_deref()
+            .ok_or_else(|| unassigned("RG has no declared SM sample"))?;
+        Ok(self.selected_sample.as_deref() == Some(sample))
+    }
+
+    /// Conservative additional space for retained scope/request copies and
+    /// temporary header resolution during worker creation. Reader header bytes
+    /// and decoder allocation remain subject to the existing cooperative model.
+    pub(crate) fn memory_bytes(&self) -> u64 {
+        let strings = self.selected_sample.as_ref().map_or(0, String::capacity)
+            + self
+                .declared_samples
+                .iter()
+                .map(String::capacity)
+                .sum::<usize>()
+            + self
+                .read_groups
+                .iter()
+                .map(|group| {
+                    group.id.capacity() + group.sample.as_ref().map_or(0, String::capacity)
+                })
+                .sum::<usize>();
+        let structures = self.declared_samples.capacity() * std::mem::size_of::<String>()
+            + self.read_groups.capacity() * std::mem::size_of::<EvidenceReadGroup>()
+            + std::mem::size_of::<Self>();
+        (strings as u64)
+            .saturating_add(structures as u64)
+            .saturating_add((self.read_groups.len() as u64).saturating_mul(256))
+            .saturating_mul(4)
+    }
+}
+
+fn optional_json(value: Option<&str>) -> String {
+    value.map_or_else(|| "null".into(), string_json)
+}
+
+fn string_json(value: &str) -> String {
+    let mut output = String::from("\"");
+    for character in value.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            character if character < '\u{20}' => {
+                use std::fmt::Write;
+                write!(output, "\\u{:04x}", character as u32).unwrap();
+            }
+            character => output.push(character),
+        }
+    }
+    output.push('"');
+    output
+}

--- a/src/evidence_cli.rs
+++ b/src/evidence_cli.rs
@@ -25,6 +25,12 @@ pub(crate) struct EvidenceOptions {
     /// Supplied plain-text SNV VCF; mutually exclusive with BED selection.
     #[arg(long, conflicts_with_all = ["regions", "region", "shard_count", "shard_index"])]
     sites: Option<PathBuf>,
+    /// Select one declared @RG SM sample; unassignable reads fail the run.
+    #[arg(long, conflicts_with = "pool_samples")]
+    sample: Option<String>,
+    /// Explicitly pool all samples and unassigned reads in the alignment file.
+    #[arg(long, conflicts_with = "sample")]
+    pool_samples: bool,
     /// Base quality threshold for exact evidence (unavailable qualities excluded).
     #[arg(long, default_value_t = 20)]
     base_quality_threshold: u8,
@@ -59,7 +65,7 @@ pub(crate) struct EvidenceOptions {
     #[arg(long)]
     cram_reference_fai: Option<PathBuf>,
     /// Minimum callable A/C/G/T read depth for a callable panel position.
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = DEFAULT_MIN_CALLABLE_DEPTH)]
     min_callable_depth: u64,
     /// Optional exact per-position evidence from the same panel traversal.
     #[arg(long)]
@@ -72,6 +78,8 @@ pub(crate) struct EvidenceOptions {
 impl EvidenceOptions {
     pub(crate) fn reject_legacy_options(&self) -> Result<()> {
         if self.sites.is_some()
+            || self.sample.is_some()
+            || self.pool_samples
             || self.cram_reference.is_some()
             || self.alignment_index.is_some()
             || self.reference_fai.is_some()
@@ -85,7 +93,7 @@ impl EvidenceOptions {
             || self.base_quality_threshold != 20
             || self.tile_bases != 16_384
             || self.max_record_bytes != 1_048_576
-            || self.min_callable_depth != 10
+            || self.min_callable_depth != DEFAULT_MIN_CALLABLE_DEPTH
         {
             bail!("evidence-specific options require analyze evidence or analyze panel-qc");
         }
@@ -323,7 +331,7 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
             .as_ref()
             .map(|p| PathBuf::from(format!("{}.manifest.json", p.display())))
     });
-    if !command.panel && command.options.min_callable_depth != 10 {
+    if !command.panel && command.options.min_callable_depth != DEFAULT_MIN_CALLABLE_DEPTH {
         bail!("--min-callable-depth is a panel-qc option");
     }
     let cram = is_cram(&command.alignments)?;
@@ -420,6 +428,11 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
     request.alignment_index = command.options.alignment_index.clone();
     request.reference_fai = command.options.reference_fai.clone();
     request.cram_reference_fai = command.options.cram_reference_fai.clone();
+    request.sample_selection = match &command.options.sample {
+        Some(sample) => EvidenceSampleSelection::Named(sample.clone()),
+        None if command.options.pool_samples => EvidenceSampleSelection::Pool,
+        None => EvidenceSampleSelection::Auto,
+    };
     request.profile.min_mapq = command.mapq_threshold.unwrap_or(20);
     request.profile.min_base_quality = command.options.base_quality_threshold;
     request.execution.memory_budget_bytes = budget;
@@ -460,6 +473,10 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
         ),
         ("profile".to_string(), EvidenceProfile::ID.to_string()),
         ("counting_unit".to_string(), "read".to_string()),
+        (
+            "sample_scope".to_string(),
+            engine.sample_scope().canonical_json(),
+        ),
         ("selection".to_string(), selection_digest),
         ("mapq".to_string(), profile.min_mapq.to_string()),
         (

--- a/src/evidence_cli/output.rs
+++ b/src/evidence_cli/output.rs
@@ -258,6 +258,10 @@ pub(super) fn execute_outputs(
     capture.opt("--max-record-bytes", command.options.max_record_bytes);
     capture.opt("--tile-bases", command.options.tile_bases);
     capture.opt("--workers", command.options.workers);
+    if let Some(sample) = &command.options.sample {
+        capture.opt("--sample", sample);
+    }
+    capture.flag_if(command.options.pool_samples, "--pool-samples");
     capture.opt(
         "--format",
         if command.options.format == FeatureFormat::ArrowIpc {
@@ -332,6 +336,10 @@ pub(super) fn execute_outputs(
         ("evidence.schema", EVIDENCE_SCHEMA_VERSION.to_string()),
         ("evidence.profile", EvidenceProfile::ID.to_string()),
         ("evidence.counting_unit", "read".to_string()),
+        (
+            "evidence.sample_scope",
+            engine.sample_scope().canonical_json(),
+        ),
         ("evidence.science_blake3", science_digest),
         (
             "analyzer.id",
@@ -432,6 +440,11 @@ pub(super) fn execute_outputs(
         ("peak_rss_bytes", peak),
         ("predicted_peak_rss_bytes", predicted_peak),
         ("execution.record_visits", stats.record_visits),
+        (
+            "execution.sample_filtered_record_visits",
+            stats.sample_filtered_record_visits,
+        ),
+        ("execution.sample_scope_bytes", plan.sample_scope_bytes),
         ("execution.microtiles", stats.microtiles),
         ("execution.emitted_loci", stats.emitted_loci),
         ("execution.analyzer_bytes", plan.analyzer_bytes),

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -24,7 +24,10 @@ fn generated_analyzer_passes_the_embedded_conformance_harness() {
     let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let local = manifest
         .replace(
-            "rosalind-bio = { version = \"=0.4.0\", features = [\"contract-testkit\"] }",
+            &format!(
+                "rosalind-bio = {{ version = \"={}\", features = [\"contract-testkit\"] }}",
+                env!("CARGO_PKG_VERSION")
+            ),
             &format!(
                 "rosalind-bio = {{ path = {:?}, features = [\"contract-testkit\"] }}",
                 workspace

--- a/tests/evidence_samples.rs
+++ b/tests/evidence_samples.rs
@@ -1,0 +1,356 @@
+use rosalind::evidence::*;
+use rosalind::selection::GenomicInterval;
+use rust_htslib::bam::record::{Aux, Cigar, CigarString, Record};
+use rust_htslib::bam::{self, header::HeaderRecord};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
+const LENGTH: u32 = CANONICAL_TILE_BASES + 32;
+
+struct Fixture {
+    root: PathBuf,
+    bam: PathBuf,
+    fasta: PathBuf,
+}
+
+impl Fixture {
+    fn new(groups: &[(&str, Option<&str>)], records: &[Record]) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "rosalind-evidence-samples-{}-{}",
+            std::process::id(),
+            NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&root).unwrap();
+        let bam = root.join("reads.bam");
+        let fasta = root.join("reference.fa");
+        std::fs::write(&fasta, format!(">chr1\n{}\n", "A".repeat(LENGTH as usize))).unwrap();
+        std::fs::write(
+            root.join("reference.fa.fai"),
+            format!("chr1\t{LENGTH}\t6\t{LENGTH}\t{}\n", LENGTH + 1),
+        )
+        .unwrap();
+        let mut header = bam::Header::new();
+        header.push_record(
+            HeaderRecord::new(b"HD")
+                .push_tag(b"VN", "1.6")
+                .push_tag(b"SO", "coordinate"),
+        );
+        header.push_record(
+            HeaderRecord::new(b"SQ")
+                .push_tag(b"SN", "chr1")
+                .push_tag(b"LN", LENGTH),
+        );
+        for (id, sample) in groups {
+            let mut group = HeaderRecord::new(b"RG");
+            group.push_tag(b"ID", id);
+            if let Some(sample) = sample {
+                group.push_tag(b"SM", sample);
+            }
+            header.push_record(&group);
+        }
+        let mut writer = bam::Writer::from_path(&bam, &header, bam::Format::Bam).unwrap();
+        for record in records {
+            writer.write(record).unwrap();
+        }
+        drop(writer);
+        bam::index::build(&bam, None::<&PathBuf>, bam::index::Type::Bai, 1).unwrap();
+        Self { root, bam, fasta }
+    }
+
+    fn request(&self, sample_selection: EvidenceSampleSelection) -> EvidenceRequest {
+        let mut request = EvidenceRequest::new(&self.bam, &self.fasta);
+        request.sample_selection = sample_selection;
+        request.selection = interval(0, 4);
+        request
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.root).ok();
+    }
+}
+
+fn interval(start: u32, end: u32) -> EvidenceSelection {
+    EvidenceSelection::Intervals(vec![GenomicInterval {
+        contig: 0,
+        start,
+        end,
+    }])
+}
+
+fn read(name: &str, group: Option<&str>, base: u8, start: u32, length: usize) -> Record {
+    let mut record = Record::new();
+    record.set(
+        name.as_bytes(),
+        Some(&CigarString(vec![Cigar::Match(length as u32)])),
+        &vec![base; length],
+        &vec![30; length],
+    );
+    record.set_tid(0);
+    record.set_pos(start as i64);
+    record.set_flags(0);
+    record.set_mapq(60);
+    if let Some(group) = group {
+        record.push_aux(b"RG", Aux::String(group)).unwrap();
+    }
+    record
+}
+
+#[derive(Default)]
+struct Capture(Vec<EvidenceRow>);
+impl EvidenceAnalyzer for Capture {
+    fn on_batch(&mut self, batch: &EvidenceBatch) -> Result<(), EvidenceError> {
+        self.0.extend_from_slice(&batch.rows);
+        Ok(())
+    }
+    fn additional_memory_bytes(&self) -> Option<u64> {
+        // Fixtures select at most 12 loci, retaining their full rows.
+        Some(64 * std::mem::size_of::<EvidenceRow>() as u64)
+    }
+}
+
+fn collect(request: EvidenceRequest) -> (Vec<EvidenceRow>, EvidenceRunStats, EvidenceSampleScope) {
+    let mut engine = EvidenceEngine::open(request).unwrap();
+    let mut capture = Capture::default();
+    let stats = engine.run(&mut capture).unwrap();
+    (capture.0, stats, engine.sample_scope().clone())
+}
+
+#[test]
+fn auto_unifies_read_groups_of_one_sample_and_matches_explicit_selection() {
+    let fixture = Fixture::new(
+        &[("lane2", Some("sample-a")), ("lane1", Some("sample-a"))],
+        &[
+            read("one", Some("lane1"), b'A', 0, 4),
+            read("two", Some("lane2"), b'C', 0, 4),
+        ],
+    );
+    let (automatic, _, scope) = collect(fixture.request(EvidenceSampleSelection::Auto));
+    let (explicit, _, selected_scope) =
+        collect(fixture.request(EvidenceSampleSelection::Named("sample-a".into())));
+    assert_eq!(automatic, explicit);
+    assert_eq!(scope, selected_scope);
+    assert_eq!(scope.mode, EvidenceSampleMode::Named);
+    assert_eq!(scope.selected_sample.as_deref(), Some("sample-a"));
+    assert_eq!(scope.declared_samples, ["sample-a"]);
+    assert_eq!(scope.read_groups[0].id, "lane1");
+    assert!(!scope.allows_unassigned);
+    assert_eq!(automatic[0].allele_counts, [1, 1, 0, 0]);
+    assert_eq!(scope.canonical_json(), "{\"version\":1,\"mode\":\"named\",\"selected_sample\":\"sample-a\",\"declared_samples\":[\"sample-a\"],\"read_groups\":[{\"id\":\"lane1\",\"sample\":\"sample-a\"},{\"id\":\"lane2\",\"sample\":\"sample-a\"}],\"allows_unassigned\":false}");
+}
+
+#[test]
+fn auto_refuses_multiple_samples_and_mixed_named_unnamed_groups() {
+    for groups in [
+        vec![("one", Some("sample-a")), ("two", Some("sample-b"))],
+        vec![("one", Some("sample-a")), ("two", None)],
+    ] {
+        let fixture = Fixture::new(&groups, &[]);
+        let error =
+            EvidenceEngine::open(fixture.request(EvidenceSampleSelection::Auto)).unwrap_err();
+        assert!(matches!(error, EvidenceError::InvalidRequest(_)));
+        let message = error.to_string();
+        assert!(message.contains("--sample"), "{message}");
+        assert!(message.contains("--pool-samples"), "{message}");
+    }
+}
+
+#[test]
+fn named_selection_precedes_every_locus_depth_and_filter_counter() {
+    let mut other_sample = read("other", Some("two"), b'C', 0, 4);
+    other_sample.set_mapq(0);
+    other_sample.set_flags(0x400);
+    let fixture = Fixture::new(
+        &[("one", Some("sample-a")), ("two", Some("sample-b"))],
+        &[read("selected", Some("one"), b'A', 0, 4), other_sample],
+    );
+    let (rows, stats, scope) =
+        collect(fixture.request(EvidenceSampleSelection::Named("sample-a".into())));
+    assert_eq!(stats.record_visits, 2);
+    assert_eq!(stats.sample_filtered_record_visits, 1);
+    assert_eq!(stats.filtered_record_visits, 0);
+    assert_eq!(scope.declared_samples, ["sample-a", "sample-b"]);
+    for row in rows {
+        assert_eq!(row.prefilter_depth, 1);
+        assert_eq!(row.aligned_depth, 1);
+        assert_eq!(row.callable_depth, 1);
+        assert_eq!(row.allele_counts, [1, 0, 0, 0]);
+        assert_eq!(row.filters, EvidenceFilterCounts::default());
+    }
+}
+
+#[test]
+fn named_runs_refuse_missing_undeclared_unnamed_or_nonstring_rg() {
+    let mut wrong_type = read("wrong-type", None, b'A', 0, 4);
+    wrong_type.push_aux(b"RG", Aux::I32(7)).unwrap();
+    let cases = [
+        read("missing", None, b'A', 0, 4),
+        read("unknown", Some("absent"), b'A', 0, 4),
+        read("unnamed", Some("unnamed"), b'A', 0, 4),
+        wrong_type,
+    ];
+    for record in cases {
+        let fixture = Fixture::new(&[("named", Some("sample-a")), ("unnamed", None)], &[record]);
+        let mut engine = EvidenceEngine::open(
+            fixture.request(EvidenceSampleSelection::Named("sample-a".into())),
+        )
+        .unwrap();
+        let mut capture = Capture::default();
+        let error = engine.run(&mut capture).unwrap_err();
+        assert!(matches!(error, EvidenceError::InvalidInput(_)));
+        assert!(error.to_string().contains("cannot be assigned"));
+        assert!(
+            capture.0.is_empty(),
+            "invalid tile must not reach consumers"
+        );
+    }
+    let fixture = Fixture::new(
+        &[("named", Some("sample-a"))],
+        &[read("missing", None, b'A', 0, 4)],
+    );
+    let mut engine = EvidenceEngine::open(fixture.request(EvidenceSampleSelection::Auto)).unwrap();
+    assert!(engine.run(&mut Capture::default()).is_err());
+}
+
+#[test]
+fn named_selection_must_exist_in_the_header() {
+    for groups in [vec![], vec![("one", Some("sample-a"))]] {
+        let fixture = Fixture::new(&groups, &[]);
+        let error =
+            EvidenceEngine::open(fixture.request(EvidenceSampleSelection::Named("absent".into())))
+                .unwrap_err();
+        assert!(error.to_string().contains("not declared"));
+    }
+}
+
+#[test]
+fn deliberate_pooling_includes_named_and_unassigned_records() {
+    let fixture = Fixture::new(
+        &[
+            ("one", Some("sample-a")),
+            ("two", Some("sample-b")),
+            ("unnamed", None),
+        ],
+        &[
+            read("one", Some("one"), b'A', 0, 4),
+            read("two", Some("two"), b'C', 0, 4),
+            read("unnamed", Some("unnamed"), b'G', 0, 4),
+            read("missing", None, b'T', 0, 4),
+            read("unknown", Some("absent"), b'T', 0, 4),
+        ],
+    );
+    let (rows, stats, scope) = collect(fixture.request(EvidenceSampleSelection::Pool));
+    assert_eq!(scope.mode, EvidenceSampleMode::Pooled);
+    assert_eq!(scope.selected_sample, None);
+    assert_eq!(scope.declared_samples, ["sample-a", "sample-b"]);
+    assert!(scope.allows_unassigned);
+    assert_eq!(stats.sample_filtered_record_visits, 0);
+    assert_eq!(rows[0].allele_counts, [1, 1, 1, 2]);
+    assert_eq!(rows[0].prefilter_depth, 5);
+}
+
+#[test]
+fn unlabeled_inputs_keep_explicit_unknown_identity_and_existing_counts() {
+    for groups in [vec![], vec![("unnamed", None)]] {
+        let fixture = Fixture::new(&groups, &[read("missing", None, b'A', 0, 4)]);
+        let (rows, _, scope) = collect(fixture.request(EvidenceSampleSelection::Auto));
+        assert_eq!(scope.mode, EvidenceSampleMode::Unknown);
+        assert!(scope.allows_unassigned);
+        assert!(scope.declared_samples.is_empty());
+        assert_eq!(rows[0].callable_depth, 1);
+        let (_, _, pooled) = collect(fixture.request(EvidenceSampleSelection::Pool));
+        assert_ne!(scope.canonical_json(), pooled.canonical_json());
+    }
+}
+
+#[test]
+fn sample_scope_and_rows_are_invariant_across_microtiles_workers_and_boundaries() {
+    let start = CANONICAL_TILE_BASES - 4;
+    let end = CANONICAL_TILE_BASES + 8;
+    let fixture = Fixture::new(
+        &[("one", Some("sample-a")), ("two", Some("sample-b"))],
+        &[
+            read("selected", Some("one"), b'A', start, 12),
+            read("other", Some("two"), b'C', start, 12),
+        ],
+    );
+    let mut request = fixture.request(EvidenceSampleSelection::Named("sample-a".into()));
+    request.selection = interval(start, end);
+    request.execution.memory_budget_bytes = Some(512 << 20);
+    let (expected, _, scope) = collect(request.clone());
+    for width in [1, 3, CANONICAL_TILE_BASES] {
+        request.execution.max_microtile_bases = width;
+        let (actual, _, actual_scope) = collect(request.clone());
+        assert_eq!(actual, expected);
+        assert_eq!(actual_scope.canonical_json(), scope.canonical_json());
+    }
+    let engine = EvidenceEngine::open(request).unwrap();
+    let factory = engine.worker_factory();
+    let handles: Vec<_> = [(start, CANONICAL_TILE_BASES), (CANONICAL_TILE_BASES, end)]
+        .into_iter()
+        .map(|(begin, finish)| {
+            let factory = factory.clone();
+            let scope = scope.clone();
+            std::thread::spawn(move || {
+                let mut worker = factory.open(interval(begin, finish)).unwrap();
+                assert_eq!(worker.sample_scope(), &scope);
+                assert!(worker.plan().sample_scope_bytes > 0);
+                let mut capture = Capture::default();
+                worker.run(&mut capture).unwrap();
+                capture.0
+            })
+        })
+        .collect();
+    let actual: Vec<_> = handles
+        .into_iter()
+        .flat_map(|handle| handle.join().unwrap())
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn canonical_scope_ignores_header_order_and_escapes_identifiers() {
+    let groups = [("z", Some("a\"b\\c")), ("a", Some("a\"b\\c"))];
+    let first = Fixture::new(&groups, &[]);
+    let second = Fixture::new(&[groups[1], groups[0]], &[]);
+    let a = EvidenceEngine::open(first.request(EvidenceSampleSelection::Auto)).unwrap();
+    let b = EvidenceEngine::open(second.request(EvidenceSampleSelection::Auto)).unwrap();
+    assert_eq!(
+        a.sample_scope().canonical_json(),
+        b.sample_scope().canonical_json()
+    );
+    assert!(a.sample_scope().canonical_json().contains("a\\\"b\\\\c"));
+}
+
+#[test]
+fn sample_header_state_is_reserved_through_replanning() {
+    let names: Vec<_> = (0..200).map(|n| format!("read-group-{n:04}")).collect();
+    let groups: Vec<_> = names
+        .iter()
+        .map(|name| (name.as_str(), Some("sample-a")))
+        .collect();
+    let fixture = Fixture::new(&groups, &[]);
+    let mut engine = EvidenceEngine::open(fixture.request(EvidenceSampleSelection::Auto)).unwrap();
+    let reserved = engine.plan().sample_scope_bytes;
+    assert!(reserved > 200 * 256);
+    assert!(engine.plan().fixed_bytes >= reserved);
+    engine.set_selection(interval(1, 3)).unwrap();
+    assert_eq!(engine.plan().sample_scope_bytes, reserved);
+    engine.plan_for_analyzer(&Capture::default()).unwrap();
+    assert_eq!(engine.plan().sample_scope_bytes, reserved);
+}
+
+#[test]
+fn duplicate_read_group_ids_are_rejected_even_for_explicit_pooling() {
+    let fixture = Fixture::new(
+        &[("same", Some("sample-a")), ("same", Some("sample-b"))],
+        &[],
+    );
+    let error = EvidenceEngine::open(fixture.request(EvidenceSampleSelection::Pool)).unwrap_err();
+    assert!(
+        error.to_string().contains("declared more than once"),
+        "{error}"
+    );
+}

--- a/tests/panel_defaults.rs
+++ b/tests/panel_defaults.rs
@@ -1,0 +1,153 @@
+use rosalind::evidence::{
+    EvidenceEngine, EvidenceRequest, PanelQcAnalyzer, PanelTarget, DEFAULT_MIN_CALLABLE_DEPTH,
+};
+use rust_htslib::bam::record::{Cigar, CigarString, Record};
+use rust_htslib::bam::{self, header::HeaderRecord, Header};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+const DEPTHS: [u64; 4] = [9, 10, 19, 20];
+
+struct Fixture {
+    dir: PathBuf,
+    reference: PathBuf,
+    bam: PathBuf,
+    bed: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "rosalind-panel-defaults-{}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            FIXTURE_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let reference = dir.join("reference.fa");
+        std::fs::write(&reference, ">chr1\nAAAA\n").unwrap();
+        std::fs::write(dir.join("reference.fa.fai"), "chr1\t4\t6\t4\t5\n").unwrap();
+        let bam = dir.join("reads.bam");
+        let mut header = Header::new();
+        header.push_record(
+            HeaderRecord::new(b"HD")
+                .push_tag(b"VN", "1.6")
+                .push_tag(b"SO", "coordinate"),
+        );
+        header.push_record(
+            HeaderRecord::new(b"SQ")
+                .push_tag(b"SN", "chr1")
+                .push_tag(b"LN", 4),
+        );
+        let mut writer = bam::Writer::from_path(&bam, &header, bam::Format::Bam).unwrap();
+        for (position, depth) in DEPTHS.into_iter().enumerate() {
+            for read in 0..depth {
+                let mut record = Record::new();
+                record.set(
+                    format!("p{position}-r{read}").as_bytes(),
+                    Some(&CigarString(vec![Cigar::Match(1)])),
+                    b"A",
+                    &[30],
+                );
+                record.set_tid(0);
+                record.set_pos(position as i64);
+                record.set_mapq(60);
+                record.set_flags(0);
+                writer.write(&record).unwrap();
+            }
+        }
+        drop(writer);
+        bam::index::build(&bam, None::<&PathBuf>, bam::index::Type::Bai, 1).unwrap();
+        let bed = dir.join("targets.bed");
+        std::fs::write(
+            &bed,
+            "chr1\t0\t1\tdepth9\nchr1\t1\t2\tdepth10\nchr1\t2\t3\tdepth19\nchr1\t3\t4\tdepth20\nchr1\t0\t4\tall\n",
+        )
+        .unwrap();
+        Self {
+            dir,
+            reference,
+            bam,
+            bed,
+        }
+    }
+
+    fn rust_panel(&self, threshold: Option<u64>) -> (PanelQcAnalyzer, Vec<u8>) {
+        let mut engine =
+            EvidenceEngine::open(EvidenceRequest::new(&self.bam, &self.reference)).unwrap();
+        let targets = PanelTarget::from_bed(&self.bed, engine.contigs()).unwrap();
+        let mut panel = PanelQcAnalyzer::new(targets).unwrap();
+        if let Some(threshold) = threshold {
+            panel = panel.with_min_callable_depth(threshold);
+        }
+        engine.set_selection(panel.selection()).unwrap();
+        engine.run(&mut panel).unwrap();
+        let mut output = Vec::new();
+        panel.write_tsv(&mut output, engine.contigs()).unwrap();
+        (panel, output)
+    }
+
+    fn cli_panel(&self, threshold: Option<u64>) -> Vec<u8> {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rosalind"));
+        command
+            .args(["analyze", "panel-qc", "--alignments"])
+            .arg(&self.bam)
+            .arg("--reference")
+            .arg(&self.reference)
+            .arg("--regions")
+            .arg(&self.bed);
+        if let Some(threshold) = threshold {
+            command
+                .arg("--min-callable-depth")
+                .arg(threshold.to_string());
+        }
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn rust_and_cli_share_default_and_explicit_panel_callability_thresholds() {
+    let fixture = Fixture::new();
+    assert_eq!(DEFAULT_MIN_CALLABLE_DEPTH, 10);
+    for (threshold, expected_threshold, expected_callable) in
+        [(None, 10, [0, 1, 1, 1, 3]), (Some(20), 20, [0, 0, 0, 1, 1])]
+    {
+        let (panel, rust_output) = fixture.rust_panel(threshold);
+        assert_eq!(panel.min_callable_depth, expected_threshold);
+        assert_eq!(
+            panel
+                .summaries()
+                .iter()
+                .map(|summary| summary.callable_positions)
+                .collect::<Vec<_>>(),
+            expected_callable
+        );
+        for (summary, depth) in panel.summaries().iter().zip(DEPTHS) {
+            assert_eq!(summary.callable_depth_sum, depth);
+            assert_eq!(summary.base_quality_sum, depth * 30);
+            assert_eq!(summary.mapping_quality_sum, depth * 60);
+        }
+        let whole_panel = &panel.summaries()[4];
+        assert_eq!(whole_panel.target_length(), 4);
+        assert_eq!(whole_panel.callable_depth_sum, 58);
+        assert_eq!(whole_panel.breadth_positions, [4, 3, 1, 0]);
+        assert_eq!(fixture.cli_panel(threshold), rust_output);
+    }
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -2592,9 +2592,13 @@ fn source_lock_hash(root: &Path) -> Result<String, String> {
         fs::read(root.join("benchmarks/giab/happy/Dockerfile"))
             .map_err(|error| error.to_string())?,
     );
-    if let Ok(requirements) = fs::read(root.join("benchmarks/giab/happy/requirements-py27.txt")) {
-        bytes.extend(b"\0requirements-py27.txt\0");
-        bytes.extend(requirements);
+    for name in ["requirements-py27.txt", "pin-version.py"] {
+        if let Ok(content) = fs::read(root.join("benchmarks/giab/happy").join(name)) {
+            bytes.push(0);
+            bytes.extend(name.as_bytes());
+            bytes.push(0);
+            bytes.extend(content);
+        }
     }
     Ok(hash_bytes(&bytes))
 }
@@ -2641,17 +2645,21 @@ fn source_lock_hash_at_ref<R: Runner>(
     }
     let mut bytes = serde_json::to_vec(&lock).map_err(|error| error.to_string())?;
     bytes.extend(dockerfile.stdout);
-    if let Ok(requirements) = runner.run(
-        root,
-        "git",
-        &[
-            "show".into(),
-            format!("{commit}:benchmarks/giab/happy/requirements-py27.txt").into(),
-        ],
-    ) {
-        if requirements.status.success() {
-            bytes.extend(b"\0requirements-py27.txt\0");
-            bytes.extend(requirements.stdout);
+    for name in ["requirements-py27.txt", "pin-version.py"] {
+        if let Ok(content) = runner.run(
+            root,
+            "git",
+            &[
+                "show".into(),
+                format!("{commit}:benchmarks/giab/happy/{name}").into(),
+            ],
+        ) {
+            if content.status.success() {
+                bytes.push(0);
+                bytes.extend(name.as_bytes());
+                bytes.push(0);
+                bytes.extend(content.stdout);
+            }
         }
     }
     Ok(hash_bytes(&bytes))
@@ -3962,6 +3970,61 @@ mod tests {
         let second = source_lock_hash(directory.path()).unwrap();
         assert_ne!(before, first);
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn evaluator_source_identity_includes_version_patch() {
+        let directory = tempdir().unwrap();
+        let happy = directory.path().join("benchmarks/giab/happy");
+        fs::create_dir_all(&happy).unwrap();
+        fs::write(happy.join("Dockerfile"), "FROM scratch\n").unwrap();
+        fs::write(happy.join("lock.json"), "{\"schema\":1}").unwrap();
+        let without_patch = source_lock_hash(directory.path()).unwrap();
+        fs::write(happy.join("pin-version.py"), "version = '0.3.15'\n").unwrap();
+        let pinned = source_lock_hash(directory.path()).unwrap();
+        fs::write(happy.join("pin-version.py"), "version = '0.3.16'\n").unwrap();
+        let changed = source_lock_hash(directory.path()).unwrap();
+        assert_ne!(without_patch, pinned);
+        assert_ne!(pinned, changed);
+    }
+
+    #[test]
+    fn evaluator_source_identity_at_ref_uses_the_same_version_patch_inputs() {
+        struct RefRunner;
+        impl Runner for RefRunner {
+            fn run(&self, cwd: &Path, program: &str, arguments: &[OsString]) -> io::Result<Output> {
+                assert_eq!(program, "git");
+                let mut output = Command::new("true").output()?;
+                if arguments[0] == "rev-parse" {
+                    let head = arguments.last().unwrap() == "HEAD^{commit}";
+                    output.stdout = if head { "a" } else { "b" }.repeat(40).into_bytes();
+                } else {
+                    assert_eq!(arguments[0], "show");
+                    let requested = arguments[1].to_str().unwrap();
+                    let (_, path) = requested.split_once(':').unwrap();
+                    match fs::read(cwd.join(path)) {
+                        Ok(bytes) => output.stdout = bytes,
+                        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                            return Command::new("false").output();
+                        }
+                        Err(error) => return Err(error),
+                    }
+                }
+                Ok(output)
+            }
+        }
+        let directory = tempdir().unwrap();
+        let happy = directory.path().join("benchmarks/giab/happy");
+        fs::create_dir_all(&happy).unwrap();
+        fs::write(happy.join("Dockerfile"), "FROM scratch\n").unwrap();
+        fs::write(happy.join("lock.json"), "{\"schema\":1}").unwrap();
+        fs::write(happy.join("requirements-py27.txt"), "locked wheels\n").unwrap();
+        let before = source_lock_hash_at_ref(&RefRunner, directory.path(), "candidate").unwrap();
+        fs::write(happy.join("pin-version.py"), "version = '0.3.15'\n").unwrap();
+        let with_patch =
+            source_lock_hash_at_ref(&RefRunner, directory.path(), "candidate").unwrap();
+        assert_ne!(before, with_patch);
+        assert_eq!(with_patch, source_lock_hash(directory.path()).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Panel QC now uses the same 10-read callability default through Rust, CLI, and Python. Evidence resolves sample membership explicitly: ambiguous multi-sample files require a named sample or deliberate pooling, with scope recorded in receipts, replay, and cache identity.

This prepares source version 0.5.0 for an immutable 0.5.0-rc.1 candidate. Native and wheel bundles execute their documented onboarding outside the checkout. Publication workflows verify the exact tested wheels and use protected top-level OIDC upload jobs. GIAB preparation checks reference indexes and hashes, and the evaluator source version is pinned correctly.

Validation: 483 workspace tests, workspace Clippy, 11 Python tests on fresh 3.9 and 3.11 environments, GIAB prerequisite/fingerprint tests, release helper tests, and real native archive/Python 3.11 wheel onboarding passed locally. GitHub validation supplies platform results.

No publication or independent adoption is claimed. Registry-only SDK installation, full evaluator container smoke, protected environment approvals/configuration, required credentials, and relevant release validation remain explicit gates. Historical artifact verification is preserved.
