### PR TITLE
Add exact allele evidence and record-preserving VCF/BCF annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ protected publication review, and change-based caller evidence requirements appl
   canonical frame offsets, sizes, alignment, and counts before decoder access.
   Dataset comparison supports matching projections and refuses absent-as-zero comparisons.
 
+### Variant evidence interoperability
+
+- Sequential VCF/VCF.gz/BCF selections retain exact normalized SNV evidence;
+  malformed, truncated, unsupported and undeclared records fail explicitly.
+- `--annotated-variants` and Python materialization preserve variant record/allele
+  order, existing annotations and genotypes while adding exact read evidence.
+  Verified bounded partition lookup inherits atomic output, receipts and replay.
+- Opt-in `allele-quality` adds exact per-allele quality/position sums with field-mask
+  version 2. Historical full and projected output bytes remain unchanged.
+- Checked native writers propagate header, record and final flush failures;
+  compressed annotation replay preserves its format and compares physical bytes.
+
 ### Analyzer-platform foundation
 
 - Repositioned Rosalind around deterministic per-locus analysis contracts; the

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ supplied with `--cram-reference` when the analysis reference is omitted.
 Callability thresholds are configurable technical screens and have no intrinsic
 clinical interpretation.
 
+## Annotate candidate variants
+
+Site selection accepts VCF, VCF.gz, and BCF. Preserve original variant records,
+allele order and genotypes while adding exact read evidence:
+
+```sh
+rosalind analyze evidence --reference genome.fa --alignments sample.sorted.bam \
+  --sites candidates.vcf.gz --fields depths,alleles,strands,allele-quality \
+  --format arrow-ipc --output evidence.arrow \
+  --annotated-variants candidates.evidence.vcf.gz
+```
+
+Optional allele quality and read-position sums help distinguish evidence behind
+REF and ALT reads. The [annotation guide](docs/variant-annotation.md) defines each
+INFO field, sample scope, memory planning and atomic verification/replay behavior.
+
 ## Build on the evidence
 
 The Rust `EvidenceRequest`/`EvidenceEngine`/`EvidenceAnalyzer` API accepts explicit
@@ -161,7 +177,7 @@ at their original capabilities. See [receipts and trust](docs/receipts-and-trust
 | Evidence schema | Read-based exact SNV counts, allele strands, quality sums/histograms, stored-SEQ offset sums, filter counts |
 | Legacy analyzers | `features`, `analyze coverage`, `ColumnAnalyzer`, and scaffold remain; separate filter defaults |
 | Legacy capacity | New runs use `pileup.semantics=exact-or-fail-v1`; old semantic replay needs its producer |
-| Outputs | TSV, canonical Arrow; legacy first-party shard merge remains supported |
+| Outputs | TSV, canonical Arrow; optional record-preserving SNV annotation in VCF/VCF.gz/BCF |
 | Platforms | Linux x86_64 and macOS arm64/x86_64 package workflows; publication/CI gates still apply |
 | Deferred | Indels, UMI/fragment consensus, methylation, long reads, production calling, Linux ARM wheels |
 

--- a/docs/ADOPTION_ROADMAP.md
+++ b/docs/ADOPTION_ROADMAP.md
@@ -8,9 +8,9 @@ artifact verification remain requirements throughout.
 | Order | Delivery | Status |
 |---|---|---|
 | 1 | Shared panel defaults and explicit named/unknown/pooled sample scope | Implemented; 11 sample tests, Rust/CLI threshold parity, Python/native parity, cache/replay and existing evidence regressions pass |
-| 2 | Installable evidence-engine RC, executable onboarding, candidate publication gates | Implemented for 0.5.0-rc.1; native bundle and fresh wheel onboarding pass locally; all 16 PR checks pass and PR #98 merged; immutable RC build and protected publication pending |
+| 2 | Installable evidence-engine RC, executable onboarding, candidate publication gates | Implemented for 0.5.0-rc.1; native bundle and fresh wheel onboarding pass locally; all 16 PR checks pass and PR #98 merged; immutable RC build dispatched at ce6c489; protected publication pending |
 | 3 | Physical field projection and bounded coalesced sparse fetches | Implemented; all 64 masks, frozen full-output hashes, cache/replay/workers, and corrected 18-run pressure matrix verified locally; CI pending |
-| 4 | VCF.gz/BCF selection, record-preserving annotation, optional per-allele quality/position sums | Pending |
+| 4 | VCF.gz/BCF selection, record-preserving annotation, optional per-allele quality/position sums | Implemented; all 128 masks, legacy byte goldens, independent allele sums, record/genotype preservation and three-budget/worker replay pass locally; 514-test workspace suite plus focused follow-up checks and Python 3.9/3.11 pass locally; platform CI pending |
 | 5 | Verified subset/superset dataset reuse, persisted analysis, bounded Parquet and Python/R/SQL adapters | Pending |
 | 6 | Evidence-native artifact runner, scaffold, and conformance | Pending |
 | 7 | Representative BAM/CRAM resource measurements and independent user validation | Pending; external users have not been recruited |

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -13,8 +13,10 @@ requires an explicit local FASTA and adjacent FAI; no network reference lookup i
 needed. Analysis references may be uncompressed FASTA plus FAI, `.rref`, or
 compatible `.idx`. Contig names and lengths must match the alignment dictionary.
 
-Supply exactly one plain-text SNV VCF (`--sites`) or BED (`--regions`). VCF REF
-and each ALT must be a single A/C/G/T base. REF is checked against the reference;
+Supply exactly one SNV VCF/VCF.gz/BCF (`--sites`) or BED (`--regions`). Variant
+selection is sequential and needs no variant index. A valid declared header is
+required; truncated compressed input and undeclared fields fail. VCF REF
+and each distinct ALT must be a single A/C/G/T base. REF is checked against the reference;
 conflicting duplicates, indels, symbolic alleles, unknown contigs, and invalid
 coordinates fail. Duplicate loci combine ALT alleles and emit one row. VCF
 genotypes, FILTER labels, and INFO annotations do not change read filtering.
@@ -24,6 +26,12 @@ loci, including uncovered positions. Overlap does not duplicate evidence rows.
 Output `pos` is one-based; Rust `EvidenceRow.position` is zero-based. Order follows
 the reference dictionary and then numerical position. Empty selections produce a
 valid empty artifact. Selection is scientific; execution tiles are not selection.
+
+Optional `--annotated-variants` restores original variant records and allele order
+using verified evidence partitions. It requires persisted evidence and the depths
+and alleles groups. Its INFO annotations never replace genotypes or existing
+fields. Original variant bytes participate in annotation identity separately from
+normalized selection. See [variant-annotation.md](variant-annotation.md).
 
 ## Observation and filtering rules
 
@@ -117,7 +125,9 @@ legacy feature encoder's 65,536-row batches. Full evidence retains schema-1 byte
 Physical projections use schema 2 and a versioned field mask, stored in one
 canonical Arrow metadata value. Groups are `depths` (including exclusive filter
 counts), `alleles`, `strands`, `quality-sums`, `quality-histograms`, and
-`read-position`. Identity columns are always present; `--fields none` emits only
+`read-position`, plus opt-in `allele-quality`. The latter stores four A/C/G/T
+quality/position sum vectors and uses field-mask version 2. Historical `all` stays
+at mask 63; `all-supported` selects all seven groups (127). Identity columns are always present; `--fields none` emits only
 those columns. Omitted groups allocate no corresponding summary or encoder vectors
 and never appear as zero-valued output columns. Group selection does not change
 filtering, reference/CIGAR validation, or the values of retained metrics.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -33,6 +33,17 @@ and quality sums. Sparse selection shares bounded fetch windows without emitting
 gap loci. The public preview batch API now exposes borrowed optional groups through
 `rows()`; owned full-row materialization is an explicit fallible adapter.
 
+VCF/VCF.gz/BCF selection and optional record-preserving annotation are implemented.
+Annotation adds evidence INFO fields in original allele order, keeps genotypes and
+existing fields, and shares atomic publication and byte replay with its evidence
+artifact. Opt-in per-allele quality/position sums use field-mask version 2; existing
+full and projected goldens remain unchanged. All 128 field masks and independent
+allele oracles pass locally, as do annotation format/budget/worker and replay tests.
+The workspace suite passed 514 tests before the final focused validation hardening;
+those additional encoder checks and the 18-test Python 3.11 suite pass. Python 3.9
+also passes the existing suite and all five annotation tests. Clippy, Rust 1.83,
+and offline documentation-link checks pass. Platform CI remains pending.
+
 ## Validation results
 
 These checks apply to the locally edited tree, not a published candidate.

--- a/docs/variant-annotation.md
+++ b/docs/variant-annotation.md
@@ -1,0 +1,84 @@
+# Annotate candidate SNVs with exact read evidence
+
+The development CLI accepts VCF, VCF.gz, and BCF site selections without a variant
+index. Alignment inputs still require BAI/CSI or CRAI. Only A/C/G/T SNVs with
+distinct ALT alleles are supported; indels, symbolic alleles, reference mismatches,
+malformed records and undeclared header fields fail explicitly.
+
+```sh
+rosalind analyze evidence --reference genome.fa --alignments sample.sorted.bam \
+  --sites candidates.vcf.gz --sample SAMPLE \
+  --fields depths,alleles,strands,allele-quality --memory-budget-mb 256 \
+  --format arrow-ipc --output evidence.arrow \
+  --annotated-variants candidates.evidence.vcf.gz
+
+rosalind verify --manifest evidence.arrow.manifest.json
+rosalind reproduce --manifest evidence.arrow.manifest.json --inputs . --no-attest
+```
+
+Use `--plan` on the analysis command to check admission for your selection and
+header. Choose `.vcf`, `.vcf.gz`, or `.bcf` for the annotated destination. The
+original record order, duplicate records, ALT order, IDs, quality values, FILTER,
+existing INFO, sample order, FORMAT and phased genotypes are preserved semantically.
+HTSlib may normalize their text representation. Rosalind adds INFO fields; it does
+not rewrite calls or infer which VCF sample corresponds to an alignment sample.
+The output header records the explicit named, unknown, or pooled alignment scope.
+
+| INFO | Meaning |
+|---|---|
+| `RSL_DP` | Callable A/C/G/T read depth |
+| `RSL_PF` | Prefilter aligned base observations; deletion/reference-skip positions excluded |
+| `RSL_ED` | Eligible aligned base observations before base-quality filtering |
+| `RSL_AD` | Callable read counts in original REF, then ALT order (`Number=R`) |
+| `RSL_ADF`, `RSL_ADR` | Forward/reverse counts, when `strands` is requested |
+| `RSL_BQS`, `RSL_MQS` | Exact per-allele base/mapping-quality sums |
+| `RSL_RPS`, `RSL_RLS` | Exact per-allele stored-SEQ position/read-length sums |
+
+The last four fields require `allele-quality` and contain decimal unsigned integer
+strings, preserving the full `uint64` range. Counts use VCF Integer and refuse
+values exceeding its signed 32-bit range; Arrow/TSV retain the exact counts.
+Read positions are zero-based offsets, adjusted for reverse orientation, and
+cannot reconstruct bases removed before alignment. Divide each sum by the
+corresponding count for a mean; a zero count makes the mean undefined. An observed
+zero is distinct from an unrequested field, which is absent.
+
+`RSL_AD` can sum to less than `RSL_DP` when reads support a base not listed in the
+record's alleles. Overlapping mates count as separate reads. See
+[SEMANTICS.md](SEMANTICS.md) for quality, flag, sample and CIGAR rules.
+
+In Arrow, `allele-quality` adds four fixed-size `uint64[4]` columns in A/C/G/T order:
+`allele_base_quality_sum`, `allele_mapping_quality_sum`, `allele_read_position_sum`,
+and `allele_read_length_sum`. TSV uses four comma-separated values per column.
+Historical `--fields all` remains the original six groups; `all-supported` opts
+into all seven. Existing schema-1 and field-mask-v1 artifact bytes are unchanged.
+Masks containing the new group use schema 2 and field-mask version 2.
+
+```python
+from rosalind import materialize_evidence
+
+result = materialize_evidence(
+    "genome.fa", "sample.sorted.bam", "evidence.arrow",
+    sites="candidates.bcf", annotated_variants="candidates.evidence.bcf",
+    fields=["depths", "alleles", "allele-quality"], memory_budget_mb=256,
+)
+print(result.annotated_variants_path)
+```
+
+Annotation uses verified canonical Arrow partitions. It retains at most one
+16,384-base partition while restoring original variant order; widely interleaved
+records may reread partitions. A temporary cache is cleaned on completion; use
+`--cache-dir` and `--resume` for persisted reuse. The planner includes physical
+source fields, lookup state, native headers, records, formatting and compression.
+Variant header/record envelopes are configurable through
+`--max-variant-header-bytes` and `--max-variant-record-bytes`. HTSlib allocations
+are checked after decoding, so these remain cooperative limits.
+
+The evidence artifact, annotated variants and receipt publish atomically. An
+existing Rosalind INFO tag is a conflict, including with `--force`. Invalid input
+or an I/O error preserves previous destinations; resource failures identify any
+partial outputs explicitly. The receipt binds the original variant file's bytes
+as well as the normalized scientific selection, because record order and duplicate
+records matter to annotation. Byte verification and replay cover both outputs.
+Compressed annotation replay uses the new versioned annotation contract; a native
+codec change can produce a byte divergence. Historical BAM/BGZF replay exclusions
+remain unchanged. No semantic comparison substitutes for physical verification.

--- a/python/rosalind/evidence.py
+++ b/python/rosalind/evidence.py
@@ -25,6 +25,7 @@ class EvidenceResult:
     manifest_path: Path
     artifact_path: Optional[Path]
     returncode: int = 0
+    annotated_variants_path: Optional[Path] = None
 
 
 class EvidenceProcessError(RuntimeError):
@@ -144,12 +145,12 @@ def _command(
     field_names = None
     if fields is not None:
         field_names = fields.split(",") if isinstance(fields, str) else list(fields)
-        groups = {"depths", "alleles", "strands", "quality-sums", "quality-histograms", "read-position"}
+        groups = {"depths", "alleles", "strands", "quality-sums", "quality-histograms", "read-position", "allele-quality"}
         if not field_names:
             field_names = ["none"]
-        if field_names not in (["all"], ["none"]) and any(name not in groups for name in field_names):
+        if field_names not in (["all"], ["all-supported"], ["none"]) and any(name not in groups for name in field_names):
             raise ValueError("fields must contain known evidence groups, or all/none alone")
-        if panel and field_names != ["all"] and not {"depths", "quality-sums"}.issubset(field_names):
+        if panel and field_names not in (["all"], ["all-supported"]) and not {"depths", "quality-sums"}.issubset(field_names):
             raise ValueError("panel QC fields must include depths and quality-sums")
     executable = _resolve_binary(binary, allow_version_mismatch)
     command = [str(executable), "analyze", "panel-qc" if panel else "evidence",
@@ -203,12 +204,26 @@ def iter_evidence(
 
 def materialize_evidence(
     reference: PathLike, alignments: PathLike, output: PathLike, *,
-    format: str = "arrow-ipc", force: bool = False, **options: object,
+    format: str = "arrow-ipc", force: bool = False,
+    annotated_variants: Optional[PathLike] = None, **options: object,
 ) -> EvidenceResult:
-    """Persist complete evidence and its receipt for verification and replay."""
+    """Persist evidence and its receipt; optionally annotate original SNV records.
+
+    ``annotated_variants`` requires ``sites`` (VCF, VCF.gz, or BCF) and a
+    .vcf/.vcf.gz/.bcf destination. Existing annotations, allele/record order and
+    genotypes are preserved. INFO fields describe the chosen alignment sample
+    scope. Request ``allele-quality`` for exact per-allele quality/position sums.
+    """
     if format not in ("arrow-ipc", "tsv"):
         raise ValueError("format must be arrow-ipc or tsv")
-    return _materialize(_command(reference, alignments, **options), output, format, force)
+    command = _command(reference, alignments, **options)
+    if annotated_variants is not None:
+        if options.get("sites") is None:
+            raise ValueError("annotated_variants requires sites (VCF, VCF.gz, or BCF)")
+        command += ["--annotated-variants", str(annotated_variants)]
+    result = _materialize(command, output, format, force)
+    return EvidenceResult(result.manifest_path, result.artifact_path, result.returncode,
+                          Path(annotated_variants) if annotated_variants is not None else None)
 
 
 def panel_qc(

--- a/python/tests/test_evidence_annotation.py
+++ b/python/tests/test_evidence_annotation.py
@@ -1,0 +1,200 @@
+"""Independent typed-variant checks for evidence annotation and atomic replay."""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import pyarrow as pa
+import pysam
+
+from rosalind import materialize_evidence, EvidenceProcessError
+
+
+class EvidenceAnnotationTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.binary = Path(os.environ['ROSALIND_BINARY']).resolve()
+        self.reference = self.root / 'reference.fa'
+        self.reference.write_text('>chr1\n' + 'A' * 40000 + '\n')
+        pysam.faidx(str(self.reference))
+        self.bam = self.root / 'reads.bam'
+        header = {'HD': {'VN': '1.6', 'SO': 'coordinate'},
+                  'SQ': [{'SN': 'chr1', 'LN': 40000}],
+                  'RG': [{'ID': 'rg1', 'SM': 'alignment-sample'}]}
+        with pysam.AlignmentFile(str(self.bam), 'wb', header=header) as out:
+            for start in [0, 16999]:
+                for i, (base, bq, mq, flags) in enumerate([
+                    ('A', 30, 60, 0), ('C', 40, 50, 16), ('T', 25, 30, 0),
+                    ('C', 5, 60, 0), ('T', 40, 60, 1024), ('A', 255, 60, 0)]):
+                    r = pysam.AlignedSegment(out.header)
+                    r.query_name = f'{start}-{i}'
+                    r.query_sequence = base * 4
+                    r.query_qualities = [bq] * 4
+                    r.flag = flags
+                    r.reference_id = 0
+                    r.reference_start = start
+                    r.mapping_quality = mq
+                    r.cigarstring = '4M'
+                    r.set_tag('RG', 'rg1')
+                    out.write(r)
+        pysam.index(str(self.bam))
+        self.sites = self.root / 'sites.vcf'
+        self.sites.write_text(
+            '##fileformat=VCFv4.2\n##contig=<ID=chr1,length=40000>\n'
+            '##INFO=<ID=OLD,Number=1,Type=String,Description="Keep">\n'
+            '##FILTER=<ID=q10,Description="Original filter">\n'
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+            '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Original depth">\n'
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n'
+            'chr1\t35001\tzero\tA\tG\t.\t.\tOLD=zero\tGT:DP\t./.:.\t0/0:0\n'
+            'chr1\t2\tmulti\tA\tT,C\t31\tq10\tOLD=first\tGT:DP\t2|1:7\t0/2:3\n'
+            'chr1\t17001\tlater\tA\tC\t17\tPASS\tOLD=middle\tGT:DP\t0/1:2\t1|1:8\n'
+            'chr1\t2\tduplicate\tA\tC,T\t9\tPASS\tOLD=last\tGT:DP\t1/2:4\t0|1:1\n')
+
+    def run_cli(self, *args):
+        result = subprocess.run([str(self.binary), *map(str, args)], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        return result
+
+    def records(self, path):
+        with pysam.VariantFile(str(path)) as f:
+            return [r.copy() for r in f]
+
+    def test_record_order_allele_order_samples_and_exact_sums_survive_formats_and_replay(self):
+        original = self.records(self.sites)
+        baseline_evidence = None
+        for index, (extension, mode, budget, workers, tile) in enumerate([
+            ('vcf', 'w', 512, 1, 1), ('vcf.gz', 'wz', 768, 2, 137), ('bcf', 'wb', 1024, 8, 16384)]):
+            source = self.root / f'source-{index}.{extension}'
+            with pysam.VariantFile(str(self.sites)) as inp:
+                with pysam.VariantFile(str(source), mode, header=inp.header) as out:
+                    for r in inp:
+                        out.write(r)
+            annotated = self.root / f'annotated-{index}.{extension}'
+            result = materialize_evidence(self.reference, self.bam, self.root / f'evidence-{index}.arrow',
+                sites=source, annotated_variants=annotated, fields='all-supported',
+                binary=self.binary, memory_budget_mb=budget, workers=workers, tile_bases=tile)
+            self.assertEqual(result.annotated_variants_path, annotated)
+            data = result.artifact_path.read_bytes()
+            if baseline_evidence is None:
+                baseline_evidence = data
+            self.assertEqual(data, baseline_evidence)
+            with pa.ipc.open_stream(result.artifact_path) as stream:
+                table = stream.read_all()
+            self.assertEqual(table['pos'].to_pylist(), [2, 17001, 35001])
+            self.assertEqual(table['allele_base_quality_sum'].to_pylist(), [[30, 40, 0, 25], [30, 40, 0, 25], [0, 0, 0, 0]])
+            actual = self.records(annotated)
+            self.assertEqual(len(actual), len(original))
+            for before, after in zip(original, actual):
+                self.assertEqual((after.contig, after.pos, after.id, after.alleles, after.qual),
+                                 (before.contig, before.pos, before.id, before.alleles, before.qual))
+                self.assertEqual(list(after.filter), list(before.filter))
+                self.assertEqual(after.info['OLD'], before.info['OLD'])
+                self.assertEqual(list(after.samples), list(before.samples))
+                for sample in before.samples:
+                    self.assertEqual(dict(after.samples[sample]), dict(before.samples[sample]))
+                    self.assertEqual(after.samples[sample].phased, before.samples[sample].phased)
+            self.assertEqual(actual[0].info['RSL_DP'], 0)
+            self.assertEqual(actual[0].info['RSL_AD'], (0, 0))
+            self.assertEqual(actual[1].info['RSL_AD'], (1, 1, 1))
+            self.assertEqual(actual[1].info['RSL_ADF'], (1, 1, 0))
+            self.assertEqual(actual[1].info['RSL_ADR'], (0, 0, 1))
+            self.assertEqual(actual[1].info['RSL_BQS'], ('30', '25', '40'))
+            self.assertEqual(actual[3].info['RSL_BQS'], ('30', '40', '25'))
+            self.assertEqual(actual[1].info['RSL_MQS'], ('60', '30', '50'))
+            self.assertEqual(actual[1].info['RSL_RPS'], ('1', '1', '2'))
+            self.assertEqual(actual[1].info['RSL_RLS'], ('4', '4', '4'))
+            self.assertEqual(actual[1].info['RSL_PF'], 6)
+            self.assertEqual(actual[1].info['RSL_ED'], 5)
+            manifest = json.loads(result.manifest_path.read_text())
+            self.assertEqual(manifest['params']['annotation.semantics'], 'snv-read-evidence-info-v1')
+            self.assertEqual(manifest['params']['evidence.fields_version'], '2')
+            self.run_cli('verify', '--manifest', result.manifest_path)
+            self.run_cli('reproduce', '--manifest', result.manifest_path, '--inputs', self.root, '--binary', self.binary, '--no-attest')
+
+    def test_annotation_bytes_are_invariant_and_zero_is_distinct_from_absent(self):
+        baseline = None
+        for i, (budget, workers, tile) in enumerate([(512, 1, 1), (768, 2, 137), (1024, 8, 16384)]):
+            output = self.root / f'counts-{i}.vcf.gz'
+            result = materialize_evidence(self.reference, self.bam, self.root / f'counts-{i}.arrow',
+                sites=self.sites, annotated_variants=output, fields='depths,alleles',
+                memory_budget_mb=budget, workers=workers, tile_bases=tile, binary=self.binary)
+            if baseline is None:
+                baseline = output.read_bytes()
+            self.assertEqual(output.read_bytes(), baseline)
+            self.assertEqual(self.records(output)[0].info['RSL_DP'], 0)
+            self.assertNotIn('RSL_BQS', self.records(output)[0].info)
+            self.run_cli('verify', '--manifest', result.manifest_path)
+
+    def test_invalid_annotation_preserves_all_existing_destinations(self):
+        evidence = self.root / 'keep.arrow'
+        annotated = self.root / 'keep.vcf'
+        receipt = Path(str(evidence) + '.manifest.json')
+        for path in [evidence, annotated, receipt]:
+            path.write_text('original')
+        # A header conflict is caught before the extraction or artifact staging.
+        text = self.sites.read_text().replace('#CHROM', '##INFO=<ID=RSL_DP,Number=1,Type=Integer,Description="Existing">\n#CHROM')
+        self.sites.write_text(text)
+        with self.assertRaises(EvidenceProcessError) as error:
+            materialize_evidence(self.reference, self.bam, evidence, sites=self.sites,
+                annotated_variants=annotated, binary=self.binary, force=True)
+        self.assertIn('already exists', str(error.exception))
+        for path in [evidence, annotated, receipt]:
+            self.assertEqual(path.read_text(), 'original')
+        self.assertFalse(list(self.root.glob('*.partial')))
+        self.assertFalse(list(self.root.glob('*.tmp*')))
+
+    def test_empty_selection_and_late_resource_failure_have_explicit_artifacts(self):
+        self.sites.write_text(''.join(line + '\n' for line in self.sites.read_text().splitlines() if line.startswith('#')))
+        output = self.root / 'empty.arrow'
+        annotated = self.root / 'empty.bcf'
+        result = materialize_evidence(self.reference, self.bam, output, sites=self.sites,
+            annotated_variants=annotated, binary=self.binary, fields='depths,alleles')
+        self.assertEqual(self.records(annotated), [])
+        self.run_cli('verify', '--manifest', result.manifest_path)
+        self.run_cli('reproduce', '--manifest', result.manifest_path, '--inputs', self.root,
+                     '--binary', self.binary, '--no-attest')
+
+        primary = self.root / 'failed.arrow'
+        annotation = self.root / 'failed.vcf.gz'
+        command = [str(self.binary), 'analyze', 'evidence', '--reference', str(self.reference),
+                   '--alignments', str(self.bam), '--sites', str(self.sites), '--fields', 'depths,alleles',
+                   '--memory-budget-mb', '512', '--format', 'arrow-ipc', '-o', str(primary),
+                   '--annotated-variants', str(annotation)]
+        result = subprocess.run(command, capture_output=True, text=True,
+            env=dict(os.environ, ROSALIND_FORCE_FINAL_RSS_BYTES=str(4 << 30)))
+        self.assertEqual(result.returncode, 4, result.stderr)
+        self.assertFalse(primary.exists())
+        self.assertFalse(annotation.exists())
+        self.assertTrue(Path(str(primary) + '.partial').is_file())
+        self.assertTrue(Path(str(annotation) + '.partial').is_file())
+        manifest = Path(str(primary) + '.manifest.json')
+        recorded = json.loads(manifest.read_text())
+        self.assertEqual(recorded['params']['run_status'], 'resource-failed')
+        self.assertTrue(all(out['path'].endswith('.partial') for out in recorded['outputs']))
+        verified = subprocess.run([str(self.binary), 'verify', '--manifest', str(manifest)],
+                                  capture_output=True, text=True)
+        self.assertEqual(verified.returncode, 5, verified.stderr)
+        self.assertIn('recorded peak', verified.stderr)
+        self.assertNotIn('hash mismatch', verified.stderr.lower())
+
+    def test_oversized_declared_annotation_envelope_cannot_wrap_admission(self):
+        result = subprocess.run([str(self.binary), 'analyze', 'evidence',
+            '--reference', str(self.reference), '--alignments', str(self.bam),
+            '--sites', str(self.sites), '--fields', 'depths,alleles',
+            '--annotated-variants', str(self.root / 'too-large.vcf'),
+            '-o', str(self.root / 'too-large.arrow'), '--plan',
+            '--max-variant-header-bytes', str((1 << 64) - 1)], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('memory envelope is too large', result.stderr)
+        self.assertEqual(result.stdout, '')
+        self.assertFalse((self.root / 'too-large.arrow').exists())
+        self.assertFalse((self.root / 'too-large.vcf').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -291,12 +291,14 @@ pysam.faidx("genome.fa")
 pysam.index("sample.bam")
 with pysam.FastaFile("genome.fa") as reference:
     contig = reference.references[0]
-    length = min(100, reference.lengths[0])
+    contig_length = reference.lengths[0]
+    length = min(100, contig_length)
     base = reference.fetch(contig, 0, 1).upper()
 alternate = next(nucleotide for nucleotide in "ACGT" if nucleotide != base)
 pathlib.Path("targets.bed").write_text(f"{contig}\t0\t{length}\tfirst\n")
 pathlib.Path("candidates.vcf").write_text(
-    "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+    f"##fileformat=VCFv4.2\n##contig=<ID={contig},length={contig_length}>\n"
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
     f"{contig}\t1\t.\t{base}\t{alternate}\t.\tPASS\t.\n")
 readme = importlib.metadata.metadata("rosalind-bio").get_payload()
 blocks = re.findall(r"<!-- smoke:python-evidence -->\s*```python\n(.*?)\n```", readme, re.S)

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -4,6 +4,9 @@
 //! ownership, never on worker count or execution microtiles. Workers only produce
 //! first-party Arrow evidence; the caller's analyzer consumes it serially.
 
+mod lookup;
+pub use lookup::VerifiedEvidenceLookup;
+
 use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Write};
@@ -153,7 +156,7 @@ fn request_digest(engine: &EvidenceEngine) -> String {
     field(EVIDENCE_SEMANTICS_VERSION.as_bytes());
     field(env!("CARGO_PKG_VERSION").as_bytes());
     field(&request.fields.schema_version().to_le_bytes());
-    field(&crate::evidence::EvidenceFields::VERSION.to_le_bytes());
+    field(&request.fields.mask_version().to_le_bytes());
     field(&request.fields.bits().to_le_bytes());
     field(crate::evidence::EvidenceProfile::ID.as_bytes());
     field(engine.sample_scope().canonical_json().as_bytes());
@@ -655,7 +658,7 @@ pub fn run_dataset_with_snapshot(
         ),
         (
             "evidence.fields_version".into(),
-            EvidenceFields::VERSION.to_string(),
+            engine.request().fields.mask_version().to_string(),
         ),
         ("pileup.semantics".into(), "exact-or-fail-v1".into()),
         ("dataset.partition_count".into(), parts.len().to_string()),
@@ -843,7 +846,7 @@ fn write_partition(
         ),
         (
             "evidence.fields_version".into(),
-            EvidenceFields::VERSION.to_string(),
+            engine.request().fields.mask_version().to_string(),
         ),
         ("pileup.semantics".into(), "exact-or-fail-v1".into()),
         ("dataset.contig".into(), part.contig.to_string()),
@@ -905,7 +908,7 @@ fn receipt_fields(receipt: &RunManifest) -> Result<EvidenceFields, DatasetError>
     };
     match receipt.params.get("evidence.fields_version") {
         None if schema == Some("1") => (),
-        Some(version) if version == &EvidenceFields::VERSION.to_string() => (),
+        Some(version) if version == &fields.mask_version().to_string() => (),
         _ => {
             return Err(DatasetError::Corrupt(
                 "unsupported evidence field mask version".into(),

--- a/src/dataset/lookup.rs
+++ b/src/dataset/lookup.rs
@@ -1,0 +1,677 @@
+//! Verified random access retaining at most one canonical projected partition.
+
+use super::*;
+use crate::core::ContigSet;
+use crate::evidence::{EvidenceBatch, EvidenceRowRef};
+
+const PARTITION_RECEIPT_BYTES: u64 = 64 << 10;
+const PARENT_BYTES_PER_PARTITION: u64 = 4096;
+const LOOKUP_PATH_BYTES: usize = 4096;
+
+#[derive(Debug)]
+struct LookupPartition {
+    ownership: Partition,
+    receipt_hash: String,
+    artifact_hash: String,
+    observed: Option<InputSnapshot>,
+}
+
+/// Verified coordinate lookup into one completed dataset. Queries may be
+/// unsorted or repeated. Only the current canonical partition's projected rows
+/// are retained; returning to another partition re-verifies and decodes it.
+///
+/// Dataset files must remain immutable throughout the lookup session. Ordinary
+/// replacements and timestamp/size changes are detected; unsigned receipts do
+/// not establish authorship, and metadata stamps are not cryptographic identity.
+#[derive(Debug)]
+pub struct VerifiedEvidenceLookup {
+    root: PathBuf,
+    contigs: ContigSet,
+    fields: EvidenceFields,
+    science_digest: String,
+    request_digest: String,
+    parent_snapshot: InputSnapshot,
+    partitions: Vec<LookupPartition>,
+    loaded: Option<(usize, EvidenceBatch)>,
+}
+
+impl VerifiedEvidenceLookup {
+    /// Conservative additional working set, excluding the already-open engine
+    /// and caller's output/record buffers. Includes canonical descriptors and
+    /// selections, receipt parsing, tracked file stamps, one projected 16,384-row
+    /// partition, and the bounded Arrow decoder. No allocations are made here.
+    pub fn memory_bytes(engine: &EvidenceEngine) -> u64 {
+        let count = partition_count(engine);
+        let fields = engine.request().fields;
+        let parent_bytes = parent_receipt_limit(count);
+        // ContigSet currently shares Arc names, but include copied names as well
+        // so the bound also covers the active batch/decoder's owned strings.
+        let dictionary = engine.contigs().iter().fold(0u64, |bytes, contig| {
+            bytes.saturating_add(128 + (contig.name.len() as u64).saturating_mul(2))
+        });
+        let metadata = engine
+            .plan()
+            .selection_bytes
+            .saturating_mul(3)
+            .saturating_add(count.saturating_mul(12 << 10))
+            // Receipt integrity verification clones the parsed claim and
+            // serializes it again; reserve those transients as well as parsing.
+            .saturating_add(parent_bytes.saturating_mul(8))
+            .saturating_add(PARTITION_RECEIPT_BYTES.saturating_mul(8))
+            .saturating_add(dictionary);
+        metadata
+            .saturating_add(
+                fields
+                    .storage_bytes_per_locus()
+                    .saturating_add(32)
+                    .saturating_mul(u64::from(CANONICAL_TILE_BASES)),
+            )
+            .saturating_add(evidence_reader_memory_bytes(fields))
+            .saturating_add(64 << 10)
+    }
+
+    /// Verify the completed parent receipt against the engine's exact request.
+    /// Partition payloads are verified when first accessed and on every reload.
+    /// Reserve [`Self::memory_bytes`] before constructing a budgeted lookup.
+    pub fn new(engine: &EvidenceEngine, outcome: &DatasetOutcome) -> Result<Self, DatasetError> {
+        let fields = engine.request().fields;
+        let digest = request_digest(engine);
+        let count = partition_count(engine);
+        require_path_size(&outcome.dataset_manifest)?;
+        let parent_snapshot = InputSnapshot::capture([outcome.dataset_manifest.clone()])?;
+        require_receipt_size(&outcome.dataset_manifest, parent_receipt_limit(count))?;
+        let manifest = read_receipt(&outcome.dataset_manifest)?;
+        let expected = [
+            ("evidence.science_blake3", outcome.science_digest.clone()),
+            ("dataset.request_blake3", digest.clone()),
+            ("dataset.partition_count", count.to_string()),
+            ("dataset.partition_bases", CANONICAL_TILE_BASES.to_string()),
+            ("outcome.rows", engine.plan().selected_loci.to_string()),
+            ("run_status", "completed".to_string()),
+            ("pileup.semantics", "exact-or-fail-v1".to_string()),
+        ];
+        if expected
+            .iter()
+            .any(|(key, value)| manifest.params.get(*key) != Some(value))
+            || manifest.inputs.len() as u64 != count
+            || manifest.outputs.len() as u64 != count
+            || receipt_fields(&manifest)? != fields
+        {
+            return Err(DatasetError::Corrupt(
+                "lookup parent receipt differs from the completed evidence request".into(),
+            ));
+        }
+        if outcome.science_digest.len() != 64
+            || !outcome
+                .science_digest
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(DatasetError::Incompatible(
+                "lookup science identity must be a 64-character digest".into(),
+            ));
+        }
+        let ownership = partitions(engine);
+        if ownership.len() as u64 != count {
+            return Err(DatasetError::Corrupt(
+                "lookup partition count is inconsistent".into(),
+            ));
+        }
+        let mut verified = Vec::with_capacity(ownership.len());
+        for ((part, receipt), artifact) in ownership
+            .into_iter()
+            .zip(&manifest.inputs)
+            .zip(&manifest.outputs)
+        {
+            if part.row_count() > u64::from(CANONICAL_TILE_BASES) {
+                return Err(DatasetError::Corrupt(
+                    "lookup ownership exceeds a canonical partition".into(),
+                ));
+            }
+            verified.push(LookupPartition {
+                ownership: part,
+                receipt_hash: receipt.blake3.clone(),
+                artifact_hash: artifact.blake3.clone(),
+                observed: None,
+            });
+        }
+        parent_snapshot.verify()?;
+        let root = outcome
+            .dataset_manifest
+            .parent()
+            .ok_or_else(|| {
+                DatasetError::Incompatible("dataset manifest has no parent directory".into())
+            })?
+            .to_path_buf();
+        Ok(Self {
+            root,
+            contigs: engine.contigs().clone(),
+            fields,
+            science_digest: outcome.science_digest.clone(),
+            request_digest: digest,
+            parent_snapshot,
+            partitions: verified,
+            loaded: None,
+        })
+    }
+
+    /// Borrow the requested selected locus. This never returns a synthetic zero
+    /// for a missing position. The borrow prevents a reload until it is released.
+    pub fn get(&mut self, contig: u32, position: u32) -> Result<EvidenceRowRef<'_>, DatasetError> {
+        crate::core::governor::checkpoint().map_err(EvidenceError::from)?;
+        self.parent_snapshot.verify()?;
+        let canonical = position / CANONICAL_TILE_BASES * CANONICAL_TILE_BASES;
+        let index = self
+            .partitions
+            .binary_search_by_key(&(contig, canonical), |partition| {
+                (partition.ownership.contig, partition.ownership.start)
+            })
+            .map_err(|_| missing_locus(contig, position))?;
+        let part = &self.partitions[index].ownership;
+        let interval = part
+            .intervals
+            .partition_point(|interval| interval.end <= position);
+        if part
+            .intervals
+            .get(interval)
+            .is_none_or(|interval| interval.start > position)
+        {
+            return Err(missing_locus(contig, position));
+        }
+        if let Some(observed) = &self.partitions[index].observed {
+            observed.verify()?;
+        }
+        if self.loaded.as_ref().map(|(loaded, _)| *loaded) != Some(index) {
+            self.load(index)?;
+        }
+        let batch = &self.loaded.as_ref().expect("successful partition load").1;
+        let row = batch
+            .loci()
+            .binary_search_by_key(&position, |locus| locus.position)
+            .map_err(|_| {
+                DatasetError::Corrupt("verified partition lost a selected locus".into())
+            })?;
+        Ok(batch.row(row).expect("verified locus index"))
+    }
+
+    /// Recheck ordinary mutation of the parent and every partition observed so
+    /// far. Call this immediately before publishing an annotation artifact.
+    pub fn verify_unchanged(&self) -> Result<(), DatasetError> {
+        crate::core::governor::checkpoint().map_err(EvidenceError::from)?;
+        self.parent_snapshot.verify()?;
+        for partition in &self.partitions {
+            if let Some(observed) = &partition.observed {
+                observed.verify()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn load(&mut self, index: usize) -> Result<(), DatasetError> {
+        // Release the previous canonical partition before retaining or decoding
+        // another; a failed replacement cannot leave stale rows addressable.
+        self.loaded = None;
+        self.parent_snapshot.verify()?;
+        let entry = &self.partitions[index];
+        let part = &entry.ownership;
+        let directory = self.root.join(part.name());
+        let receipt_path = directory.join("manifest.json");
+        let artifact_path = directory.join("evidence.arrow");
+        require_path_size(&receipt_path)?;
+        require_path_size(&artifact_path)?;
+        let observed = InputSnapshot::capture([receipt_path.clone(), artifact_path.clone()])?;
+        require_receipt_size(&receipt_path, PARTITION_RECEIPT_BYTES)?;
+        if blake3_file(&receipt_path)? != entry.receipt_hash {
+            return Err(DatasetError::Corrupt(
+                "lookup partition receipt differs from its completed parent".into(),
+            ));
+        }
+        let receipt = verify_partition(
+            &directory,
+            part,
+            &self.science_digest,
+            &self.request_digest,
+            self.fields,
+        )?;
+        if receipt.outputs[0].blake3 != entry.artifact_hash {
+            return Err(DatasetError::Corrupt(
+                "lookup partition artifact differs from its completed parent".into(),
+            ));
+        }
+        observed.verify()?;
+        let name = self
+            .contigs
+            .by_id(part.contig)
+            .ok_or_else(|| DatasetError::Corrupt("unknown lookup ownership contig".into()))?
+            .name
+            .to_string();
+        let mut retained =
+            EvidenceBatch::new(part.contig, name, part.start, self.fields, Vec::new());
+        retained.reserve_exact(part.row_count() as usize);
+        let mut interval_index = 0;
+        let mut next_position = part.intervals.first().map_or(0, |interval| interval.start);
+        let mut row_index = 0;
+        let metadata = read_evidence_batches_expected_fields(
+            BufReader::new(File::open(&artifact_path)?),
+            &self.contigs,
+            self.fields,
+            |batch| {
+                crate::core::governor::checkpoint()?;
+                if batch.fields() != self.fields
+                    || batch.contig_id != part.contig
+                    || batch.canonical_tile_start != part.start
+                {
+                    return Err(EvidenceError::InvalidInput(
+                        "lookup batch fields or canonical ownership differ".into(),
+                    ));
+                }
+                for row in batch.rows() {
+                    let interval = part.intervals.get(interval_index).ok_or_else(|| {
+                        EvidenceError::InvalidInput("lookup partition contains extra loci".into())
+                    })?;
+                    if row.position != next_position {
+                        return Err(EvidenceError::InvalidInput(
+                            "lookup partition omits or duplicates a selected locus".into(),
+                        ));
+                    }
+                    if let EvidenceSelection::Sites(sites) = &part.selection {
+                        let site = sites.get(row_index).ok_or_else(|| {
+                            EvidenceError::InvalidInput(
+                                "lookup has an unselected variant locus".into(),
+                            )
+                        })?;
+                        if row.position != site.position
+                            || row.reference != site.reference
+                            || row.requested_alts != site.alternates
+                        {
+                            return Err(EvidenceError::InvalidInput(
+                                "lookup variant REF/ALT annotation differs from selection".into(),
+                            ));
+                        }
+                    } else if !row.requested_alts.is_empty() {
+                        return Err(EvidenceError::InvalidInput(
+                            "lookup interval evidence contains unexpected ALT annotations".into(),
+                        ));
+                    }
+                    retained.push_row(row)?;
+                    row_index += 1;
+                    next_position += 1;
+                    if next_position == interval.end {
+                        interval_index += 1;
+                        if let Some(next) = part.intervals.get(interval_index) {
+                            next_position = next.start;
+                        }
+                    }
+                }
+                Ok(())
+            },
+        )
+        .map_err(|error| match error {
+            error @ EvidenceError::Core(_) => DatasetError::Evidence(error),
+            error => DatasetError::Corrupt(format!("invalid lookup Arrow evidence: {error}")),
+        })?;
+        if metadata.fields != self.fields
+            || metadata.schema_version != self.fields.schema_version()
+            || interval_index != part.intervals.len()
+            || retained.len() as u64 != part.row_count()
+        {
+            return Err(DatasetError::Corrupt(
+                "lookup partition lacks its complete selected field/locus set".into(),
+            ));
+        }
+        observed.verify()?;
+        self.parent_snapshot.verify()?;
+        crate::core::governor::checkpoint().map_err(EvidenceError::from)?;
+        self.partitions[index].observed = Some(observed);
+        self.loaded = Some((index, retained));
+        Ok(())
+    }
+}
+
+fn partition_count(engine: &EvidenceEngine) -> u64 {
+    let mut count = 0u64;
+    let mut last = None;
+    for interval in engine.intervals() {
+        if interval.start == interval.end {
+            continue;
+        }
+        let first = interval.start / CANONICAL_TILE_BASES;
+        let final_tile = (interval.end - 1) / CANONICAL_TILE_BASES;
+        count +=
+            u64::from(final_tile - first + 1) - u64::from(last == Some((interval.contig, first)));
+        last = Some((interval.contig, final_tile));
+    }
+    count
+}
+
+fn parent_receipt_limit(partitions: u64) -> u64 {
+    (64u64 << 10).saturating_add(partitions.saturating_mul(PARENT_BYTES_PER_PARTITION))
+}
+
+fn require_receipt_size(path: &Path, maximum: u64) -> Result<(), DatasetError> {
+    if fs::metadata(path)?.len() > maximum {
+        return Err(DatasetError::Corrupt(format!(
+            "lookup receipt exceeds its {maximum}-byte metadata envelope: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn require_path_size(path: &Path) -> Result<(), DatasetError> {
+    // The per-partition metadata reservation includes two cloned stamp paths
+    // plus ownership/hash metadata. Refuse a larger path before cloning it.
+    if path.as_os_str().len() > LOOKUP_PATH_BYTES {
+        return Err(DatasetError::Incompatible(format!(
+            "lookup path exceeds the {LOOKUP_PATH_BYTES}-byte path envelope"
+        )));
+    }
+    Ok(())
+}
+
+fn missing_locus(contig: u32, position: u32) -> DatasetError {
+    DatasetError::Incompatible(format!(
+        "locus {contig}:{position} is absent from the selected evidence dataset"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evidence::{EvidenceCallback, EvidenceLocus, EvidenceRequest, SnvSite};
+    use rust_htslib::bam::{self, header::HeaderRecord, record::Cigar, record::CigarString};
+
+    struct Fixture {
+        root: PathBuf,
+        engine: EvidenceEngine,
+        outcome: DatasetOutcome,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "rosalind-evidence-lookup-{}-{}",
+                std::process::id(),
+                TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&root).unwrap();
+            let length = CANONICAL_TILE_BASES + 4;
+            let reference = root.join("reference.fa");
+            fs::write(
+                &reference,
+                format!(">chr1\n{}\n>chr2\nCCCC\n", "A".repeat(length as usize)),
+            )
+            .unwrap();
+            fs::write(
+                root.join("reference.fa.fai"),
+                format!(
+                    "chr1\t{length}\t6\t{length}\t{}\nchr2\t4\t{}\t4\t5\n",
+                    length + 1,
+                    length + 13
+                ),
+            )
+            .unwrap();
+            let bam_path = root.join("reads.bam");
+            let mut header = bam::Header::new();
+            header.push_record(HeaderRecord::new(b"HD").push_tag(b"SO", "coordinate"));
+            for (name, length) in [("chr1", length), ("chr2", 4)] {
+                header.push_record(
+                    HeaderRecord::new(b"SQ")
+                        .push_tag(b"SN", name)
+                        .push_tag(b"LN", length),
+                );
+            }
+            let mut writer = bam::Writer::from_path(&bam_path, &header, bam::Format::Bam).unwrap();
+            for (tid, position, base, quality, mapq) in [
+                (0, 1, b'C', 30, 60),
+                (0, CANONICAL_TILE_BASES + 1, b'G', 35, 42),
+                (1, 1, b'T', 40, 55),
+            ] {
+                let mut record = bam::Record::new();
+                record.set(
+                    format!("r{tid}-{position}").as_bytes(),
+                    Some(&CigarString(vec![Cigar::Match(1)])),
+                    &[base],
+                    &[quality],
+                );
+                record.set_tid(tid);
+                record.set_pos(i64::from(position));
+                record.set_flags(0);
+                record.set_mapq(mapq);
+                writer.write(&record).unwrap();
+            }
+            drop(writer);
+            bam::index::build(&bam_path, None::<&PathBuf>, bam::index::Type::Bai, 1).unwrap();
+            let mut request = EvidenceRequest::new(&bam_path, &reference);
+            request.fields = EvidenceFields::DEPTHS
+                .union(EvidenceFields::ALLELES)
+                .union(EvidenceFields::ALLELE_QUALITY);
+            request.selection = EvidenceSelection::Sites(vec![
+                SnvSite {
+                    contig: 0,
+                    position: 1,
+                    reference: b'A',
+                    alternates: vec![b'C'],
+                },
+                SnvSite {
+                    contig: 0,
+                    position: 2,
+                    reference: b'A',
+                    alternates: vec![b'G'],
+                },
+                SnvSite {
+                    contig: 0,
+                    position: CANONICAL_TILE_BASES + 1,
+                    reference: b'A',
+                    alternates: vec![b'G', b'T'],
+                },
+                SnvSite {
+                    contig: 1,
+                    position: 1,
+                    reference: b'C',
+                    alternates: vec![b'T'],
+                },
+            ]);
+            let mut engine = EvidenceEngine::open(request).unwrap();
+            let mut consumer = EvidenceCallback::with_fields(
+                |_: &EvidenceBatch| Ok(()),
+                0,
+                engine.request().fields,
+            );
+            let outcome = run_dataset(
+                &mut engine,
+                &"a".repeat(64),
+                &DatasetOptions {
+                    cache_dir: root.join("cache"),
+                    resume: false,
+                    workers: 1,
+                },
+                &mut consumer,
+            )
+            .unwrap();
+            Self {
+                root,
+                engine,
+                outcome,
+            }
+        }
+
+        fn partition_path(&self, index: usize) -> PathBuf {
+            self.outcome
+                .dataset_manifest
+                .parent()
+                .unwrap()
+                .join(partitions(&self.engine)[index].name())
+        }
+
+        fn replace_partition(&self, replacement: &EvidenceBatch) {
+            let directory = self.partition_path(0);
+            let artifact = directory.join("evidence.arrow");
+            let mut writer = EvidenceArrowWriter::with_fields(
+                File::create(&artifact).unwrap(),
+                replacement.fields(),
+            );
+            writer.on_batch(replacement).unwrap();
+            writer.finish().unwrap();
+            drop(writer);
+            let receipt_path = directory.join("manifest.json");
+            let mut receipt = read_receipt(&receipt_path).unwrap();
+            receipt.outputs[0].blake3 = blake3_file(&artifact).unwrap();
+            receipt.finalize();
+            fs::write(&receipt_path, receipt.to_canonical_json()).unwrap();
+            let mut parent = read_receipt(&self.outcome.dataset_manifest).unwrap();
+            parent.inputs[0].blake3 = blake3_file(&receipt_path).unwrap();
+            parent.outputs[0].blake3 = receipt.outputs[0].blake3.clone();
+            parent.finalize();
+            fs::write(&self.outcome.dataset_manifest, parent.to_canonical_json()).unwrap();
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn unsorted_repeated_lookups_preserve_projected_allele_quality_and_zero_depth() {
+        let fixture = Fixture::new();
+        let mut lookup = VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome).unwrap();
+        for (contig, position, allele, bq, mq) in [
+            (0, CANONICAL_TILE_BASES + 1, 2, 35, 42),
+            (0, 1, 1, 30, 60),
+            (1, 1, 3, 40, 55),
+            (0, CANONICAL_TILE_BASES + 1, 2, 35, 42),
+            (0, 1, 1, 30, 60),
+        ] {
+            let row = lookup.get(contig, position).unwrap();
+            assert_eq!(row.depths.unwrap().callable_depth, 1);
+            assert_eq!(row.alleles.unwrap().allele_counts[allele], 1);
+            assert_eq!(row.allele_quality.unwrap().base_quality_sum[allele], bq);
+            assert_eq!(row.allele_quality.unwrap().mapping_quality_sum[allele], mq);
+            assert!(row.quality_histograms.is_none());
+            assert!(lookup.loaded.as_ref().unwrap().1.len() <= CANONICAL_TILE_BASES as usize);
+        }
+        assert_eq!(lookup.get(0, 2).unwrap().depths.unwrap().callable_depth, 0);
+        assert!(matches!(
+            lookup.get(0, 0),
+            Err(DatasetError::Incompatible(_))
+        ));
+        assert!(matches!(
+            lookup.get(7, 1),
+            Err(DatasetError::Incompatible(_))
+        ));
+        lookup.verify_unchanged().unwrap();
+        assert!(
+            VerifiedEvidenceLookup::memory_bytes(&fixture.engine)
+                > fixture.engine.request().fields.storage_bytes_per_locus()
+                    * u64::from(CANONICAL_TILE_BASES)
+        );
+    }
+
+    #[test]
+    fn parent_request_and_partition_hash_anchors_are_required() {
+        let fixture = Fixture::new();
+        let mut changed = fixture.engine.request().clone();
+        changed.profile.min_mapq += 1;
+        let changed = EvidenceEngine::open(changed).unwrap();
+        assert!(VerifiedEvidenceLookup::new(&changed, &fixture.outcome).is_err());
+        let path = fixture.partition_path(0).join("manifest.json");
+        let mut receipt = read_receipt(&path).unwrap();
+        receipt.params.insert("extra".into(), "resealed".into());
+        receipt.finalize();
+        fs::write(&path, receipt.to_canonical_json()).unwrap();
+        let mut lookup = VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome).unwrap();
+        assert!(matches!(lookup.get(0, 1), Err(DatasetError::Corrupt(_))));
+        assert!(lookup.loaded.is_none());
+    }
+
+    #[test]
+    fn resealed_rows_cannot_change_selected_order_annotations_or_fields() {
+        for mutation in [
+            "missing",
+            "duplicate",
+            "alt",
+            "reference",
+            "fields",
+            "contig",
+        ] {
+            let fixture = Fixture::new();
+            let mut loci = vec![
+                EvidenceLocus {
+                    position: 1,
+                    reference: b'A',
+                    requested_alts: vec![b'C'],
+                },
+                EvidenceLocus {
+                    position: 2,
+                    reference: b'A',
+                    requested_alts: vec![b'G'],
+                },
+            ];
+            let mut fields = fixture.engine.request().fields;
+            let mut contig = 0;
+            let mut name = "chr1";
+            match mutation {
+                "missing" => {
+                    loci.pop();
+                }
+                "duplicate" => {
+                    loci[1] = loci[0].clone();
+                }
+                "alt" => {
+                    loci[0].requested_alts = vec![b'T'];
+                }
+                "reference" => {
+                    loci[0].reference = b'G';
+                }
+                "fields" => {
+                    fields = EvidenceFields::DEPTHS;
+                }
+                "contig" => {
+                    contig = 1;
+                    name = "chr2";
+                }
+                _ => unreachable!(),
+            }
+            fixture.replace_partition(&EvidenceBatch::new(contig, name, 0, fields, loci));
+            let mut lookup =
+                VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome).unwrap();
+            assert!(
+                matches!(lookup.get(0, 1), Err(DatasetError::Corrupt(_))),
+                "{mutation}"
+            );
+            assert!(lookup.loaded.is_none(), "{mutation}");
+        }
+    }
+
+    #[test]
+    fn final_guard_checks_previously_loaded_partitions_and_parent_mutation() {
+        let fixture = Fixture::new();
+        let mut lookup = VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome).unwrap();
+        lookup.get(0, 1).unwrap();
+        lookup.get(1, 1).unwrap();
+        fs::write(fixture.partition_path(0).join("evidence.arrow"), b"changed").unwrap();
+        assert!(lookup.verify_unchanged().is_err());
+        assert!(lookup.get(0, 1).is_err());
+        let fixture = Fixture::new();
+        let mut lookup = VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome).unwrap();
+        fs::write(&fixture.outcome.dataset_manifest, b"changed").unwrap();
+        assert!(lookup.get(0, 1).is_err());
+    }
+
+    #[test]
+    fn oversized_parent_receipt_refuses_before_parsing() {
+        let fixture = Fixture::new();
+        File::options()
+            .write(true)
+            .open(&fixture.outcome.dataset_manifest)
+            .unwrap()
+            .set_len(parent_receipt_limit(partition_count(&fixture.engine)) + 1)
+            .unwrap();
+        match VerifiedEvidenceLookup::new(&fixture.engine, &fixture.outcome) {
+            Err(DatasetError::Corrupt(message)) => assert!(message.contains("metadata envelope")),
+            _ => panic!("oversized metadata was not refused"),
+        }
+    }
+}

--- a/src/dataset_diff.rs
+++ b/src/dataset_diff.rs
@@ -122,7 +122,8 @@ fn verified_dataset(receipt_path: &Path) -> Result<VerifiedDataset, DatasetDiffE
         .get("evidence.fields_version")
         .map(String::as_str);
     if schema != Some(fields.schema_version().to_string().as_str())
-        || !matches!((schema, field_version), (Some("1"), None) | (_, Some("1")))
+        || !(field_version == Some(fields.mask_version().to_string().as_str())
+            || (schema == Some("1") && field_version.is_none()))
     {
         return Err(DatasetDiffError::Incompatible(
             "unsupported evidence schema/field mask version".into(),
@@ -507,7 +508,7 @@ impl<'a> Rows<'a> {
             .iter()
             .zip(&self.columns)
             .skip(4)
-            .filter(|(_, name)| !name.ends_with("_histogram"))
+            .filter(|(_, name)| !name.ends_with("_histogram") && !name.starts_with("allele_"))
             .any(|(value, _)| {
                 value
                     .parse::<u64>()
@@ -517,6 +518,25 @@ impl<'a> Rows<'a> {
             return Err(DatasetDiffError::Integrity(
                 "invalid evidence scalar counter".into(),
             ));
+        }
+        for (index, name) in self
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, name)| name.starts_with("allele_"))
+        {
+            let values: Vec<_> = fields[index].split(',').collect();
+            if values.len() != 4
+                || values.iter().any(|value| {
+                    value
+                        .parse::<u64>()
+                        .map_or(true, |number| number.to_string() != *value)
+                })
+            {
+                return Err(DatasetDiffError::Integrity(format!(
+                    "invalid per-allele counter array {name}"
+                )));
+            }
         }
         for (name, bins) in [
             ("base_quality_histogram", 94usize),

--- a/src/evidence/batch.rs
+++ b/src/evidence/batch.rs
@@ -73,6 +73,19 @@ pub struct EvidenceReadPosition {
     pub read_length_sum: u64,
 }
 
+/// Exact sufficient statistics separated by callable A/C/G/T observations.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct EvidenceAlleleQuality {
+    /// Base-quality sums in A/C/G/T order.
+    pub base_quality_sum: [u64; 4],
+    /// Mapping-quality sums in A/C/G/T order.
+    pub mapping_quality_sum: [u64; 4],
+    /// Sequencing-cycle sums in A/C/G/T order, with reverse reads restored.
+    pub read_position_sum: [u64; 4],
+    /// Full stored-read-length sums in A/C/G/T order.
+    pub read_length_sum: [u64; 4],
+}
+
 /// Selected loci with physically present, contiguous summary groups. An absent
 /// group has no allocation and does not imply zero measurements. Group lengths
 /// and availability are maintained by the batch constructors and append methods.
@@ -92,6 +105,7 @@ pub struct EvidenceBatch {
     quality_sums: Option<Vec<EvidenceQualitySums>>,
     quality_histograms: Option<Vec<EvidenceQualityHistograms>>,
     read_position: Option<Vec<EvidenceReadPosition>>,
+    allele_quality: Option<Vec<EvidenceAlleleQuality>>,
 }
 
 /// A borrowed locus. Check a group's availability before reading its metrics.
@@ -116,6 +130,8 @@ pub struct EvidenceRowRef<'a> {
     pub quality_histograms: Option<&'a EvidenceQualityHistograms>,
     /// Present only when READ_POSITION was requested.
     pub read_position: Option<&'a EvidenceReadPosition>,
+    /// Present only when ALLELE_QUALITY was explicitly requested.
+    pub allele_quality: Option<&'a EvidenceAlleleQuality>,
 }
 impl EvidenceRowRef<'_> {
     /// Physical groups available on this row.
@@ -131,6 +147,10 @@ impl EvidenceRowRef<'_> {
                 EvidenceFields::QUALITY_HISTOGRAMS,
             ),
             (self.read_position.is_some(), EvidenceFields::READ_POSITION),
+            (
+                self.allele_quality.is_some(),
+                EvidenceFields::ALLELE_QUALITY,
+            ),
         ] {
             if present {
                 fields = fields.union(group);
@@ -180,6 +200,7 @@ pub(crate) struct EvidenceRowMut<'a> {
     pub quality_sums: Option<&'a mut EvidenceQualitySums>,
     pub quality_histograms: Option<&'a mut EvidenceQualityHistograms>,
     pub read_position: Option<&'a mut EvidenceReadPosition>,
+    pub allele_quality: Option<&'a mut EvidenceAlleleQuality>,
 }
 
 impl EvidenceBatch {
@@ -217,6 +238,9 @@ impl EvidenceBatch {
             read_position: fields
                 .contains(EvidenceFields::READ_POSITION)
                 .then(|| vec![EvidenceReadPosition::default(); len]),
+            allele_quality: fields
+                .contains(EvidenceFields::ALLELE_QUALITY)
+                .then(|| vec![EvidenceAlleleQuality::default(); len]),
         }
     }
 
@@ -314,6 +338,7 @@ impl EvidenceBatch {
                 .as_ref()
                 .map(|values| &values[index]),
             read_position: self.read_position.as_ref().map(|values| &values[index]),
+            allele_quality: self.allele_quality.as_ref().map(|values| &values[index]),
         })
     }
     /// Iterate borrowed rows in their existing coordinate order.
@@ -334,6 +359,10 @@ impl EvidenceBatch {
                 .as_mut()
                 .map(|values| &mut values[index]),
             read_position: self.read_position.as_mut().map(|values| &mut values[index]),
+            allele_quality: self
+                .allele_quality
+                .as_mut()
+                .map(|values| &mut values[index]),
         })
     }
     pub(crate) fn reserve_exact(&mut self, additional: usize) {
@@ -354,6 +383,9 @@ impl EvidenceBatch {
             values.reserve_exact(additional);
         }
         if let Some(values) = &mut self.read_position {
+            values.reserve_exact(additional);
+        }
+        if let Some(values) = &mut self.allele_quality {
             values.reserve_exact(additional);
         }
     }
@@ -377,6 +409,9 @@ impl EvidenceBatch {
         if let Some(values) = &mut self.read_position {
             values.clear();
         }
+        if let Some(values) = &mut self.allele_quality {
+            values.clear();
+        }
     }
     /// Replace locus identities while retaining each summary allocation. The
     /// caller reuses the returned identity vector as its next-window scratch.
@@ -396,6 +431,7 @@ impl EvidenceBatch {
         reset!(&mut self.quality_sums, EvidenceQualitySums);
         reset!(&mut self.quality_histograms, EvidenceQualityHistograms);
         reset!(&mut self.read_position, EvidenceReadPosition);
+        reset!(&mut self.allele_quality, EvidenceAlleleQuality);
         std::mem::replace(&mut self.loci, loci)
     }
     pub(crate) fn push_row(&mut self, row: EvidenceRowRef<'_>) -> Result<(), EvidenceError> {
@@ -427,6 +463,9 @@ impl EvidenceBatch {
         if let Some(values) = &mut self.read_position {
             values.push(*row.read_position.expect("source field invariant"));
         }
+        if let Some(values) = &mut self.allele_quality {
+            values.push(*row.allele_quality.expect("source field invariant"));
+        }
         Ok(())
     }
 }
@@ -447,7 +486,7 @@ mod tests {
 
     #[test]
     fn every_mask_allocates_exactly_its_requested_groups() {
-        for bits in 0..=EvidenceFields::ALL.bits() {
+        for bits in 0..=EvidenceFields::ALL_SUPPORTED.bits() {
             let fields = EvidenceFields::from_bits(bits).unwrap();
             let batch = EvidenceBatch::new(0, "chr1", 0, fields, loci(3));
             assert_eq!(batch.len(), 3);
@@ -476,6 +515,7 @@ mod tests {
                 EvidenceQualityHistograms
             );
             check!(read_position, READ_POSITION, EvidenceReadPosition);
+            check!(allele_quality, ALLELE_QUALITY, EvidenceAlleleQuality);
             assert_eq!(bytes as u64, fields.storage_bytes_per_locus() * 3);
             for row in batch.rows() {
                 assert_eq!(row.fields(), fields);

--- a/src/evidence/encoding.rs
+++ b/src/evidence/encoding.rs
@@ -43,6 +43,22 @@ const SCALAR_NAMES: [&str; 28] = [
     "filtered_low_base_quality",
     "filtered_ambiguous_base",
 ];
+const ALLELE_SUM_NAMES: [&str; 4] = [
+    "allele_base_quality_sum",
+    "allele_mapping_quality_sum",
+    "allele_read_position_sum",
+    "allele_read_length_sum",
+];
+fn allele_sum<'a>(row: EvidenceRowRef<'a>, index: usize) -> &'a [u64; 4] {
+    let values = row.allele_quality.expect("field capability checked");
+    match index {
+        0 => &values.base_quality_sum,
+        1 => &values.mapping_quality_sum,
+        2 => &values.read_position_sum,
+        3 => &values.read_length_sum,
+        _ => unreachable!("known allele summary"),
+    }
+}
 fn scalar_group(index: usize) -> EvidenceFields {
     match index {
         0..=2 | 19..=27 => EvidenceFields::DEPTHS,
@@ -151,6 +167,11 @@ impl<W: Write> EvidenceTsvWriter<W> {
                     "\tbase_quality_histogram\tmapping_quality_histogram"
                 )?;
             }
+            if self.fields.contains(EvidenceFields::ALLELE_QUALITY) {
+                for name in ALLELE_SUM_NAMES {
+                    write!(self.out, "\t{name}")?;
+                }
+            }
             writeln!(self.out)?;
             self.started = true;
         }
@@ -192,6 +213,16 @@ impl<W: Write> EvidenceAnalyzer for EvidenceTsvWriter<W> {
                 write_histogram(&mut self.out, &histograms.base_quality_histogram)?;
                 write!(self.out, "\t")?;
                 write_histogram(&mut self.out, &histograms.mapping_quality_histogram)?;
+            }
+            if self.fields.contains(EvidenceFields::ALLELE_QUALITY) {
+                for index in 0..4 {
+                    let values = allele_sum(row, index);
+                    write!(
+                        self.out,
+                        "\t{},{},{},{}",
+                        values[0], values[1], values[2], values[3]
+                    )?;
+                }
             }
             writeln!(self.out)?;
         }
@@ -239,12 +270,21 @@ fn schema(selected: EvidenceFields) -> Schema {
             false,
         ));
     }
+    if selected.contains(EvidenceFields::ALLELE_QUALITY) {
+        for name in ALLELE_SUM_NAMES {
+            fields.push(Field::new(
+                name,
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt64, false)), 4),
+                false,
+            ));
+        }
+    }
     Schema::new(fields).with_metadata(std::collections::HashMap::from([(
         "rosalind.evidence.schema".into(),
         if selected == EvidenceFields::ALL {
             "1".into()
         } else {
-            format!("2;fields-v{}={}", EvidenceFields::VERSION, selected.bits())
+            format!("2;fields-v{}={}", selected.mask_version(), selected.bits())
         },
     )]))
 }
@@ -354,6 +394,24 @@ impl<W: Write> EvidenceArrowWriter<W> {
                 ));
             }
         }
+        if self.fields.contains(EvidenceFields::ALLELE_QUALITY) {
+            for index in 0..4 {
+                let values: ArrayRef = Arc::new(UInt64Array::from_iter_values(
+                    self.rows
+                        .rows()
+                        .flat_map(|row| allele_sum(row, index).iter().copied()),
+                ));
+                arrays.push(Arc::new(
+                    FixedSizeListArray::try_new(
+                        Arc::new(Field::new("item", DataType::UInt64, false)),
+                        4,
+                        values,
+                        None,
+                    )
+                    .map_err(arrow_error)?,
+                ));
+            }
+        }
         let batch =
             RecordBatch::try_new(Arc::new(schema(self.fields)), arrays).map_err(arrow_error)?;
         self.writer
@@ -456,7 +514,7 @@ fn body_envelope(fields: EvidenceFields) -> u64 {
 }
 /// Conservative retained IPC buffers, decoded arrays, projected callback storage,
 /// and metadata. Does not include memory retained by the downstream analyzer.
-/// Use ALL when the input field set is unknown, or enforce the expected set with
+/// Use ALL_SUPPORTED when the input field set is unknown, or enforce the expected set with
 /// `read_evidence_batches_expected_fields` before admitting a smaller reservation.
 pub fn evidence_reader_memory_bytes(fields: EvidenceFields) -> u64 {
     2 * body_envelope(fields)
@@ -515,8 +573,9 @@ fn read_evidence_batches_impl<R: std::io::Read>(
         EvidenceFields::ALL
     } else {
         let bits = metadata
-            .strip_prefix("2;fields-v1=")
-            .and_then(|value| value.parse::<u32>().ok())
+            .strip_prefix("2;fields-v")
+            .and_then(|value| value.split_once('='))
+            .and_then(|(_, bits)| bits.parse::<u32>().ok())
             .ok_or_else(|| invalid("unsupported evidence schema or field mask version"))?;
         EvidenceFields::from_bits(bits)?
     };
@@ -593,6 +652,27 @@ fn read_evidence_batches_impl<R: std::io::Read>(
         };
         let bq = histogram(0)?;
         let mq = histogram(1)?;
+        let mut allele_arrays = Vec::new();
+        if fields.contains(EvidenceFields::ALLELE_QUALITY) {
+            let start = 4
+                + scalar_indices.len()
+                + if fields.contains(EvidenceFields::QUALITY_HISTOGRAMS) {
+                    2
+                } else {
+                    0
+                };
+            for column in start..start + 4 {
+                let array = encoded
+                    .column(column)
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| invalid("invalid per-allele summary array"))?;
+                if array.values().null_count() != 0 {
+                    return Err(invalid("per-allele summaries cannot contain nulls"));
+                }
+                allele_arrays.push(array);
+            }
+        }
         let mut index = 0;
         while index < encoded.num_rows() {
             let start = index;
@@ -710,6 +790,24 @@ fn read_evidence_batches_impl<R: std::io::Read>(
                         destination.copy_from_slice(values.values());
                     }
                 }
+                if let Some(sums) = row.allele_quality {
+                    for (column, target) in [
+                        &mut sums.base_quality_sum,
+                        &mut sums.mapping_quality_sum,
+                        &mut sums.read_position_sum,
+                        &mut sums.read_length_sum,
+                    ]
+                    .into_iter()
+                    .enumerate()
+                    {
+                        let array = allele_arrays[column].value(source);
+                        let values = array
+                            .as_any()
+                            .downcast_ref::<UInt64Array>()
+                            .ok_or_else(|| invalid("invalid per-allele summary values"))?;
+                        target.copy_from_slice(values.values());
+                    }
+                }
                 validate_row(batch.row(offset).unwrap())?;
             }
             on_batch(&batch)?;
@@ -803,6 +901,68 @@ fn validate_row(row: EvidenceRowRef<'_>) -> Result<(), EvidenceError> {
             u128::from(q.base_quality_sum) > d * 93 || u128::from(q.mapping_quality_sum) > d * 254
         }) {
             return Err(invalid());
+        }
+    }
+    if let Some(a) = row.allele_quality {
+        let total_bq = sum(&a.base_quality_sum);
+        let total_mq = sum(&a.mapping_quality_sum);
+        let total_position = sum(&a.read_position_sum);
+        let total_length = sum(&a.read_length_sum);
+        if depth.is_some_and(|count| {
+            total_bq > count * 93
+                || total_mq > count * 254
+                || total_position + count > total_length
+                || (count == 0 && total_length != 0)
+        }) {
+            return Err(invalid());
+        }
+        if let Some(h) = row.quality_histograms {
+            if total_bq != weighted(&h.base_quality_histogram)
+                || total_mq != weighted(&h.mapping_quality_histogram)
+            {
+                return Err(invalid());
+            }
+        }
+        if let Some(q) = row.quality_sums {
+            if sum(&a.base_quality_sum) != u128::from(q.base_quality_sum)
+                || sum(&a.mapping_quality_sum) != u128::from(q.mapping_quality_sum)
+            {
+                return Err(invalid());
+            }
+        }
+        if let Some(p) = row.read_position {
+            if sum(&a.read_position_sum) != u128::from(p.read_position_sum)
+                || sum(&a.read_length_sum) != u128::from(p.read_length_sum)
+            {
+                return Err(invalid());
+            }
+        }
+        for allele in 0..4 {
+            let count = row
+                .alleles
+                .map(|counts| u128::from(counts.allele_counts[allele]))
+                .or_else(|| {
+                    row.strands
+                        .map(|strands| sum(&strands.strand_counts[allele]))
+                });
+            let length = u128::from(a.read_length_sum[allele]);
+            // Even without counts, each contributing read has positive length
+            // and its zero-based position is strictly less than that length.
+            if u128::from(a.base_quality_sum[allele]) > length * 93
+                || u128::from(a.mapping_quality_sum[allele]) > length * 254
+                || (length > 0 && u128::from(a.read_position_sum[allele]) >= length)
+            {
+                return Err(invalid());
+            }
+            if count.is_some_and(|count| {
+                u128::from(a.base_quality_sum[allele]) > count * 93
+                    || u128::from(a.mapping_quality_sum[allele]) > count * 254
+                    || (count == 0 && a.read_length_sum[allele] != 0)
+            }) || u128::from(a.read_position_sum[allele]) + count.unwrap_or(0)
+                > u128::from(a.read_length_sum[allele])
+            {
+                return Err(invalid());
+            }
         }
     }
     if let Some(p) = row.read_position {
@@ -918,8 +1078,14 @@ impl<R: std::io::Read> BoundedIpcReader<R> {
                 let buffers = batch
                     .buffers()
                     .ok_or_else(|| invalid("evidence IPC buffers missing"))?;
-                let expected_nodes = 4 + scalar_count + if histograms { 4 } else { 0 };
-                let expected_buffers = 11 + scalar_count * 2 + if histograms { 6 } else { 0 };
+                let allele_sums = fields.contains(EvidenceFields::ALLELE_QUALITY);
+                let histogram_nodes = if histograms { 4 } else { 0 };
+                let expected_nodes =
+                    4 + scalar_count + histogram_nodes + if allele_sums { 8 } else { 0 };
+                let expected_buffers = 11
+                    + scalar_count * 2
+                    + if histograms { 6 } else { 0 }
+                    + if allele_sums { 12 } else { 0 };
                 if nodes.len() != expected_nodes || buffers.len() != expected_buffers {
                     return Err(invalid(
                         "evidence IPC node/buffer count differs from projected schema",
@@ -934,8 +1100,15 @@ impl<R: std::io::Read> BoundedIpcReader<R> {
                 let rows = batch.length();
                 for (index, node) in nodes.iter().enumerate() {
                     let expected_length = match index.checked_sub(4 + scalar_count) {
-                        Some(1) => rows * BASE_QUALITY_BINS as i64,
-                        Some(3) => rows * MAPPING_QUALITY_BINS as i64,
+                        Some(1) if histograms => rows * BASE_QUALITY_BINS as i64,
+                        Some(3) if histograms => rows * MAPPING_QUALITY_BINS as i64,
+                        Some(index)
+                            if allele_sums
+                                && index >= histogram_nodes
+                                && (index - histogram_nodes) % 2 == 1 =>
+                        {
+                            rows * 4
+                        }
                         _ => rows,
                     };
                     if node.length() != expected_length || node.null_count() != 0 {
@@ -1133,7 +1306,7 @@ mod tests {
             error.to_string().contains("differs from expected fields"),
             "{error}"
         );
-        for bits in 0..=EvidenceFields::ALL.bits() {
+        for bits in 0..=EvidenceFields::ALL_SUPPORTED.bits() {
             let fields = EvidenceFields::from_bits(bits).unwrap();
             for rows in [0, 2] {
                 let (bytes, contigs) = fixture(fields, rows);
@@ -1167,6 +1340,64 @@ mod tests {
             |_| Ok(())
         )
         .is_err());
+    }
+
+    #[test]
+    fn allele_sums_validate_against_each_independently_available_count_source() {
+        for (bits, case) in [(64, 0), (64, 1), (65, 0), (66, 0), (68, 0), (80, 0)] {
+            let fields = EvidenceFields::from_bits(bits).unwrap();
+            let mut batch = EvidenceBatch::new(
+                0,
+                "chr1",
+                0,
+                fields,
+                vec![EvidenceLocus {
+                    position: 0,
+                    reference: b'A',
+                    requested_alts: vec![b'C'],
+                }],
+            );
+            let row = batch.row_mut(0).unwrap();
+            let sums = row.allele_quality.unwrap();
+            match bits {
+                64 if case == 0 => sums.base_quality_sum[0] = 1,
+                64 => {
+                    sums.read_position_sum[0] = 1;
+                    sums.read_length_sum[0] = 1;
+                }
+                // No callable observations can contribute quality or length.
+                65 => sums.base_quality_sum[0] = 1,
+                66 => sums.read_length_sum[0] = 1,
+                // A strand count independently proves no C observations exist.
+                68 => {
+                    row.strands.unwrap().strand_counts[0][0] = 1;
+                    sums.read_length_sum[0] = 1;
+                    sums.base_quality_sum[1] = 1;
+                }
+                // Pooled histograms constrain sums even without QUALITY_SUMS.
+                80 => {
+                    let hist = row.quality_histograms.unwrap();
+                    hist.base_quality_histogram[30] = 1;
+                    hist.mapping_quality_histogram[60] = 1;
+                    sums.base_quality_sum[0] = 31;
+                    sums.mapping_quality_sum[0] = 60;
+                    sums.read_length_sum[0] = 1;
+                }
+                _ => unreachable!(),
+            }
+            let mut writer = EvidenceArrowWriter::with_fields(Vec::new(), fields);
+            writer.on_batch(&batch).unwrap();
+            let bytes = writer.into_inner().unwrap();
+            let mut contigs = crate::core::ContigSet::new();
+            contigs.push("chr1", 1);
+            assert!(
+                read_evidence_batches_expected_fields(bytes.as_slice(), &contigs, fields, |_| {
+                    panic!("invalid values must fail before consumer access")
+                })
+                .is_err(),
+                "mask={bits}"
+            );
+        }
     }
 
     #[test]

--- a/src/evidence/engine.rs
+++ b/src/evidence/engine.rs
@@ -787,14 +787,26 @@ fn accumulate_record(
                         checked_add(&mut sums.base_quality_sum, quality as u64)?;
                         checked_add(&mut sums.mapping_quality_sum, record.mapq() as u64)?;
                     }
+                    let cycle = if record.is_reverse() {
+                        record.seq_len() - 1 - offset
+                    } else {
+                        offset
+                    };
                     if let Some(position) = row.read_position {
-                        let cycle = if record.is_reverse() {
-                            record.seq_len() - 1 - offset
-                        } else {
-                            offset
-                        };
                         checked_add(&mut position.read_position_sum, cycle as u64)?;
                         checked_add(&mut position.read_length_sum, record.seq_len() as u64)?;
+                    }
+                    if let Some(quality_sums) = row.allele_quality {
+                        checked_add(&mut quality_sums.base_quality_sum[allele], quality as u64)?;
+                        checked_add(
+                            &mut quality_sums.mapping_quality_sum[allele],
+                            record.mapq() as u64,
+                        )?;
+                        checked_add(&mut quality_sums.read_position_sum[allele], cycle as u64)?;
+                        checked_add(
+                            &mut quality_sums.read_length_sum[allele],
+                            record.seq_len() as u64,
+                        )?;
                     }
                     if let Some(histograms) = row.quality_histograms {
                         checked_add(&mut histograms.base_quality_histogram[quality as usize], 1)?;
@@ -1003,7 +1015,7 @@ mod projection_tests {
             }
             batch
         };
-        let full = extract(EvidenceFields::ALL);
+        let full = extract(EvidenceFields::ALL_SUPPORTED);
         assert_eq!(full.row(0).unwrap().depths.unwrap().prefilter_depth, 4);
         assert_eq!(full.row(0).unwrap().depths.unwrap().callable_depth, 2);
         assert_eq!(
@@ -1029,7 +1041,7 @@ mod projection_tests {
             2
         );
         assert_eq!(full.row(6).unwrap().depths.unwrap().prefilter_depth, 0);
-        for bits in 0..=EvidenceFields::ALL.bits() {
+        for bits in 0..=EvidenceFields::ALL_SUPPORTED.bits() {
             let fields = EvidenceFields::from_bits(bits).unwrap();
             let projected = extract(fields);
             assert_eq!(projected.len(), selected_loci().len());
@@ -1067,6 +1079,12 @@ mod projection_tests {
                     expected
                         .quality_histograms
                         .filter(|_| fields.contains(EvidenceFields::QUALITY_HISTOGRAMS))
+                );
+                assert_eq!(
+                    row.allele_quality,
+                    expected
+                        .allele_quality
+                        .filter(|_| fields.contains(EvidenceFields::ALLELE_QUALITY))
                 );
                 assert_eq!(
                     row.read_position,

--- a/src/evidence/mod.rs
+++ b/src/evidence/mod.rs
@@ -13,8 +13,9 @@ mod sample;
 mod selection;
 
 pub use batch::{
-    EvidenceAlleles, EvidenceBatch, EvidenceDepths, EvidenceLocus, EvidenceQualityHistograms,
-    EvidenceQualitySums, EvidenceReadPosition, EvidenceRowRef, EvidenceStrands,
+    EvidenceAlleleQuality, EvidenceAlleles, EvidenceBatch, EvidenceDepths, EvidenceLocus,
+    EvidenceQualityHistograms, EvidenceQualitySums, EvidenceReadPosition, EvidenceRowRef,
+    EvidenceStrands,
 };
 pub use encoding::{
     evidence_reader_memory_bytes, read_evidence_batches, read_evidence_batches_expected_fields,
@@ -158,13 +159,19 @@ impl EvidenceFields {
     pub const QUALITY_HISTOGRAMS: Self = Self(16);
     /// Sequencing-cycle and read-length sums.
     pub const READ_POSITION: Self = Self(32);
-    /// Complete evidence schema version1.
-    pub const ALL: Self = Self(63);
-    /// Stable field-mask version for receipts and cache keys.
+    /// Historical complete evidence schema version 1.
+    pub const FULL_V1: Self = Self(63);
+    /// Historical full field set; retained for source and artifact compatibility.
+    pub const ALL: Self = Self::FULL_V1;
+    /// Per-allele quality and stored-read-position sufficient statistics.
+    pub const ALLELE_QUALITY: Self = Self(64);
+    /// Every currently supported group, including explicit extended metrics.
+    pub const ALL_SUPPORTED: Self = Self(127);
+    /// Historical mask version; use `mask_version()` for a specific field set.
     pub const VERSION: u32 = 1;
     /// Construct a validated field set from its portable bit representation.
     pub fn from_bits(bits: u32) -> Result<Self, EvidenceError> {
-        if bits & !Self::ALL.0 != 0 {
+        if bits & !Self::ALL_SUPPORTED.0 != 0 {
             Err(EvidenceError::InvalidRequest(
                 "unknown evidence field bits".into(),
             ))
@@ -192,6 +199,14 @@ impl EvidenceFields {
             2
         }
     }
+    /// Field-mask definition version. Legacy masks preserve their original bytes.
+    pub fn mask_version(self) -> u32 {
+        if self.contains(Self::ALLELE_QUALITY) {
+            2
+        } else {
+            1
+        }
+    }
     /// Exact retained locus and requested summary bytes, excluding vector
     /// headers, ALT payloads, reference windows, and allocator overhead.
     pub fn storage_bytes_per_locus(self) -> u64 {
@@ -212,6 +227,10 @@ impl EvidenceFields {
                 Self::READ_POSITION,
                 std::mem::size_of::<EvidenceReadPosition>(),
             ),
+            (
+                Self::ALLELE_QUALITY,
+                std::mem::size_of::<EvidenceAlleleQuality>(),
+            ),
         ] {
             if self.contains(group) {
                 bytes += size;
@@ -228,6 +247,7 @@ impl EvidenceFields {
             (Self::QUALITY_SUMS, "quality-sums"),
             (Self::QUALITY_HISTOGRAMS, "quality-histograms"),
             (Self::READ_POSITION, "read-position"),
+            (Self::ALLELE_QUALITY, "allele-quality"),
         ]
         .into_iter()
         .filter_map(|(field, name)| self.contains(field).then_some(name))

--- a/src/evidence/selection.rs
+++ b/src/evidence/selection.rs
@@ -2,7 +2,6 @@ use super::EvidenceError;
 use crate::core::ContigSet;
 use crate::selection::{GenomicInterval, IntervalSet};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 type ResolvedSelection = (Vec<GenomicInterval>, BTreeMap<(u32, u32), SnvSite>);
@@ -37,57 +36,33 @@ impl EvidenceSelection {
             .map_err(|error| EvidenceError::InvalidRequest(error.to_string()))?;
         Ok(Self::Intervals(set.intervals().to_vec()))
     }
-    /// Parse plain-text VCF, accepting only one-base REF and one-base ALT alleles.
-    /// Duplicate loci union ALT alleles and must agree on REF.
+    /// Parse VCF, compressed VCF, or BCF using the default record envelopes.
+    /// Duplicate loci union ALT alleles and must agree on REF. No index is needed.
     pub fn from_vcf(path: impl AsRef<Path>, contigs: &ContigSet) -> Result<Self, EvidenceError> {
+        Self::from_variants(path, contigs, crate::variant_io::VariantLimits::default())
+    }
+
+    /// Parse typed SNV records with explicit cooperative header/record envelopes.
+    /// The normalized selection is independent of record order and compression;
+    /// use [`crate::variant_io::VariantReader`] when original records are needed.
+    pub fn from_variants(
+        path: impl AsRef<Path>,
+        contigs: &ContigSet,
+        limits: crate::variant_io::VariantLimits,
+    ) -> Result<Self, EvidenceError> {
+        let mut reader = crate::variant_io::VariantReader::open(path, limits)?;
         let mut sites: BTreeMap<(u32, u32), (u8, BTreeSet<u8>)> = BTreeMap::new();
-        for (line_number, line) in BufReader::new(std::fs::File::open(path)?)
-            .lines()
-            .enumerate()
-        {
-            let line = line?;
-            if line.starts_with('#') || line.trim().is_empty() {
-                continue;
+        while let Some(record) = reader.read()? {
+            let site = crate::variant_io::parse_snv_record(record, contigs)?;
+            let entry = sites
+                .entry((site.contig, site.position))
+                .or_insert((site.reference, BTreeSet::new()));
+            if entry.0 != site.reference {
+                return Err(EvidenceError::InvalidInput(
+                    "duplicate variant locus has conflicting REF".into(),
+                ));
             }
-            let fields: Vec<_> = line.split('\t').collect();
-            let invalid = |message: &str| {
-                EvidenceError::InvalidRequest(format!("VCF line {}: {message}", line_number + 1))
-            };
-            if fields.len() < 5 {
-                return Err(invalid("requires at least five columns"));
-            }
-            let contig = contigs
-                .by_name(fields[0])
-                .ok_or_else(|| invalid("unknown contig"))?;
-            let one_based = fields[1]
-                .parse::<u32>()
-                .map_err(|_| invalid("invalid POS"))?;
-            if one_based == 0 || one_based > contig.length {
-                return Err(invalid("POS outside reference"));
-            }
-            let parse_base = |text: &str| -> Result<u8, EvidenceError> {
-                if text.len() != 1 {
-                    return Err(invalid("only SNVs are supported"));
-                }
-                let base = text.as_bytes()[0].to_ascii_uppercase();
-                if !b"ACGT".contains(&base) {
-                    return Err(invalid("REF and ALT must be A/C/G/T"));
-                }
-                Ok(base)
-            };
-            let reference = parse_base(fields[3])?;
-            let key = (contig.id, one_based - 1);
-            let entry = sites.entry(key).or_insert((reference, BTreeSet::new()));
-            if entry.0 != reference {
-                return Err(invalid("duplicate locus has conflicting REF"));
-            }
-            for alternate in fields[4].split(',') {
-                let alternate = parse_base(alternate)?;
-                if alternate == reference {
-                    return Err(invalid("ALT equals REF"));
-                }
-                entry.1.insert(alternate);
-            }
+            entry.1.extend(site.alternates);
         }
         Ok(Self::Sites(
             sites

--- a/src/evidence_cli.rs
+++ b/src/evidence_cli.rs
@@ -22,9 +22,18 @@ use output::execute_outputs;
 
 #[derive(Args, Debug, Clone)]
 pub(crate) struct EvidenceOptions {
-    /// Supplied plain-text SNV VCF; mutually exclusive with BED selection.
+    /// Supplied SNV VCF, VCF.gz, or BCF; mutually exclusive with BED selection.
     #[arg(long, conflicts_with_all = ["regions", "region", "shard_count", "shard_index"])]
     sites: Option<PathBuf>,
+    /// Annotate original variant records with exact read evidence (.vcf/.vcf.gz/.bcf).
+    #[arg(long, requires = "sites")]
+    annotated_variants: Option<PathBuf>,
+    /// Cooperative maximum decoded variant record/formatting envelope.
+    #[arg(long, default_value_t = 1_048_576)]
+    max_variant_record_bytes: usize,
+    /// Cooperative maximum variant header/formatting envelope.
+    #[arg(long, default_value_t = 8_388_608)]
+    max_variant_header_bytes: usize,
     /// Select one declared @RG SM sample; unassignable reads fail the run.
     #[arg(long, conflicts_with = "pool_samples")]
     sample: Option<String>,
@@ -38,7 +47,7 @@ pub(crate) struct EvidenceOptions {
     #[arg(long, value_enum, default_value_t = FeatureFormat::Tsv)]
     format: FeatureFormat,
     /// Physical evidence groups, comma separated: all, none, depths, alleles, strands,
-    /// quality-sums, quality-histograms, read-position. Panel defaults to depths,quality-sums.
+    /// quality-sums, quality-histograms, read-position, allele-quality. Panel defaults to depths,quality-sums.
     #[arg(long, value_delimiter = ',')]
     fields: Option<Vec<String>>,
     /// Maximum execution microtile width; does not change scientific results.
@@ -80,8 +89,17 @@ pub(crate) struct EvidenceOptions {
 }
 
 impl EvidenceOptions {
+    fn variant_limits(&self) -> rosalind::variant_io::VariantLimits {
+        rosalind::variant_io::VariantLimits {
+            max_header_bytes: self.max_variant_header_bytes,
+            max_record_bytes: self.max_variant_record_bytes,
+        }
+    }
     pub(crate) fn reject_legacy_options(&self) -> Result<()> {
         if self.sites.is_some()
+            || self.annotated_variants.is_some()
+            || self.max_variant_record_bytes != 1_048_576
+            || self.max_variant_header_bytes != 8_388_608
             || self.fields.is_some()
             || self.sample.is_some()
             || self.pool_samples
@@ -121,6 +139,7 @@ fn requested_fields(command: &EvidenceCommand) -> Result<EvidenceFields> {
     for name in names {
         let group = match name.as_str() {
             "all" if names.len() == 1 => EvidenceFields::ALL,
+            "all-supported" if names.len() == 1 => EvidenceFields::ALL_SUPPORTED,
             "none" if names.len() == 1 => EvidenceFields::from_bits(0)?,
             "depths" => EvidenceFields::DEPTHS,
             "alleles" => EvidenceFields::ALLELES,
@@ -128,6 +147,7 @@ fn requested_fields(command: &EvidenceCommand) -> Result<EvidenceFields> {
             "quality-sums" => EvidenceFields::QUALITY_SUMS,
             "quality-histograms" => EvidenceFields::QUALITY_HISTOGRAMS,
             "read-position" => EvidenceFields::READ_POSITION,
+            "allele-quality" => EvidenceFields::ALLELE_QUALITY,
             _ => bail!("invalid evidence field group {name:?}; use comma-separated groups or all/none alone"),
         };
         fields = fields.union(group);
@@ -269,6 +289,7 @@ fn validate_destinations(command: &EvidenceCommand, receipt: Option<&Path>) -> R
         .output
         .iter()
         .chain(command.options.position_output.iter())
+        .chain(command.options.annotated_variants.iter())
         .collect();
     let partials: Vec<_> = artifacts
         .iter()
@@ -363,6 +384,17 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
         bail!("--workers must be positive");
     }
     let fields = requested_fields(&command)?;
+    if let Some(output) = &command.options.annotated_variants {
+        if command.panel || command.options.sites.is_none() || command.output.is_none() {
+            bail!("--annotated-variants requires analyze evidence --sites and a persisted -o evidence artifact");
+        }
+        rosalind::variant_annotation::annotation_format(output)?;
+        rosalind::variant_annotation::preflight_annotation(
+            command.options.sites.as_ref().unwrap(),
+            fields,
+            command.options.variant_limits(),
+        )?;
+    }
     let receipt_path = command.manifest.clone().or_else(|| {
         command
             .output
@@ -480,7 +512,7 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
     request.execution.max_record_bytes = command.options.max_record_bytes;
     let mut engine = EvidenceEngine::open(request)?;
     let selection = if let Some(sites) = &command.options.sites {
-        EvidenceSelection::from_vcf(sites, engine.contigs())?
+        EvidenceSelection::from_variants(sites, engine.contigs(), command.options.variant_limits())?
     } else {
         EvidenceSelection::from_bed(
             command.selection.regions.as_ref().unwrap(),
@@ -507,7 +539,7 @@ fn run_inner(mut command: EvidenceCommand) -> Result<()> {
         ),
         (
             "fields_version".to_string(),
-            EvidenceFields::VERSION.to_string(),
+            engine.request().fields.mask_version().to_string(),
         ),
         (
             "fields".to_string(),

--- a/src/evidence_cli/output.rs
+++ b/src/evidence_cli/output.rs
@@ -42,21 +42,38 @@ pub(super) fn execute_outputs(
     let tsv_memory = EvidenceTsvWriter::with_fields(io::sink(), fields)
         .additional_memory_bytes()
         .unwrap();
-    let consumer_bytes = panel
-        .as_ref()
-        .and_then(EvidenceAnalyzer::additional_memory_bytes)
-        .unwrap_or(0)
-        + if command.options.position_output.is_some()
-            || (!command.panel && command.options.format == FeatureFormat::ArrowIpc)
-        {
-            arrow_memory
-        } else {
-            tsv_memory
-        };
+    let annotation_bytes = if command.options.annotated_variants.is_some() {
+        rosalind::variant_annotation::annotation_memory_bytes(
+            engine,
+            command.options.variant_limits(),
+        )
+    } else {
+        0
+    };
+    let encoder_bytes = if command.options.position_output.is_some()
+        || (!command.panel && command.options.format == FeatureFormat::ArrowIpc)
+    {
+        arrow_memory
+    } else {
+        tsv_memory
+    };
+    let consumer_bytes = annotation_bytes
+        .checked_add(
+            panel
+                .as_ref()
+                .and_then(EvidenceAnalyzer::additional_memory_bytes)
+                .unwrap_or(0),
+        )
+        .and_then(|bytes| bytes.checked_add(encoder_bytes))
+        .ok_or_else(|| {
+            EvidenceError::InvalidRequest("annotation/consumer memory envelope is too large".into())
+        })?;
     let planner = EvidenceCallback::with_fields(|_: &EvidenceBatch| Ok(()), consumer_bytes, fields);
     let plan = engine.plan_for_analyzer(&planner)?.clone();
     let temporary_cache = TemporaryCache(
-        if command.options.cache_dir.is_none() && command.options.workers > 1 {
+        if command.options.cache_dir.is_none()
+            && (command.options.workers > 1 || command.options.annotated_variants.is_some())
+        {
             Some(std::env::temp_dir().join(format!(
                     "rosalind-workers-{}-{}",
                     std::process::id(),
@@ -116,6 +133,12 @@ pub(super) fn execute_outputs(
         .as_ref()
         .map(|path| AtomicFile::create(path))
         .transpose()?;
+    let mut annotated = command
+        .options
+        .annotated_variants
+        .as_ref()
+        .map(|path| AtomicFile::create(path))
+        .transpose()?;
     let setup_ms = started.elapsed().as_millis();
     let mut dataset_outcome = None;
     let mut drive = |engine: &mut EvidenceEngine,
@@ -140,7 +163,7 @@ pub(super) fn execute_outputs(
             Ok(engine.run(analyzer)?)
         }
     };
-    let result = {
+    let mut result = {
         let stdout = io::stdout();
         let mut output: Box<dyn Write + '_> = match &mut primary {
             Some(file) => Box::new(io::BufWriter::new(file.file_mut())),
@@ -182,6 +205,33 @@ pub(super) fn execute_outputs(
         output.flush()?;
         result
     };
+    let mut annotated_records = None;
+    if result.is_ok() {
+        if let (Some(file), Some(requested)) = (&mut annotated, &command.options.annotated_variants)
+        {
+            file.close_for_path_writer();
+            let annotation_result = rosalind::variant_annotation::annotate_variants(
+                command.options.sites.as_ref().unwrap(),
+                file.temporary_path(),
+                rosalind::variant_annotation::annotation_format(requested)?,
+                command.options.variant_limits(),
+                engine,
+                dataset_outcome.as_ref().unwrap(),
+                &science_digest,
+            )
+            .map_err(|error| match error {
+                DatasetError::Evidence(error) => anyhow::Error::from(error),
+                other => anyhow::Error::from(other),
+            });
+            match annotation_result {
+                Ok(count) => annotated_records = Some(count),
+                Err(error) => result = Err(error),
+            }
+        }
+    } else {
+        // No annotation bytes exist if extraction failed. Drop its staging file.
+        annotated = None;
+    }
     input_snapshot.verify()?;
     let analysis_ms = started.elapsed().as_millis().saturating_sub(setup_ms);
     let (stats, mut failure) = match result {
@@ -205,6 +255,11 @@ pub(super) fn execute_outputs(
             "--position-output",
             positional.as_ref(),
             command.options.position_output.as_ref(),
+        ),
+        (
+            "--annotated-variants",
+            annotated.as_ref(),
+            command.options.annotated_variants.as_ref(),
         ),
     ] {
         if let (Some(file), Some(path)) = (pending, requested) {
@@ -258,6 +313,16 @@ pub(super) fn execute_outputs(
     );
     capture.opt("--max-read-len", command.max_read_len);
     capture.opt("--max-record-bytes", command.options.max_record_bytes);
+    if command.options.sites.is_some() {
+        capture.opt(
+            "--max-variant-record-bytes",
+            command.options.max_variant_record_bytes,
+        );
+        capture.opt(
+            "--max-variant-header-bytes",
+            command.options.max_variant_header_bytes,
+        );
+    }
     capture.opt("--tile-bases", command.options.tile_bases);
     capture.opt("--workers", command.options.workers);
     let field_names = fields.names().join(",");
@@ -296,7 +361,7 @@ pub(super) fn execute_outputs(
     });
     manifest.tool_version = env!("CARGO_PKG_VERSION").to_string();
     capture.record_into(&mut manifest);
-    let analysis_identity = format!(
+    let mut analysis_identity = format!(
         "evidence={science_digest};analyzer={};schema=1;callable_depth={};panel_selection={}",
         if command.panel {
             "panel-qc"
@@ -322,6 +387,35 @@ pub(super) fn execute_outputs(
             ""
         }
     );
+    if command.options.annotated_variants.is_some() {
+        let sites_path = std::fs::canonicalize(command.options.sites.as_ref().unwrap())?;
+        let sites_hash = &manifest
+            .inputs
+            .iter()
+            .find(|input| Path::new(&input.path) == sites_path)
+            .ok_or_else(|| anyhow::anyhow!("annotation input identity missing"))?
+            .blake3;
+        analysis_identity.push_str(&format!(
+            ";annotation={};variant_bytes={sites_hash}",
+            rosalind::variant_annotation::ANNOTATION_SEMANTICS
+        ));
+        manifest.params.insert(
+            "annotation.semantics".into(),
+            rosalind::variant_annotation::ANNOTATION_SEMANTICS.into(),
+        );
+        manifest
+            .params
+            .insert("annotation.variant_blake3".into(), sites_hash.clone());
+        manifest.measurements.insert(
+            "execution.annotation_bytes".into(),
+            annotation_bytes.to_string(),
+        );
+        if let Some(count) = annotated_records {
+            manifest
+                .measurements
+                .insert("execution.annotated_records".into(), count.to_string());
+        }
+    }
     manifest.params.insert(
         "science.blake3".into(),
         blake3::hash(analysis_identity.as_bytes())
@@ -345,10 +439,7 @@ pub(super) fn execute_outputs(
         ("producer.binary", "rosalind".to_string()),
         ("replay.kind", "rosalind".to_string()),
         ("evidence.schema", fields.schema_version().to_string()),
-        (
-            "evidence.fields_version",
-            EvidenceFields::VERSION.to_string(),
-        ),
+        ("evidence.fields_version", fields.mask_version().to_string()),
         ("evidence.profile", EvidenceProfile::ID.to_string()),
         ("evidence.counting_unit", "read".to_string()),
         (
@@ -577,6 +668,10 @@ pub(super) fn execute_outputs(
     for (file, requested) in [
         (primary.take(), command.output.as_ref()),
         (positional.take(), command.options.position_output.as_ref()),
+        (
+            annotated.take(),
+            command.options.annotated_variants.as_ref(),
+        ),
     ] {
         if let (Some(file), Some(path)) = (file, requested) {
             group.push((
@@ -644,17 +739,29 @@ fn assign_artifact_roles(
     for (index, (_, flag)) in ordered.iter().enumerate() {
         let role = if failed {
             "partial-evidence"
+        } else if *flag == "--annotated-variants" {
+            "annotated-variants"
         } else if command.panel && *flag == "-o" {
             "panel-summary"
         } else {
             "exact-evidence"
         };
-        let format =
-            if *flag == "--position-output" || command.options.format == FeatureFormat::ArrowIpc {
-                "arrow-ipc"
-            } else {
-                "tsv"
-            };
+        let format = if *flag == "--annotated-variants" {
+            match rosalind::variant_annotation::annotation_format(
+                command.options.annotated_variants.as_ref().unwrap(),
+            )
+            .expect("validated annotation format")
+            {
+                rosalind::variant_io::VariantFormat::Vcf => "vcf",
+                rosalind::variant_io::VariantFormat::VcfGz => "vcf.gz",
+                rosalind::variant_io::VariantFormat::Bcf => "bcf",
+            }
+        } else if *flag == "--position-output" || command.options.format == FeatureFormat::ArrowIpc
+        {
+            "arrow-ipc"
+        } else {
+            "tsv"
+        };
         manifest
             .params
             .insert(format!("artifact.output.{index}.role"), role.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ pub mod selection;
 pub mod studio;
 /// Helper utilities: read-only mmap + peak-RSS measurement.
 pub mod util;
+/// Record-preserving annotation from verified SNV evidence.
+pub mod variant_annotation;
+/// Checked VCF/BCF input and output.
+pub mod variant_io;
 
 // ── Genomics product surface — what builders compose on ───────────────────────
 // The bounded streaming substrate:

--- a/src/reproduce.rs
+++ b/src/reproduce.rs
@@ -294,6 +294,35 @@ fn output_is_byte_comparable(path: &str) -> bool {
         || p.ends_with(".rref")
 }
 
+// Additive annotation support does not broaden historical BAM/BGZF replay.
+// Comparison remains physical: a different native codec can produce DIVERGED;
+// no semantic comparison is substituted for compressed artifact bytes.
+fn artifact_is_byte_comparable(manifest: &RunManifest, index: usize) -> bool {
+    let path = &manifest.outputs[index].path;
+    if output_is_byte_comparable(path) {
+        return true;
+    }
+    manifest
+        .params
+        .get("annotation.semantics")
+        .map(String::as_str)
+        == Some(crate::variant_annotation::ANNOTATION_SEMANTICS)
+        && manifest
+            .params
+            .get(&format!("artifact.output.{index}.role"))
+            .map(String::as_str)
+            == Some("annotated-variants")
+        && match manifest
+            .params
+            .get(&format!("artifact.output.{index}.format"))
+            .map(String::as_str)
+        {
+            Some("vcf.gz") => path.ends_with(".vcf.gz"),
+            Some("bcf") => path.ends_with(".bcf"),
+            _ => false,
+        }
+}
+
 /// Build a content-hash → path index of every file directly under `inputs_dir`.
 fn index_inputs(inputs_dir: &Path) -> Result<BTreeMap<String, PathBuf>> {
     let mut idx = BTreeMap::new();
@@ -401,7 +430,9 @@ fn build_reproduction_plan(
     if let Some(output) = manifest
         .outputs
         .iter()
-        .find(|output| !output_is_byte_comparable(&output.path))
+        .enumerate()
+        .find(|(index, _)| !artifact_is_byte_comparable(&manifest, *index))
+        .map(|(_, output)| output)
     {
         return Err(ReplaySafetyError::UnsafeRecipe(format!(
             "output {} is not byte-comparable",
@@ -465,10 +496,15 @@ fn build_reproduction_plan(
     let mut output_by_hash = BTreeMap::new();
     let mut outputs = Vec::with_capacity(manifest.outputs.len());
     for (position, output) in manifest.outputs.iter().enumerate() {
-        let extension = Path::new(&output.path)
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .unwrap_or("out");
+        // The compound suffix selects the compressed VCF writer on replay.
+        let extension = if output.path.ends_with(".vcf.gz") {
+            "vcf.gz"
+        } else {
+            Path::new(&output.path)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("out")
+        };
         let path = work_dir.join(format!("out_{position}.{extension}"));
         output_by_hash.insert(output.blake3.clone(), path.clone());
         outputs.push(PlannedOutput {
@@ -781,7 +817,9 @@ pub fn reproduce_with_binary(
     if let Some(o) = manifest
         .outputs
         .iter()
-        .find(|o| !output_is_byte_comparable(&o.path))
+        .enumerate()
+        .find(|(index, _)| !artifact_is_byte_comparable(&manifest, *index))
+        .map(|(_, output)| output)
     {
         return Ok(report(
             "INCONCLUSIVE",

--- a/src/util/rss.rs
+++ b/src/util/rss.rs
@@ -7,6 +7,12 @@ use libc::rusage;
 
 /// Return the process peak RSS in bytes (best-effort, platform-dependent).
 ///
+/// Linux uses `/proc/self/status`'s `VmHWM`, which measures the current executable's
+/// resident high-water mark. `getrusage` can retain memory inherited from a parent
+/// across `exec`, incorrectly charging a Python caller's memory to its native
+/// worker. When procfs is unavailable or malformed, fall back conservatively to
+/// `getrusage` instead of undercounting.
+///
 /// `ru_maxrss` units differ by platform: **bytes** on Darwin (macOS/iOS),
 /// **KiB** on Linux and the BSDs (FreeBSD/NetBSD/OpenBSD/DragonFly). We treat
 /// Darwin as bytes and everything else as KiB (×1024). For an unenumerated
@@ -15,6 +21,11 @@ use libc::rusage;
 /// RSS would let `--enforce`/`verify` pass a job that actually breached its
 /// budget, which is exactly the failure the contract forbids.
 pub fn peak_rss_bytes() -> u64 {
+    #[cfg(target_os = "linux")]
+    if let Some(bytes) = linux_peak_rss_bytes() {
+        return bytes;
+    }
+
     let mut usage: rusage = unsafe { std::mem::zeroed() };
     let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage as *mut rusage) };
     if rc != 0 {
@@ -32,9 +43,80 @@ pub fn peak_rss_bytes() -> u64 {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn linux_peak_rss_bytes() -> Option<u64> {
+    use std::io::Read;
+
+    // VmHWM normally appears near the start of this small virtual file. Limit
+    // observation scratch even for unusual process metadata; a missing or
+    // truncated line uses the conservative getrusage fallback above.
+    let mut status = [0u8; 16 * 1024];
+    let mut file = std::fs::File::open("/proc/self/status").ok()?;
+    let mut used = 0;
+    while used < status.len() {
+        let count = file.read(&mut status[used..]).ok()?;
+        if count == 0 {
+            break;
+        }
+        used += count;
+        if let Some(bytes) = parse_linux_peak_rss(&status[..used]) {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_peak_rss(status: &[u8]) -> Option<u64> {
+    for line in status.split_inclusive(|byte| *byte == b'\n') {
+        let Some(value) = line.strip_prefix(b"VmHWM:") else {
+            continue;
+        };
+        if !line.ends_with(b"\n") {
+            return None;
+        }
+        let mut fields = value
+            .split(u8::is_ascii_whitespace)
+            .filter(|field| !field.is_empty());
+        let number = fields.next()?;
+        if number.is_empty()
+            || !number.iter().all(u8::is_ascii_digit)
+            || fields.next()? != b"kB"
+            || fields.next().is_some()
+        {
+            return None;
+        }
+        return std::str::from_utf8(number)
+            .ok()?
+            .parse::<u64>()
+            .ok()?
+            .checked_mul(1024);
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_peak_parser_requires_a_complete_valid_kib_value() {
+        assert_eq!(
+            parse_linux_peak_rss(b"Name:\tworker\nVmHWM:\t123 kB\nVmRSS:\t100 kB\n"),
+            Some(123 * 1024)
+        );
+        for malformed in [
+            b"VmRSS:\t123 kB\n".as_slice(),
+            b"VmHWM:\t123 kB",
+            b"VmHWM:\t123 MB\n",
+            b"VmHWM:\t-1 kB\n",
+            b"VmHWM:\t123 kB extra\n",
+            b"VmHWM:\t18446744073709551615 kB\n",
+        ] {
+            assert_eq!(parse_linux_peak_rss(malformed), None);
+        }
+    }
 
     #[test]
     fn peak_rss_reflects_a_real_allocation_in_bytes() {

--- a/src/variant_annotation.rs
+++ b/src/variant_annotation.rs
@@ -1,0 +1,298 @@
+//! Record-preserving SNV annotation from verified canonical evidence partitions.
+//!
+//! INFO annotations describe alignment read evidence for the explicitly resolved
+//! sample scope; they never overwrite VCF genotypes, FILTER, or existing fields.
+
+use std::path::Path;
+
+use rust_htslib::bcf;
+
+use crate::core::governor::checkpoint;
+use crate::dataset::{DatasetError, DatasetOutcome, VerifiedEvidenceLookup};
+use crate::evidence::{EvidenceEngine, EvidenceError, EvidenceFields, EvidenceProfile};
+use crate::variant_io::{
+    parse_snv_record, CheckedVariantWriter, VariantFormat, VariantLimits, VariantReader,
+};
+
+/// Version of the INFO annotations and record-preservation contract.
+pub const ANNOTATION_SEMANTICS: &str = "snv-read-evidence-info-v1";
+
+/// Infer the requested encoding from the final (not staging) filename.
+pub fn annotation_format(path: &Path) -> Result<VariantFormat, EvidenceError> {
+    let name = path.to_string_lossy();
+    if name.ends_with(".vcf.gz") {
+        Ok(VariantFormat::VcfGz)
+    } else if name.ends_with(".vcf") {
+        Ok(VariantFormat::Vcf)
+    } else if name.ends_with(".bcf") {
+        Ok(VariantFormat::Bcf)
+    } else {
+        Err(EvidenceError::InvalidRequest(
+            "annotated variant output must end in .vcf, .vcf.gz, or .bcf".into(),
+        ))
+    }
+}
+
+/// Additional conservative memory reservation, including verified lookup state,
+/// native headers/records, formatted VCF scratch and compression buffers. Native
+/// decoding is checked cooperatively after HTSlib allocation.
+pub fn annotation_memory_bytes(engine: &EvidenceEngine, limits: VariantLimits) -> u64 {
+    VerifiedEvidenceLookup::memory_bytes(engine)
+        .saturating_add((limits.max_header_bytes as u64).saturating_mul(8))
+        .saturating_add((limits.max_record_bytes as u64).saturating_mul(8))
+        .saturating_add(8 << 20)
+}
+
+struct Tag {
+    id: &'static str,
+    number: &'static str,
+    kind: &'static str,
+    description: &'static str,
+}
+
+fn tags(fields: EvidenceFields) -> Vec<Tag> {
+    let mut tags = vec![
+        Tag {
+            id: "RSL_DP",
+            number: "1",
+            kind: "Integer",
+            description: "Rosalind callable A/C/G/T read depth",
+        },
+        Tag {
+            id: "RSL_PF",
+            number: "1",
+            kind: "Integer",
+            description:
+                "Rosalind prefilter aligned base observations excluding deletion and reference skip",
+        },
+        Tag {
+            id: "RSL_ED",
+            number: "1",
+            kind: "Integer",
+            description:
+                "Rosalind eligible aligned base observations before base-quality filtering",
+        },
+        Tag {
+            id: "RSL_AD",
+            number: "R",
+            kind: "Integer",
+            description: "Rosalind callable read counts in original REF and ALT order",
+        },
+    ];
+    if fields.contains(EvidenceFields::STRANDS) {
+        tags.extend([
+            Tag {
+                id: "RSL_ADF",
+                number: "R",
+                kind: "Integer",
+                description: "Rosalind forward callable read counts in REF and ALT order",
+            },
+            Tag {
+                id: "RSL_ADR",
+                number: "R",
+                kind: "Integer",
+                description: "Rosalind reverse callable read counts in REF and ALT order",
+            },
+        ]);
+    }
+    if fields.contains(EvidenceFields::ALLELE_QUALITY) {
+        tags.extend([
+            Tag {
+                id: "RSL_BQS",
+                number: "R",
+                kind: "String",
+                description: "Rosalind exact unsigned base-quality sums in REF and ALT order",
+            },
+            Tag {
+                id: "RSL_MQS",
+                number: "R",
+                kind: "String",
+                description: "Rosalind exact unsigned mapping-quality sums in REF and ALT order",
+            },
+            Tag {
+                id: "RSL_RPS",
+                number: "R",
+                kind: "String",
+                description:
+                    "Rosalind exact unsigned zero-based sequencing-cycle sums in REF and ALT order",
+            },
+            Tag {
+                id: "RSL_RLS",
+                number: "R",
+                kind: "String",
+                description: "Rosalind exact unsigned stored-read-length sums in REF and ALT order",
+            },
+        ]);
+    }
+    tags
+}
+
+/// Check required fields and header collisions before starting extraction.
+pub fn preflight_annotation(
+    input: &Path,
+    fields: EvidenceFields,
+    limits: VariantLimits,
+) -> Result<(), EvidenceError> {
+    if !fields.contains(EvidenceFields::DEPTHS.union(EvidenceFields::ALLELES)) {
+        return Err(EvidenceError::InvalidRequest(
+            "variant annotation requires --fields to include depths and alleles".into(),
+        ));
+    }
+    let reader = VariantReader::open(input, limits)?;
+    for tag in tags(fields) {
+        if reader.header().info_type(tag.id.as_bytes()).is_ok() {
+            return Err(EvidenceError::InvalidInput(format!(
+                "variant INFO {} already exists; annotation never overwrites existing fields",
+                tag.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn integer(value: u64) -> Result<i32, EvidenceError> {
+    i32::try_from(value).map_err(|_| {
+        EvidenceError::InvalidInput(
+            "read count exceeds the VCF Integer range; retain exact evidence in Arrow/TSV".into(),
+        )
+    })
+}
+
+fn allele_index(base: u8) -> usize {
+    match base {
+        b'A' => 0,
+        b'C' => 1,
+        b'G' => 2,
+        b'T' => 3,
+        _ => unreachable!("validated SNV"),
+    }
+}
+
+/// Write annotations to a staging path. The caller must publish it atomically
+/// with its receipt only after this function succeeds and inputs are rechecked.
+/// Record order, repeated sites, original allele order and sample data survive.
+#[allow(clippy::too_many_arguments)]
+pub fn annotate_variants(
+    input: &Path,
+    staging_output: &Path,
+    format: VariantFormat,
+    limits: VariantLimits,
+    engine: &EvidenceEngine,
+    dataset: &DatasetOutcome,
+    science_digest: &str,
+) -> Result<u64, DatasetError> {
+    if science_digest.len() != 64 || !science_digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(EvidenceError::InvalidRequest(
+            "annotation science identity must be a 64-character digest".into(),
+        )
+        .into());
+    }
+    let fields = engine.request().fields;
+    preflight_annotation(input, fields, limits)?;
+    let mut lookup = VerifiedEvidenceLookup::new(engine, dataset)?;
+    let mut reader = VariantReader::open(input, limits)?;
+    let mut header = bcf::Header::from_template(reader.header());
+    for tag in tags(fields) {
+        header.push_record(
+            format!(
+                "##INFO=<ID={},Number={},Type={},Description=\"{}\">",
+                tag.id, tag.number, tag.kind, tag.description
+            )
+            .as_bytes(),
+        );
+    }
+    // JSON quoting escapes sample names without putting execution-dependent
+    // paths, timestamps, worker counts or receipt hashes into deterministic VCF.
+    let scope = format!(
+        "\"{}\"",
+        engine
+            .sample_scope()
+            .canonical_json()
+            .replace('\\', "\\\\")
+            .replace('\"', "\\\"")
+    );
+    header.push_record(format!("##rosalind_evidence=<Semantics={ANNOTATION_SEMANTICS},Profile={},Fields={},Science={science_digest},SampleScope={scope}>", EvidenceProfile::ID, fields.bits()).as_bytes());
+    let mut writer = CheckedVariantWriter::create(staging_output, &header, format, limits)?;
+    // The writer owns a checked header copy; avoid retaining another copy while
+    // decoding records and evidence partitions.
+    drop(header);
+    let mut count = 0u64;
+    while let Some(record) = reader.read()? {
+        checkpoint().map_err(EvidenceError::from)?;
+        let site = parse_snv_record(record, engine.contigs())?;
+        let row = lookup.get(site.contig, site.position)?;
+        if row.reference != site.reference
+            || site
+                .alternates
+                .iter()
+                .any(|alt| !row.requested_alts.contains(alt))
+        {
+            return Err(EvidenceError::InvalidInput(format!(
+                "variant and evidence alleles differ at contig {} position {}",
+                site.contig,
+                site.position + 1
+            ))
+            .into());
+        }
+        let depths = row.depths.ok_or_else(|| {
+            EvidenceError::InvalidInput("annotation evidence has no depths".into())
+        })?;
+        let alleles = row.alleles.ok_or_else(|| {
+            EvidenceError::InvalidInput("annotation evidence has no allele counts".into())
+        })?;
+        let indices: Vec<_> = std::iter::once(site.reference)
+            .chain(site.alternates)
+            .map(allele_index)
+            .collect();
+        let mut ints: Vec<(&[u8], Vec<i32>)> = vec![
+            (b"RSL_DP", vec![integer(depths.callable_depth)?]),
+            (b"RSL_PF", vec![integer(depths.prefilter_depth)?]),
+            (b"RSL_ED", vec![integer(depths.aligned_depth)?]),
+            (
+                b"RSL_AD",
+                indices
+                    .iter()
+                    .map(|&i| integer(alleles.allele_counts[i]))
+                    .collect::<Result<_, _>>()?,
+            ),
+        ];
+        if let Some(strands) = row.strands {
+            for (tag, strand) in [(b"RSL_ADF".as_slice(), 0), (b"RSL_ADR".as_slice(), 1)] {
+                ints.push((
+                    tag,
+                    indices
+                        .iter()
+                        .map(|&i| integer(strands.strand_counts[i][strand]))
+                        .collect::<Result<_, _>>()?,
+                ));
+            }
+        }
+        let mut strings: Vec<(&[u8], Vec<String>)> = Vec::new();
+        if let Some(q) = row.allele_quality {
+            for (tag, sums) in [
+                (b"RSL_BQS".as_slice(), &q.base_quality_sum),
+                (b"RSL_MQS".as_slice(), &q.mapping_quality_sum),
+                (b"RSL_RPS".as_slice(), &q.read_position_sum),
+                (b"RSL_RLS".as_slice(), &q.read_length_sum),
+            ] {
+                strings.push((tag, indices.iter().map(|&i| sums[i].to_string()).collect()));
+            }
+        }
+        let int_refs: Vec<_> = ints.iter().map(|(tag, v)| (*tag, v.as_slice())).collect();
+        let values: Vec<Vec<&[u8]>> = strings
+            .iter()
+            .map(|(_, v)| v.iter().map(|s| s.as_bytes()).collect())
+            .collect();
+        let string_refs: Vec<_> = strings
+            .iter()
+            .zip(&values)
+            .map(|((tag, _), v)| (*tag, v.as_slice()))
+            .collect();
+        writer.write_with_info(record, &int_refs, &string_refs)?;
+        count = count.checked_add(1).ok_or(EvidenceError::CounterOverflow)?;
+    }
+    writer.finish()?;
+    lookup.verify_unchanged()?;
+    checkpoint().map_err(EvidenceError::from)?;
+    Ok(count)
+}

--- a/src/variant_io.rs
+++ b/src/variant_io.rs
@@ -1,0 +1,824 @@
+//! Sequential, checked VCF/VCF.gz/BCF I/O for evidence selections and annotations.
+//!
+//! Inputs need no index and retain their record and allele order. HTSlib performs
+//! native decoding before the declared header/record envelope is checked; these
+//! are cooperative limits, not a guarantee against a transient native allocation.
+//! Writers must be explicitly finished before an enclosing atomic artifact is
+//! committed. Dropping a writer never reports successful completion.
+
+use crate::core::ContigSet;
+use crate::evidence::{EvidenceError, SnvSite};
+use rust_htslib::bcf::{self, header::HeaderView, Read};
+use rust_htslib::htslib;
+use std::ffi::{CStr, CString};
+use std::mem::size_of;
+use std::path::Path;
+use std::ptr::NonNull;
+
+/// Declared per-header and per-decoded-record cooperative envelopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VariantLimits {
+    /// Maximum formatted header bytes, including native formatting capacity.
+    pub max_header_bytes: usize,
+    /// Maximum decoded record capacities and, for VCF output, formatted capacity.
+    pub max_record_bytes: usize,
+}
+
+impl Default for VariantLimits {
+    fn default() -> Self {
+        Self {
+            max_header_bytes: 8 * 1024 * 1024,
+            max_record_bytes: 1024 * 1024,
+        }
+    }
+}
+
+impl VariantLimits {
+    fn validate(self) -> Result<(), EvidenceError> {
+        if self.max_header_bytes == 0 || self.max_record_bytes == 0 {
+            return Err(EvidenceError::InvalidRequest(
+                "variant header and record envelopes must be positive".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A sequential reader with one reusable decoded record and checked parser flags.
+#[derive(Debug)]
+pub struct VariantReader {
+    reader: bcf::Reader,
+    record: bcf::Record,
+    limits: VariantLimits,
+    record_number: u64,
+    failed: bool,
+}
+
+impl VariantReader {
+    /// Open a local VCF, compressed VCF, or BCF without requiring an index.
+    pub fn open(path: impl AsRef<Path>, limits: VariantLimits) -> Result<Self, EvidenceError> {
+        limits.validate()?;
+        check_input_file(path.as_ref())?;
+        let reader = bcf::Reader::from_path(path.as_ref())
+            .map_err(|e| invalid(format!("cannot open variant input: {e}")))?;
+        // rust-htslib 0.44.1 does not check bcf_hdr_read's null result. Its
+        // HeaderView destructor accepts null, but all other methods require it.
+        if reader.header().inner.is_null() {
+            return Err(invalid("cannot decode variant header"));
+        }
+        check_header(reader.header().inner, limits)?;
+        let record = reader.empty_record();
+        Ok(Self {
+            reader,
+            record,
+            limits,
+            record_number: 0,
+            failed: false,
+        })
+    }
+
+    /// The unchanged input header, including sample and INFO/FORMAT definitions.
+    pub fn header(&self) -> &HeaderView {
+        self.reader.header()
+    }
+
+    /// Number of records decoded so far, including a record that failed validation.
+    pub fn record_number(&self) -> u64 {
+        self.record_number
+    }
+
+    /// Read the next record in original order, reusing the same native allocation.
+    /// Any parse or envelope failure poisons the reader rather than allowing a
+    /// caller to continue with header definitions invented by HTSlib recovery.
+    pub fn read(&mut self) -> Result<Option<&mut bcf::Record>, EvidenceError> {
+        if self.failed {
+            return Err(invalid(
+                "variant reader cannot continue after a failed record",
+            ));
+        }
+        let result = match self.reader.read(&mut self.record) {
+            None => return Ok(None),
+            Some(result) => result,
+        };
+        self.record_number = self
+            .record_number
+            .checked_add(1)
+            .ok_or(EvidenceError::CounterOverflow)?;
+        let checked = result
+            .map_err(|e| invalid(format!("variant record {}: {e}", self.record_number)))
+            .and_then(|()| {
+                // SAFETY: rust-htslib initialized this record. Its read method
+                // ignores the unpack return value, so check it explicitly too.
+                if unsafe { htslib::bcf_unpack(self.record.inner, htslib::BCF_UN_ALL as i32) } < 0 {
+                    return Err(invalid("cannot unpack variant input record"));
+                }
+                check_record(self.record.inner(), self.limits)?;
+                check_record_header(&self.record)
+            });
+        if let Err(error) = checked {
+            self.failed = true;
+            return Err(error);
+        }
+        Ok(Some(&mut self.record))
+    }
+}
+
+/// Resolve a single typed record to an A/C/G/T SNV, preserving its ALT order.
+/// Selection normalization subsequently unions repeated loci and ALT alleles.
+pub fn parse_snv_record(
+    record: &bcf::Record,
+    contigs: &ContigSet,
+) -> Result<SnvSite, EvidenceError> {
+    if record.inner().errcode != 0 {
+        return Err(invalid(
+            "variant record has unresolved HTSlib parser errors",
+        ));
+    }
+    let rid = record
+        .rid()
+        .ok_or_else(|| invalid("variant has no contig"))?;
+    let name = record
+        .header()
+        .rid2name(rid)
+        .map_err(|e| invalid(format!("invalid variant contig: {e}")))?;
+    let name = std::str::from_utf8(name).map_err(|_| invalid("non-UTF-8 variant contig"))?;
+    let contig = contigs
+        .by_name(name)
+        .ok_or_else(|| invalid(format!("unknown variant contig {name}")))?;
+    let position = u32::try_from(record.pos()).map_err(|_| invalid("POS outside reference"))?;
+    if position >= contig.length {
+        return Err(invalid("POS outside reference"));
+    }
+    let alleles = record.alleles();
+    if alleles.len() < 2 {
+        return Err(invalid("SNV record requires at least one ALT"));
+    }
+    let base = |allele: &[u8]| {
+        if allele.len() != 1 || !b"ACGT".contains(&allele[0].to_ascii_uppercase()) {
+            return Err(invalid(
+                "only A/C/G/T SNV REF and ALT alleles are supported",
+            ));
+        }
+        Ok(allele[0].to_ascii_uppercase())
+    };
+    let reference = base(alleles[0])?;
+    if alleles.len() > 4 {
+        return Err(invalid(
+            "SNV record cannot have more than three distinct ALT bases",
+        ));
+    }
+    let mut seen = [false; 256];
+    let alternates = alleles[1..]
+        .iter()
+        .map(|allele| {
+            let alternate = base(allele)?;
+            if alternate == reference {
+                return Err(invalid("ALT equals REF"));
+            }
+            if std::mem::replace(&mut seen[alternate as usize], true) {
+                return Err(invalid("duplicate ALT allele within a variant record"));
+            }
+            Ok(alternate)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(SnvSite {
+        contig: contig.id,
+        position,
+        reference,
+        alternates,
+    })
+}
+
+/// Explicit output encoding, independent of a temporary artifact's suffix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariantFormat {
+    /// Uncompressed VCF text.
+    Vcf,
+    /// BGZF-compressed VCF text.
+    VcfGz,
+    /// BGZF-compressed BCF.
+    Bcf,
+}
+
+/// Checked native writer with a reusable copy for header translation/annotations.
+///
+/// The original Rust record remains associated with its input header. Account for
+/// input/output/translation headers, native I/O, the input record, the copied
+/// record, and VCF formatting scratch when planning an annotation process.
+#[derive(Debug)]
+pub struct CheckedVariantWriter {
+    file: Option<NonNull<htslib::htsFile>>,
+    header: HeaderView,
+    source: Option<SourceHeader>,
+    scratch: NativeRecord,
+    text: NativeString,
+    format: VariantFormat,
+    limits: VariantLimits,
+    failed: bool,
+}
+
+impl CheckedVariantWriter {
+    /// Create an output and check header serialization/write errors immediately.
+    pub fn create(
+        path: impl AsRef<Path>,
+        header: &bcf::Header,
+        format: VariantFormat,
+        limits: VariantLimits,
+    ) -> Result<Self, EvidenceError> {
+        limits.validate()?;
+        let path = checked_path(path.as_ref())?;
+        if header.inner.is_null() {
+            return Err(invalid("null variant output header"));
+        }
+        check_header(header.inner, limits)?;
+        // SAFETY: the borrowed Header owns a live bcf_hdr_t; the duplicate becomes
+        // exclusively owned by HeaderView and is destroyed exactly once.
+        let cloned = unsafe { htslib::bcf_hdr_dup(header.inner) };
+        if cloned.is_null() {
+            return Err(io_error("cannot duplicate variant output header"));
+        }
+        let header = HeaderView::new(cloned);
+        check_header(header.inner, limits)?;
+        let mode = match format {
+            VariantFormat::Vcf => c"w",
+            VariantFormat::VcfGz => c"wz",
+            VariantFormat::Bcf => c"wb",
+        };
+        let scratch = NativeRecord::new()?;
+        // SAFETY: both C strings are NUL terminated and live for the call.
+        let file = NonNull::new(unsafe { htslib::hts_open(path.as_ptr(), mode.as_ptr()) })
+            .ok_or_else(|| io_error("cannot open variant output"))?;
+        let mut writer = Self {
+            file: Some(file),
+            header,
+            source: None,
+            scratch,
+            text: NativeString::default(),
+            format,
+            limits,
+            failed: false,
+        };
+        // SAFETY: file and header are live, uniquely owned native objects.
+        if unsafe { htslib::bcf_hdr_write(file.as_ptr(), writer.header.inner) } < 0 {
+            writer.failed = true;
+            return Err(io_error("cannot write variant output header"));
+        }
+        Ok(writer)
+    }
+
+    /// The owned output header, including added annotation definitions.
+    pub fn header(&self) -> &HeaderView {
+        &self.header
+    }
+
+    /// Write a translated copy without changing the original record or its header.
+    pub fn write(&mut self, record: &bcf::Record) -> Result<(), EvidenceError> {
+        self.write_with_info(record, &[], &[])
+    }
+
+    /// Add typed INFO fields to a translated copy and check the complete write.
+    /// Keys must already exist with the matching type in the output header.
+    /// String values are comma-separated VCF elements and must not contain
+    /// delimiters, whitespace, or NUL. Integer narrowing is the caller's duty.
+    pub fn write_with_info(
+        &mut self,
+        record: &bcf::Record,
+        integers: &[(&[u8], &[i32])],
+        strings: &[(&[u8], &[&[u8]])],
+    ) -> Result<(), EvidenceError> {
+        if self.failed {
+            return Err(io_error(
+                "variant writer cannot continue after a failed write",
+            ));
+        }
+        let result = self.write_record(record, integers, strings);
+        if result.is_err() {
+            self.failed = true;
+        }
+        result
+    }
+
+    fn write_record(
+        &mut self,
+        record: &bcf::Record,
+        integers: &[(&[u8], &[i32])],
+        strings: &[(&[u8], &[&[u8]])],
+    ) -> Result<(), EvidenceError> {
+        let source_bytes = check_record(record.inner(), self.limits)?;
+        check_record_header(record)?;
+        self.bind_source(record)?;
+        let mut annotation_bytes = 0usize;
+        for (key, values) in integers {
+            self.check_info_type(key, bcf::header::TagType::Integer)?;
+            annotation_bytes = annotation_bytes
+                .checked_add(
+                    values
+                        .len()
+                        .checked_mul(size_of::<i32>())
+                        .ok_or(EvidenceError::CounterOverflow)?,
+                )
+                .ok_or(EvidenceError::CounterOverflow)?;
+        }
+        for (key, values) in strings {
+            self.check_info_type(key, bcf::header::TagType::String)?;
+            for value in *values {
+                if value.is_empty()
+                    || value
+                        .iter()
+                        .any(|b| b.is_ascii_whitespace() || b"\0,;=".contains(b))
+                {
+                    return Err(invalid("invalid VCF INFO string element"));
+                }
+                annotation_bytes = annotation_bytes
+                    .checked_add(
+                        value
+                            .len()
+                            .checked_add(1)
+                            .ok_or(EvidenceError::CounterOverflow)?,
+                    )
+                    .ok_or(EvidenceError::CounterOverflow)?;
+            }
+        }
+        check_limit(
+            source_bytes
+                .checked_add(annotation_bytes)
+                .ok_or(EvidenceError::CounterOverflow)?,
+            self.limits.max_record_bytes,
+            "record plus annotations",
+        )?;
+        // SAFETY: source, reusable scratch, and both headers are live. bcf_copy
+        // synchronizes native packed storage but preserves source scientific data;
+        // translation/INFO updates apply only to the exclusive scratch record.
+        unsafe {
+            if htslib::bcf_copy(self.scratch.0.as_ptr(), record.inner).is_null() {
+                return Err(io_error("cannot copy variant output record"));
+            }
+            if htslib::bcf_translate(
+                self.header.inner,
+                self.source.as_ref().expect("bound source").translated.inner,
+                self.scratch.0.as_ptr(),
+            ) < 0
+            {
+                return Err(invalid("cannot translate variant record to output header"));
+            }
+        }
+        for (key, values) in integers {
+            let key = checked_key(key)?;
+            self.update_info(
+                &key,
+                values.as_ptr().cast(),
+                values.len(),
+                htslib::BCF_HT_INT,
+            )?;
+        }
+        for (key, values) in strings {
+            let key = checked_key(key)?;
+            let joined = values.join(&b',');
+            self.update_info(
+                &key,
+                joined.as_ptr().cast(),
+                joined.len(),
+                htslib::BCF_HT_STR,
+            )?;
+        }
+        // SAFETY: the scratch record remains owned and initialized. Unpacking
+        // makes every capacity visible to the envelope accounting below.
+        if unsafe { htslib::bcf_unpack(self.scratch.0.as_ptr(), htslib::BCF_UN_ALL as i32) } < 0 {
+            return Err(invalid("cannot unpack annotated variant record"));
+        }
+        check_record(self.scratch.get(), self.limits)?;
+        if self.format != VariantFormat::Bcf {
+            self.text.0.l = 0;
+            // SAFETY: header/record/string are live; native kstring owns its buffer.
+            if unsafe {
+                htslib::vcf_format(self.header.inner, self.scratch.0.as_ptr(), &mut self.text.0)
+            } < 0
+            {
+                return Err(invalid("cannot format annotated VCF record"));
+            }
+            check_limit(
+                usize::try_from(self.text.0.m).map_err(|_| EvidenceError::CounterOverflow)?,
+                self.limits.max_record_bytes,
+                "formatted VCF record",
+            )?;
+        }
+        // SAFETY: the file is still open and all translated IDs use its header.
+        if unsafe {
+            htslib::bcf_write(
+                self.file.expect("open writer").as_ptr(),
+                self.header.inner,
+                self.scratch.0.as_ptr(),
+            )
+        } < 0
+        {
+            return Err(io_error("cannot write variant output record"));
+        }
+        // BCF serialization can grow packed buffers after INFO updates.
+        check_record(self.scratch.get(), self.limits)?;
+        Ok(())
+    }
+
+    fn bind_source(&mut self, record: &bcf::Record) -> Result<(), EvidenceError> {
+        if self
+            .source
+            .as_ref()
+            .is_some_and(|source| source.anchor.header().inner == record.header().inner)
+        {
+            return Ok(());
+        }
+        check_header(record.header().inner, self.limits)?;
+        check_output_header(record.header(), &self.header)?;
+        // SAFETY: duplicate a live header. Translation tables belong to this
+        // writer; bcf_translate must never cache them in the shared input header.
+        let cloned = unsafe { htslib::bcf_hdr_dup(record.header().inner) };
+        if cloned.is_null() {
+            return Err(io_error("cannot duplicate variant translation header"));
+        }
+        let translated = HeaderView::new(cloned);
+        let empty = NativeRecord::new()?;
+        let mut anchor = record.clone();
+        // Keep the source Rc<HeaderView> alive without retaining a record payload.
+        // SAFETY: the new empty record replaces one owned native record; the old
+        // allocation is freed once, and anchor's destructor owns the replacement.
+        unsafe {
+            let old = std::mem::replace(&mut anchor.inner, empty.0.as_ptr());
+            std::mem::forget(empty);
+            htslib::bcf_destroy(old);
+        }
+        self.source = Some(SourceHeader { anchor, translated });
+        Ok(())
+    }
+
+    fn check_info_type(
+        &self,
+        key: &[u8],
+        expected: bcf::header::TagType,
+    ) -> Result<(), EvidenceError> {
+        checked_key(key)?;
+        let (actual, _) = self
+            .header
+            .info_type(key)
+            .map_err(|e| invalid(format!("undefined output INFO key: {e}")))?;
+        if actual != expected {
+            return Err(invalid("output INFO key has incompatible type"));
+        }
+        Ok(())
+    }
+
+    fn update_info(
+        &mut self,
+        key: &CString,
+        values: *const libc::c_void,
+        count: usize,
+        kind: u32,
+    ) -> Result<(), EvidenceError> {
+        let count = i32::try_from(count).map_err(|_| EvidenceError::CounterOverflow)?;
+        // SAFETY: the caller's typed slice or joined byte string lives for the
+        // call. HTSlib copies it into the exclusive scratch record.
+        if unsafe {
+            htslib::bcf_update_info(
+                self.header.inner,
+                self.scratch.0.as_ptr(),
+                key.as_ptr(),
+                values,
+                count,
+                kind as i32,
+            )
+        } < 0
+        {
+            return Err(invalid("cannot update variant INFO value"));
+        }
+        Ok(())
+    }
+
+    /// Flush and close explicitly. A prior write failure always prevents success.
+    pub fn finish(mut self) -> Result<(), EvidenceError> {
+        let file = self.file.take().expect("open writer");
+        // SAFETY: take transfers the sole handle, preventing Drop from reclosing.
+        let result = unsafe { htslib::hts_close(file.as_ptr()) };
+        if result < 0 {
+            return Err(io_error("cannot flush/close variant output"));
+        }
+        if self.failed {
+            return Err(io_error("variant output had an earlier failed write"));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CheckedVariantWriter {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            // SAFETY: best-effort abandonment closes the sole remaining handle.
+            // Only explicit finish can report successful artifact completion.
+            unsafe { htslib::hts_close(file.as_ptr()) };
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SourceHeader {
+    // An empty Record retains the original private Rc<HeaderView>, preventing a
+    // later reader from reusing its address while this translation cache is live.
+    anchor: bcf::Record,
+    translated: HeaderView,
+}
+
+#[derive(Debug)]
+struct NativeRecord(NonNull<htslib::bcf1_t>);
+impl NativeRecord {
+    fn new() -> Result<Self, EvidenceError> {
+        // SAFETY: allocation has no arguments; ownership is transferred on success.
+        NonNull::new(unsafe { htslib::bcf_init() })
+            .map(Self)
+            .ok_or_else(|| io_error("cannot allocate variant record"))
+    }
+    fn get(&self) -> &htslib::bcf1_t {
+        // SAFETY: this wrapper exclusively owns an initialized live record.
+        unsafe { self.0.as_ref() }
+    }
+}
+impl Drop for NativeRecord {
+    fn drop(&mut self) {
+        // SAFETY: this is the sole owning wrapper.
+        unsafe { htslib::bcf_destroy(self.0.as_ptr()) };
+    }
+}
+
+#[derive(Debug)]
+struct NativeString(htslib::kstring_t);
+impl Default for NativeString {
+    fn default() -> Self {
+        Self(htslib::kstring_t {
+            l: 0,
+            m: 0,
+            s: std::ptr::null_mut(),
+        })
+    }
+}
+impl Drop for NativeString {
+    fn drop(&mut self) {
+        // SAFETY: HTSlib kstrings use malloc/realloc; free also accepts null.
+        unsafe { libc::free(self.0.s.cast()) };
+    }
+}
+
+fn check_header(
+    header: *mut htslib::bcf_hdr_t,
+    limits: VariantLimits,
+) -> Result<(), EvidenceError> {
+    let mut text = NativeString::default();
+    // SAFETY: synchronizing cached IDs before duplication also captures samples
+    // just appended to a Header. HTSlib's formatter alone does not synchronize.
+    if unsafe { htslib::bcf_hdr_sync(header) } < 0 {
+        return Err(invalid("cannot synchronize variant header"));
+    }
+    // SAFETY: callers validate nonnull, live header; text owns a native kstring.
+    if unsafe { htslib::bcf_hdr_format(header, 0, &mut text.0) } < 0 {
+        return Err(invalid("cannot format variant header"));
+    }
+    check_limit(
+        usize::try_from(text.0.m).map_err(|_| EvidenceError::CounterOverflow)?,
+        limits.max_header_bytes,
+        "variant header",
+    )?;
+    if text.0.l != 0 {
+        let length = usize::try_from(text.0.l).map_err(|_| EvidenceError::CounterOverflow)?;
+        // SAFETY: successful formatting initialized exactly l bytes in kstring.
+        let bytes = unsafe { std::slice::from_raw_parts(text.0.s.cast::<u8>(), length) };
+        std::str::from_utf8(bytes).map_err(|_| invalid("variant header is not UTF-8"))?;
+    }
+    Ok(())
+}
+
+fn check_output_header(source: &HeaderView, output: &HeaderView) -> Result<(), EvidenceError> {
+    let sample_count = source.sample_count();
+    // rust-htslib 0.44.1's samples() constructs a slice from a null pointer for
+    // some valid zero-sample headers; avoid calling it for that case.
+    if sample_count != output.sample_count()
+        || (sample_count != 0 && source.samples() != output.samples())
+    {
+        return Err(invalid(
+            "variant output must preserve sample names and order",
+        ));
+    }
+    for rid in 0..source.contig_count() {
+        let name = source.rid2name(rid).map_err(|e| invalid(e.to_string()))?;
+        let output_rid = output
+            .name2rid(name)
+            .map_err(|_| invalid("variant output is missing an input contig"))?;
+        // SAFETY: name/rid lookups above validate the live contig dictionary
+        // entries. HTSlib stores declared contig length in idinfo.info[0].
+        let same_length = unsafe {
+            let source_value =
+                (*(*source.inner).id[htslib::BCF_DT_CTG as usize].add(rid as usize)).val;
+            let output_value =
+                (*(*output.inner).id[htslib::BCF_DT_CTG as usize].add(output_rid as usize)).val;
+            !source_value.is_null()
+                && !output_value.is_null()
+                && (*source_value).info[0] == (*output_value).info[0]
+        };
+        if !same_length {
+            return Err(invalid("variant output changes an input contig length"));
+        }
+    }
+    // SAFETY: both headers are initialized and validated as UTF-8. Enumerate
+    // HTSlib's live dictionary entries; removed entries have a null key.
+    unsafe {
+        let source_raw = &*source.inner;
+        for index in 0..source_raw.n[htslib::BCF_DT_ID as usize] as usize {
+            let pair = &*source_raw.id[htslib::BCF_DT_ID as usize].add(index);
+            if pair.key.is_null() {
+                continue;
+            }
+            let key = CStr::from_ptr(pair.key).to_bytes();
+            output
+                .name_to_id(key)
+                .map_err(|_| invalid("variant output is missing an input tag"))?;
+            for (source_type, output_type) in [
+                (source.info_type(key), output.info_type(key)),
+                (source.format_type(key), output.format_type(key)),
+            ] {
+                if let Ok(expected) = source_type {
+                    if output_type.ok() != Some(expected) {
+                        return Err(invalid(
+                            "variant output changes an input INFO/FORMAT definition",
+                        ));
+                    }
+                }
+            }
+            let source_filter = htslib::bcf_hdr_get_hrec(
+                source.inner,
+                htslib::BCF_HL_FLT as i32,
+                c"ID".as_ptr(),
+                pair.key,
+                std::ptr::null(),
+            );
+            if !source_filter.is_null()
+                && htslib::bcf_hdr_get_hrec(
+                    output.inner,
+                    htslib::BCF_HL_FLT as i32,
+                    c"ID".as_ptr(),
+                    pair.key,
+                    std::ptr::null(),
+                )
+                .is_null()
+            {
+                return Err(invalid(
+                    "variant output is missing an input FILTER definition",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_record_header(record: &bcf::Record) -> Result<(), EvidenceError> {
+    if record.inner().n_sample() != record.header().sample_count() {
+        return Err(invalid(
+            "variant record sample count does not match its header",
+        ));
+    }
+    if record
+        .rid()
+        .is_none_or(|rid| rid >= record.header().contig_count())
+    {
+        return Err(invalid("variant record contig ID is outside its header"));
+    }
+    Ok(())
+}
+
+fn check_record(record: &htslib::bcf1_t, limits: VariantLimits) -> Result<usize, EvidenceError> {
+    if record.errcode != 0 {
+        return Err(invalid(format!(
+            "variant parser error flags {} (undefined contig/tag or malformed record)",
+            record.errcode
+        )));
+    }
+    let d = &record.d;
+    let mut bytes = size_of::<htslib::bcf1_t>();
+    for capacity in [record.shared.m, record.indiv.m] {
+        bytes = bytes
+            .checked_add(usize::try_from(capacity).map_err(|_| EvidenceError::CounterOverflow)?)
+            .ok_or(EvidenceError::CounterOverflow)?;
+    }
+    for (count, width) in [
+        (d.m_id, 1),
+        (d.m_als, 1),
+        (d.m_allele, size_of::<*mut libc::c_char>()),
+        (d.m_flt, size_of::<libc::c_int>()),
+        (d.m_info, size_of::<htslib::bcf_info_t>()),
+        (d.m_fmt, size_of::<htslib::bcf_fmt_t>()),
+        (d.n_var, size_of::<htslib::bcf_variant_t>()),
+    ] {
+        let count =
+            usize::try_from(count).map_err(|_| invalid("negative variant allocation capacity"))?;
+        bytes = bytes
+            .checked_add(
+                count
+                    .checked_mul(width)
+                    .ok_or(EvidenceError::CounterOverflow)?,
+            )
+            .ok_or(EvidenceError::CounterOverflow)?;
+    }
+    // Updated INFO/FORMAT values can own independent buffers outside shared/indiv.
+    check_limit(bytes, limits.max_record_bytes, "decoded variant record")?;
+    let info_count = if record.unpacked & htslib::BCF_UN_INFO as i32 != 0 {
+        record.n_info() as usize
+    } else {
+        0
+    };
+    let format_count = if record.unpacked & htslib::BCF_UN_FMT as i32 != 0 {
+        record.n_fmt() as usize
+    } else {
+        0
+    };
+    if (info_count > 0 && (d.info.is_null() || info_count > d.m_info as usize))
+        || (format_count > 0 && (d.fmt.is_null() || format_count > d.m_fmt as usize))
+    {
+        return Err(invalid("variant decoded field array is inconsistent"));
+    }
+    // SAFETY: capacities/pointers come from an unpacked live native record. Only
+    // initialized entries (n_info/n_fmt), rather than spare capacity, are read.
+    unsafe {
+        for i in 0..info_count {
+            let info = &*d.info.add(i);
+            if info.vptr_free() != 0 {
+                bytes = bytes
+                    .checked_add(info.vptr_len as usize + info.vptr_off() as usize)
+                    .ok_or(EvidenceError::CounterOverflow)?;
+            }
+        }
+        for i in 0..format_count {
+            let format = &*d.fmt.add(i);
+            if format.p_free() != 0 {
+                bytes = bytes
+                    .checked_add(format.p_len as usize + format.p_off() as usize)
+                    .ok_or(EvidenceError::CounterOverflow)?;
+            }
+        }
+    }
+    check_limit(bytes, limits.max_record_bytes, "decoded variant record")?;
+    Ok(bytes)
+}
+
+fn checked_path(path: &Path) -> Result<CString, EvidenceError> {
+    let text = path
+        .to_str()
+        .ok_or_else(|| invalid("variant path is not UTF-8"))?;
+    if text == "-" {
+        return Err(invalid(
+            "variant artifacts require a local path, not standard I/O",
+        ));
+    }
+    CString::new(text).map_err(|_| invalid("variant path contains NUL"))
+}
+
+fn check_input_file(path: &Path) -> Result<(), EvidenceError> {
+    let cpath = checked_path(path)?;
+    if !std::fs::metadata(path)?.is_file() {
+        return Err(invalid("variant input must be a regular local file"));
+    }
+    // The pinned high-level Reader hides its htsFile handle. A short independent
+    // open checks the BGZF end marker before sequential decoding, so a truncated
+    // stream cannot be mistaken for normal EOF by the high-level iterator.
+    // SAFETY: path/mode are live C strings; this scope owns the returned handle.
+    let file = NonNull::new(unsafe { htslib::hts_open(cpath.as_ptr(), c"r".as_ptr()) })
+        .ok_or_else(|| invalid("cannot inspect variant input"))?;
+    // SAFETY: both calls use the live handle, closed exactly once here.
+    let eof = unsafe { htslib::hts_check_EOF(file.as_ptr()) };
+    let closed = unsafe { htslib::hts_close(file.as_ptr()) };
+    if !matches!(eof, 1 | 3) {
+        return Err(invalid(
+            "variant input has no valid BGZF end marker or cannot be checked",
+        ));
+    }
+    if closed < 0 {
+        return Err(io_error("cannot close variant input preflight handle"));
+    }
+    Ok(())
+}
+
+fn checked_key(key: &[u8]) -> Result<CString, EvidenceError> {
+    if key.is_empty() {
+        return Err(invalid("empty variant INFO key"));
+    }
+    CString::new(key).map_err(|_| invalid("variant INFO key contains NUL"))
+}
+
+fn check_limit(actual: usize, maximum: usize, label: &str) -> Result<(), EvidenceError> {
+    if actual > maximum {
+        return Err(EvidenceError::RecordLimit(format!(
+            "{label} requires {actual} bytes; declared {maximum}"
+        )));
+    }
+    Ok(())
+}
+
+fn invalid(message: impl Into<String>) -> EvidenceError {
+    EvidenceError::InvalidInput(message.into())
+}
+
+fn io_error(message: &str) -> EvidenceError {
+    EvidenceError::Io(std::io::Error::other(message))
+}

--- a/src/variant_io.rs
+++ b/src/variant_io.rs
@@ -373,11 +373,14 @@ impl CheckedVariantWriter {
         }
         for (key, values) in strings {
             let key = checked_key(key)?;
-            let joined = values.join(&b',');
+            // BCF_HT_STR uses strlen: its count is not a byte-length bound.
+            // Include the NUL already reserved by annotation_bytes above.
+            let joined = CString::new(values.join(&b','))
+                .map_err(|_| invalid("variant INFO string contains NUL"))?;
             self.update_info(
                 &key,
                 joined.as_ptr().cast(),
-                joined.len(),
+                usize::from(!values.is_empty()),
                 htslib::BCF_HT_STR,
             )?;
         }
@@ -473,8 +476,8 @@ impl CheckedVariantWriter {
         kind: u32,
     ) -> Result<(), EvidenceError> {
         let count = i32::try_from(count).map_err(|_| EvidenceError::CounterOverflow)?;
-        // SAFETY: the caller's typed slice or joined byte string lives for the
-        // call. HTSlib copies it into the exclusive scratch record.
+        // SAFETY: the caller's typed slice or NUL-terminated CString lives for
+        // the call. HTSlib copies it into the exclusive scratch record.
         if unsafe {
             htslib::bcf_update_info(
                 self.header.inner,
@@ -689,6 +692,11 @@ fn check_record_header(record: &bcf::Record) -> Result<(), EvidenceError> {
 }
 
 fn check_record(record: &htslib::bcf1_t, limits: VariantLimits) -> Result<usize, EvidenceError> {
+    // Bindgen names this pointee differently on Linux and macOS. Infer its
+    // native layout from the field type without dereferencing the pointer.
+    fn pointee_size<T>(_: *const T) -> usize {
+        size_of::<T>()
+    }
     if record.errcode != 0 {
         return Err(invalid(format!(
             "variant parser error flags {} (undefined contig/tag or malformed record)",
@@ -709,7 +717,7 @@ fn check_record(record: &htslib::bcf1_t, limits: VariantLimits) -> Result<usize,
         (d.m_flt, size_of::<libc::c_int>()),
         (d.m_info, size_of::<htslib::bcf_info_t>()),
         (d.m_fmt, size_of::<htslib::bcf_fmt_t>()),
-        (d.n_var, size_of::<htslib::bcf_variant_t>()),
+        (d.n_var, pointee_size(d.var)),
     ] {
         let count =
             usize::try_from(count).map_err(|_| invalid("negative variant allocation capacity"))?;

--- a/tests/contract_public.rs
+++ b/tests/contract_public.rs
@@ -151,6 +151,28 @@ fn direct_runner_completes_and_seals_external_identity() {
 
 #[test]
 fn direct_runner_refuses_before_primary_output_creation() {
+    // Refusal starts the process-global governor before reference validation.
+    // Its deliberately tiny budget must not trip concurrent record-only runs
+    // in this test binary. Keep the real public API call in a child process.
+    const ISOLATED: &str = "ROSALIND_TEST_CONTRACT_REFUSAL_ISOLATED";
+    if std::env::var_os(ISOLATED).is_none() {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "direct_runner_refuses_before_primary_output_creation",
+                "--nocapture",
+            ])
+            .env(ISOLATED, "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "isolated contract refusal failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
     let dir = unique_dir();
     let (index, bam) = fixture(&dir);
     let output = dir.join("must-not-exist.tsv");

--- a/tests/evidence_engine.rs
+++ b/tests/evidence_engine.rs
@@ -207,7 +207,7 @@ fn snv_sites_validate_reference_and_merge_duplicate_alternates() {
     let f = Fixture::new(20);
     f.write(vec![matched("r", 0, 10, 60, 0)], bam::index::Type::Bai);
     let vcf = f.root.join("sites.vcf");
-    std::fs::write(&vcf,"##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\nchr1\t2\t.\tA\tT,C\nchr1\t2\t.\tA\tG\nchr1\t18\t.\tA\tC\n").unwrap();
+    std::fs::write(&vcf,"##fileformat=VCFv4.2\n##contig=<ID=chr1,length=20>\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\nchr1\t2\t.\tA\tT,C\t.\tPASS\t.\nchr1\t2\t.\tA\tG\t.\tPASS\t.\nchr1\t18\t.\tA\tC\t.\tPASS\t.\n").unwrap();
     let mut engine = EvidenceEngine::open(f.request(3)).unwrap();
     let selection = EvidenceSelection::from_vcf(&vcf, engine.contigs()).unwrap();
     engine.set_selection(selection).unwrap();
@@ -723,6 +723,38 @@ fn full_evidence_egress_matches_frozen_schema_one_bytes() {
             "TSV width={width}"
         );
     }
+    // Captured before the additive allele-quality field was introduced.
+    for (bits, arrow_hash, tsv_hash) in [
+        (
+            3,
+            "4700bed38ea7efc36d8884e62d5a63f8f306a265c63536480c29bee1ed878435",
+            "5d2d16594c44d0a17f18bffa11d282627c0c0227233c84ace660eaf949574aef",
+        ),
+        (
+            9,
+            "4abba987ac34dad83522be504ecf700116f476cc4270b4cedd8fa590dc5f605d",
+            "ea2b969bbd054df91dedfe025bc6a4c418ab3b32774a87ca0fcc7e5e90d2436d",
+        ),
+    ] {
+        let fields = EvidenceFields::from_bits(bits).unwrap();
+        let mut request = f.request(16384);
+        request.fields = fields;
+        let mut arrow = EvidenceArrowWriter::with_fields(Vec::new(), fields);
+        EvidenceEngine::open(request.clone())
+            .unwrap()
+            .run(&mut arrow)
+            .unwrap();
+        assert_eq!(
+            blake3::hash(&arrow.into_inner().unwrap()).to_hex().as_str(),
+            arrow_hash
+        );
+        let mut tsv = EvidenceTsvWriter::with_fields(Vec::new(), fields);
+        EvidenceEngine::open(request)
+            .unwrap()
+            .run(&mut tsv)
+            .unwrap();
+        assert_eq!(blake3::hash(&tsv.into_inner()).to_hex().as_str(), tsv_hash);
+    }
     {
         let mut arrow = EvidenceArrowWriter::new(Vec::new());
         arrow.finish().unwrap();
@@ -769,8 +801,10 @@ fn every_projection_preserves_present_values_and_roundtrips_empty_metadata() {
         bam::index::Type::Bai,
     );
     let full = collect(f.request(20));
-    let mut full_tsv = EvidenceTsvWriter::new(Vec::new());
-    EvidenceEngine::open(f.request(20))
+    let mut full_tsv = EvidenceTsvWriter::with_fields(Vec::new(), EvidenceFields::ALL_SUPPORTED);
+    let mut all_request = f.request(20);
+    all_request.fields = EvidenceFields::ALL_SUPPORTED;
+    EvidenceEngine::open(all_request)
         .unwrap()
         .run(&mut full_tsv)
         .unwrap();
@@ -779,7 +813,7 @@ fn every_projection_preserves_present_values_and_roundtrips_empty_metadata() {
         .lines()
         .map(|line| line.split('\t').collect())
         .collect();
-    for bits in 0..64 {
+    for bits in 0..128 {
         let fields = EvidenceFields::from_bits(bits).unwrap();
         let mut previous = None;
         for width in [1, 20] {
@@ -844,6 +878,28 @@ fn every_projection_preserves_present_values_and_roundtrips_empty_metadata() {
                                 (expected.read_position_sum, expected.read_length_sum)
                             );
                         }
+                        assert_eq!(
+                            row.allele_quality.is_some(),
+                            fields.contains(EvidenceFields::ALLELE_QUALITY)
+                        );
+                        if let Some(aq) = row.allele_quality {
+                            // Independent A/C/G/T oracle, including orientation-aware cycles.
+                            let mut oracle = EvidenceAlleleQuality::default();
+                            let p = row.position as usize;
+                            if p < 4 {
+                                let forward = p;
+                                let reverse = 3 - p;
+                                oracle.base_quality_sum[forward] = [30, 25, 40, 20][p];
+                                oracle.mapping_quality_sum[forward] = 60;
+                                oracle.read_position_sum[forward] = p as u64;
+                                oracle.read_length_sum[forward] = 5;
+                                oracle.base_quality_sum[reverse] = [45, 35, 20, 30][p];
+                                oracle.mapping_quality_sum[reverse] = 30;
+                                oracle.read_position_sum[reverse] = (4 - p) as u64;
+                                oracle.read_length_sum[reverse] = 5;
+                            }
+                            assert_eq!(aq, &oracle, "position={p}, bits={bits}");
+                        }
                         assert_eq!(row.try_to_full_row().is_ok(), fields == EvidenceFields::ALL);
                         count += 1;
                     }
@@ -884,4 +940,37 @@ fn every_projection_preserves_present_values_and_roundtrips_empty_metadata() {
             .unwrap();
         assert_eq!(metadata.fields, fields);
     }
+}
+
+#[test]
+fn per_allele_quality_distinguishes_equal_pooled_quality_distributions() {
+    let first = Fixture::new(2);
+    let second = Fixture::new(2);
+    for (fixture, qualities) in [(&first, [30, 40]), (&second, [40, 30])] {
+        fixture.write(
+            vec![
+                record("a", 0, b"A", &[qualities[0]], 60, 0, vec![Cigar::Match(1)]),
+                record("c", 0, b"C", &[qualities[1]], 60, 0, vec![Cigar::Match(1)]),
+            ],
+            bam::index::Type::Bai,
+        );
+    }
+    let encode = |fixture: &Fixture, fields: EvidenceFields| {
+        let mut request = fixture.request(2);
+        request.fields = fields;
+        let mut writer = EvidenceArrowWriter::with_fields(Vec::new(), fields);
+        EvidenceEngine::open(request)
+            .unwrap()
+            .run(&mut writer)
+            .unwrap();
+        writer.into_inner().unwrap()
+    };
+    assert_eq!(
+        encode(&first, EvidenceFields::ALL),
+        encode(&second, EvidenceFields::ALL)
+    );
+    assert_ne!(
+        encode(&first, EvidenceFields::ALL_SUPPORTED),
+        encode(&second, EvidenceFields::ALL_SUPPORTED)
+    );
 }

--- a/tests/evidence_variant_input.rs
+++ b/tests/evidence_variant_input.rs
@@ -210,6 +210,52 @@ fn annotation_updates_copy_and_preserves_original_header_record_and_allele_order
 }
 
 #[test]
+fn repeated_info_strings_have_exact_boundaries_and_empty_updates_remove_tags() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let mut reader = VariantReader::open(input, VariantLimits::default()).unwrap();
+    let mut output_header = bcf::Header::from_template(reader.header());
+    output_header
+        .push_record(b"##INFO=<ID=SUM,Number=R,Type=String,Description=\"Exact integer sums\">");
+    let record = reader.read().unwrap().unwrap();
+    let values = |index: usize| -> [&[u8]; 3] {
+        if index % 2 == 0 {
+            [b"30", b"40", b"25"]
+        } else {
+            [b"18446744073709551615", b"0", b"999999999999999999"]
+        }
+    };
+    for (name, format) in [
+        ("strings.vcf", VariantFormat::Vcf),
+        ("strings.vcf.gz", VariantFormat::VcfGz),
+        ("strings.bcf", VariantFormat::Bcf),
+    ] {
+        let output = f.0.join(name);
+        let mut writer =
+            CheckedVariantWriter::create(&output, &output_header, format, VariantLimits::default())
+                .unwrap();
+        for index in 0..64 {
+            writer
+                .write_with_info(record, &[], &[(b"SUM", &values(index)), (b"OLD", &[])])
+                .unwrap();
+        }
+        writer.finish().unwrap();
+        assert_eq!(record.info(b"OLD").string().unwrap().unwrap()[0], b"keep");
+        let mut reread = VariantReader::open(output, VariantLimits::default()).unwrap();
+        for index in 0..64 {
+            let actual = reread.read().unwrap().unwrap();
+            assert_eq!(
+                &*actual.info(b"SUM").string().unwrap().unwrap(),
+                &values(index),
+                "{name}, record {index}"
+            );
+            assert!(actual.info(b"OLD").string().unwrap().is_none());
+        }
+        assert!(reread.read().unwrap().is_none());
+    }
+}
+
+#[test]
 fn parser_warning_recovery_is_rejected_and_cannot_be_resumed() {
     let f = Fixture::new();
     for (name, row) in [

--- a/tests/evidence_variant_input.rs
+++ b/tests/evidence_variant_input.rs
@@ -1,0 +1,514 @@
+use rosalind::core::ContigSet;
+use rosalind::evidence::{EvidenceError, EvidenceSelection};
+use rosalind::variant_io::{
+    parse_snv_record, CheckedVariantWriter, VariantFormat, VariantLimits, VariantReader,
+};
+use rust_htslib::bcf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+
+struct Fixture(PathBuf);
+impl Fixture {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "rosalind-variant-io-{}-{}",
+            std::process::id(),
+            FIXTURE_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+    fn write(&self, name: &str, text: impl AsRef<[u8]>) -> PathBuf {
+        let path = self.0.join(name);
+        std::fs::write(&path, text).unwrap();
+        path
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn header() -> &'static str {
+    "##fileformat=VCFv4.2\n\
+     ##contig=<ID=chr1,length=100>\n\
+     ##INFO=<ID=OLD,Number=1,Type=String,Description=\"Original annotation\">\n\
+     ##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n\
+     ##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Original depth\">\n\
+     #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+}
+
+fn source(f: &Fixture) -> PathBuf {
+    f.write(
+        "input.vcf",
+        format!(
+            "{}chr1\t8\tsecond\tA\tT,C\t31\tPASS\tOLD=keep\tGT:DP\t2|1:7\n\
+             chr1\t2\tfirst\tA\tG\t.\t.\tOLD=two\tGT:DP\t0/1:3\n\
+             chr1\t8\tduplicate\tA\tG,T\t9\tPASS\t.\tGT:DP\t1/2:4\n",
+            header()
+        ),
+    )
+}
+
+fn contigs() -> ContigSet {
+    let mut contigs = ContigSet::new();
+    contigs.push("chr1", 100);
+    contigs
+}
+
+fn sites(path: &Path) -> Vec<rosalind::evidence::SnvSite> {
+    match EvidenceSelection::from_vcf(path, &contigs()).unwrap() {
+        EvidenceSelection::Sites(sites) => sites,
+        _ => panic!("expected sites"),
+    }
+}
+
+#[test]
+fn vcf_bgzf_and_bcf_have_identical_normalized_unsorted_duplicate_selection() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let expected = sites(&input);
+    assert_eq!(expected.len(), 2);
+    assert_eq!(expected[0].position, 1);
+    assert_eq!(expected[1].position, 7);
+    assert_eq!(expected[1].alternates, b"CGT");
+    for (name, format) in [
+        ("out.vcf", VariantFormat::Vcf),
+        ("out.vcf.gz", VariantFormat::VcfGz),
+        ("out.bcf", VariantFormat::Bcf),
+    ] {
+        let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+        let output = f.0.join(name);
+        let mut writer = CheckedVariantWriter::create(
+            &output,
+            &bcf::Header::from_template(reader.header()),
+            format,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        while let Some(record) = reader.read().unwrap() {
+            writer.write(record).unwrap();
+        }
+        writer.finish().unwrap();
+        assert_eq!(sites(&output), expected);
+        let mut reader = VariantReader::open(output, VariantLimits::default()).unwrap();
+        assert_eq!(reader.header().samples(), vec![b"SAMPLE".as_slice()]);
+        for (position, id, alternates, genotype, depth) in [
+            (7, "second", "TC", "2|1", 7),
+            (1, "first", "G", "0/1", 3),
+            (7, "duplicate", "GT", "1/2", 4),
+        ] {
+            let record = reader.read().unwrap().unwrap();
+            let site = parse_snv_record(record, &contigs()).unwrap();
+            assert_eq!(site.position, position);
+            assert_eq!(site.alternates, alternates.as_bytes());
+            assert_eq!(record.id(), id.as_bytes());
+            assert_eq!(record.genotypes().unwrap().get(0).to_string(), genotype);
+            assert_eq!(record.format(b"DP").integer().unwrap()[0], &[depth]);
+        }
+        assert!(reader.read().unwrap().is_none());
+        assert_eq!(reader.record_number(), 3);
+    }
+}
+
+#[test]
+fn ordinary_gzip_vcf_is_supported_without_a_tabix_index() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let output = f.0.join("ordinary.vcf.gz");
+    let mut gzip = flate2::write::GzEncoder::new(
+        std::fs::File::create(&output).unwrap(),
+        flate2::Compression::default(),
+    );
+    gzip.write_all(&std::fs::read(&input).unwrap()).unwrap();
+    gzip.finish().unwrap();
+    assert_eq!(sites(&output), sites(&input));
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&output)
+        .unwrap();
+    file.set_len(file.metadata().unwrap().len() - 8).unwrap();
+    drop(file);
+    assert!(
+        EvidenceSelection::from_vcf(&output, &contigs()).is_err(),
+        "ordinary gzip truncation must be rejected"
+    );
+}
+
+#[test]
+fn sample_free_vcf_and_empty_stream_roundtrip_without_null_sample_access() {
+    let f = Fixture::new();
+    for (name, row) in [("site", "chr1\t1\t.\tA\tC\t.\t.\t.\n"), ("empty", "")] {
+        let input = f.write(name, format!("##fileformat=VCFv4.2\n##contig=<ID=chr1,length=100>\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n{row}"));
+        let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+        assert_eq!(reader.header().sample_count(), 0);
+        let output = f.0.join(format!("{name}.bcf"));
+        let mut writer = CheckedVariantWriter::create(
+            &output,
+            &bcf::Header::from_template(reader.header()),
+            VariantFormat::Bcf,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        while let Some(record) = reader.read().unwrap() {
+            writer.write(record).unwrap();
+        }
+        writer.finish().unwrap();
+        assert_eq!(sites(&input), sites(&output));
+    }
+}
+
+#[test]
+fn annotation_updates_copy_and_preserves_original_header_record_and_allele_order() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+    let mut output_header = bcf::Header::from_template(reader.header());
+    output_header
+        .push_record(b"##INFO=<ID=COUNT,Number=R,Type=Integer,Description=\"Read counts\">");
+    output_header
+        .push_record(b"##INFO=<ID=SUM,Number=R,Type=String,Description=\"Exact integer sums\">");
+    let output = f.0.join("annotated.bcf");
+    let mut writer = CheckedVariantWriter::create(
+        &output,
+        &output_header,
+        VariantFormat::Bcf,
+        VariantLimits::default(),
+    )
+    .unwrap();
+    let record = reader.read().unwrap().unwrap();
+    writer
+        .write_with_info(
+            record,
+            &[(b"COUNT", &[12, 7, 2])],
+            &[(b"SUM", &[b"18446744073709551615", b"42", b"0"])],
+        )
+        .unwrap();
+    assert!(record.header().info_type(b"COUNT").is_err());
+    assert!(record.info(b"COUNT").integer().is_err());
+    assert_eq!(record.alleles(), [b"A", b"T", b"C"]);
+    assert_eq!(record.genotypes().unwrap().get(0).to_string(), "2|1");
+    assert_eq!(record.info(b"OLD").string().unwrap().unwrap()[0], b"keep");
+    writer.finish().unwrap();
+    let mut reader = VariantReader::open(output, VariantLimits::default()).unwrap();
+    let record = reader.read().unwrap().unwrap();
+    assert_eq!(
+        &*record.info(b"COUNT").integer().unwrap().unwrap(),
+        &[12, 7, 2]
+    );
+    assert_eq!(
+        &*record.info(b"SUM").string().unwrap().unwrap(),
+        &[b"18446744073709551615".as_slice(), b"42", b"0"]
+    );
+    assert_eq!(record.id(), b"second");
+    assert_eq!(record.genotypes().unwrap().get(0).to_string(), "2|1");
+    assert_eq!(record.info(b"OLD").string().unwrap().unwrap()[0], b"keep");
+}
+
+#[test]
+fn parser_warning_recovery_is_rejected_and_cannot_be_resumed() {
+    let f = Fixture::new();
+    for (name, row) in [
+        ("info", "chr1\t1\t.\tA\tC\t.\t.\tUNDEFINED=4\tGT\t0/1\n"),
+        ("format", "chr1\t1\t.\tA\tC\t.\t.\t.\tUNKNOWN\t4\n"),
+        ("contig", "chr2\t1\t.\tA\tC\t.\t.\t.\tGT\t0/1\n"),
+        ("columns", "chr1\t1\t.\tA\tC\t.\t.\t.\tGT\n"),
+    ] {
+        let path = f.write(name, format!("{}{row}", header()));
+        let mut reader = VariantReader::open(path, VariantLimits::default()).unwrap();
+        assert!(reader.read().is_err(), "{name}");
+        assert!(
+            reader.read().is_err(),
+            "reader must remain poisoned: {name}"
+        );
+    }
+}
+
+#[test]
+fn malformed_or_missing_header_fails_without_native_null_header_access() {
+    let f = Fixture::new();
+    for (name, contents) in [
+        ("empty", ""),
+        ("missing", "chr1\t1\t.\tA\tC\t.\t.\t.\n"),
+        ("partial", "##fileformat=VCFv4.2\n"),
+        ("bad", "##fileformat=VCFv4.2\n#CHROM\tPOS\n"),
+    ] {
+        let path = f.write(name, contents);
+        assert!(
+            VariantReader::open(path, VariantLimits::default()).is_err(),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn snv_selection_rejects_non_snvs_coordinates_and_conflicting_duplicate_ref() {
+    let f = Fixture::new();
+    for (name, pos, reference, alternate) in [
+        ("deletion", "1", "AT", "A"),
+        ("insertion", "1", "A", "AT"),
+        ("symbolic", "1", "A", "<DEL>"),
+        ("missing", "1", "A", "."),
+        ("n", "1", "N", "C"),
+        ("same", "1", "A", "A"),
+        ("duplicate_alt", "1", "A", "C,C"),
+        ("zero", "0", "A", "C"),
+        ("past_end", "101", "A", "C"),
+    ] {
+        let path = f.write(
+            name,
+            format!(
+                "{}chr1\t{pos}\t.\t{reference}\t{alternate}\t.\t.\t.\tGT\t0/1\n",
+                header()
+            ),
+        );
+        assert!(
+            EvidenceSelection::from_vcf(path, &contigs()).is_err(),
+            "{name}"
+        );
+    }
+    let conflict = f.write(
+        "conflict",
+        format!(
+            "{}chr1\t1\t.\tA\tC\t.\t.\t.\tGT\t0/1\nchr1\t1\t.\tG\tT\t.\t.\t.\tGT\t0/1\n",
+            header()
+        ),
+    );
+    assert!(EvidenceSelection::from_vcf(conflict, &contigs())
+        .unwrap_err()
+        .to_string()
+        .contains("conflicting REF"));
+}
+
+#[test]
+fn header_record_and_annotation_envelopes_fail_closed() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let tiny_header = VariantLimits {
+        max_header_bytes: 10,
+        ..VariantLimits::default()
+    };
+    assert!(matches!(
+        VariantReader::open(&input, tiny_header),
+        Err(EvidenceError::RecordLimit(_))
+    ));
+    let tiny_record = VariantLimits {
+        max_record_bytes: 10,
+        ..VariantLimits::default()
+    };
+    let mut reader = VariantReader::open(&input, tiny_record).unwrap();
+    assert!(matches!(reader.read(), Err(EvidenceError::RecordLimit(_))));
+    let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+    let mut output_header = bcf::Header::from_template(reader.header());
+    output_header.push_record(b"##INFO=<ID=LONG,Number=1,Type=String,Description=\"Large value\">");
+    assert!(matches!(
+        CheckedVariantWriter::create(
+            f.0.join("bad-header"),
+            &output_header,
+            VariantFormat::Bcf,
+            tiny_header
+        ),
+        Err(EvidenceError::RecordLimit(_))
+    ));
+    assert!(!f.0.join("bad-header").exists());
+    let mut writer = CheckedVariantWriter::create(
+        f.0.join("large.bcf"),
+        &output_header,
+        VariantFormat::Bcf,
+        VariantLimits {
+            max_record_bytes: 4096,
+            ..VariantLimits::default()
+        },
+    )
+    .unwrap();
+    let record = reader.read().unwrap().unwrap();
+    let large = vec![b'x'; 5000];
+    assert!(matches!(
+        writer.write_with_info(record, &[], &[(b"LONG", &[&large])]),
+        Err(EvidenceError::RecordLimit(_))
+    ));
+    assert!(writer.write(record).is_err());
+    assert!(writer.finish().is_err());
+}
+
+#[test]
+fn output_type_errors_do_not_mutate_source_and_prevent_successful_finish() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+    let header = bcf::Header::from_template(reader.header());
+    let record = reader.read().unwrap().unwrap();
+    for key in [b"UNKNOWN".as_slice(), b"OLD"] {
+        let mut writer = CheckedVariantWriter::create(
+            f.0.join(String::from_utf8_lossy(key).as_ref()),
+            &header,
+            VariantFormat::Vcf,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        assert!(writer.write_with_info(record, &[(key, &[1])], &[]).is_err());
+        assert!(writer.finish().is_err());
+        assert_eq!(record.info(b"OLD").string().unwrap().unwrap()[0], b"keep");
+    }
+}
+
+#[test]
+fn translation_cache_is_isolated_between_writers_using_the_same_input_record() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+    let original_header = bcf::Header::from_template(reader.header());
+    let mut reordered = bcf::Header::new();
+    reordered.push_record(b"##contig=<ID=chr1,length=100>");
+    reordered
+        .push_record(b"##INFO=<ID=BEFORE,Number=1,Type=String,Description=\"Changes native IDs\">");
+    reordered
+        .push_record(b"##INFO=<ID=OLD,Number=1,Type=String,Description=\"Original annotation\">");
+    reordered.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    reordered.push_record(b"##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Original depth\">");
+    reordered.push_sample(b"SAMPLE");
+    let record = reader.read().unwrap().unwrap();
+    for (name, header) in [
+        ("translated.bcf", reordered),
+        ("original.bcf", original_header),
+    ] {
+        let output = f.0.join(name);
+        let mut writer = CheckedVariantWriter::create(
+            &output,
+            &header,
+            VariantFormat::Bcf,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        writer.write(record).unwrap();
+        writer.finish().unwrap();
+        let mut output = VariantReader::open(output, VariantLimits::default()).unwrap();
+        let roundtrip = output.read().unwrap().unwrap();
+        assert_eq!(
+            roundtrip.info(b"OLD").string().unwrap().unwrap()[0],
+            b"keep"
+        );
+        assert_eq!(roundtrip.genotypes().unwrap().get(0).to_string(), "2|1");
+        assert_eq!(roundtrip.format(b"DP").integer().unwrap()[0], &[7]);
+    }
+    assert_eq!(record.info(b"OLD").string().unwrap().unwrap()[0], b"keep");
+}
+
+#[test]
+fn output_cannot_silently_omit_input_definitions_or_relabel_samples() {
+    let f = Fixture::new();
+    let input = source(&f);
+    let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+    let mut missing = bcf::Header::from_template(reader.header());
+    missing.remove_info(b"OLD");
+    let mut samples = bcf::Header::from_template(reader.header());
+    samples.push_sample(b"EXTRA");
+    let mut length = bcf::Header::from_template(reader.header());
+    length.remove_contig(b"chr1");
+    length.push_record(b"##contig=<ID=chr1,length=200>");
+    let record = reader.read().unwrap().unwrap();
+    for (name, header) in [
+        ("missing.bcf", missing),
+        ("sample.bcf", samples),
+        ("length.bcf", length),
+    ] {
+        let mut writer = CheckedVariantWriter::create(
+            f.0.join(name),
+            &header,
+            VariantFormat::Bcf,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        assert!(writer.write(record).is_err());
+        assert!(writer.finish().is_err());
+    }
+}
+
+#[test]
+fn missing_bgzf_end_marker_cannot_be_accepted_as_successful_eof() {
+    let f = Fixture::new();
+    let input = source(&f);
+    for format in [VariantFormat::VcfGz, VariantFormat::Bcf] {
+        let mut reader = VariantReader::open(&input, VariantLimits::default()).unwrap();
+        let output = f.0.join(format!("truncated-{format:?}"));
+        let mut writer = CheckedVariantWriter::create(
+            &output,
+            &bcf::Header::from_template(reader.header()),
+            format,
+            VariantLimits::default(),
+        )
+        .unwrap();
+        while let Some(record) = reader.read().unwrap() {
+            writer.write(record).unwrap();
+        }
+        writer.finish().unwrap();
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&output)
+            .unwrap();
+        let length = file.metadata().unwrap().len();
+        file.set_len(length - 28).unwrap();
+        drop(file);
+        assert!(VariantReader::open(output, VariantLimits::default())
+            .unwrap_err()
+            .to_string()
+            .contains("BGZF end marker"));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn native_header_and_final_flush_errors_are_reported() {
+    let mut header = bcf::Header::new();
+    let writer = CheckedVariantWriter::create(
+        "/dev/full",
+        &header,
+        VariantFormat::Vcf,
+        VariantLimits::default(),
+    )
+    .unwrap();
+    assert!(
+        writer.finish().is_err(),
+        "buffered header flush must fail explicitly"
+    );
+    header.push_record(format!("##long={}", "x".repeat(100_000)).as_bytes());
+    assert!(
+        CheckedVariantWriter::create(
+            "/dev/full",
+            &header,
+            VariantFormat::Vcf,
+            VariantLimits::default()
+        )
+        .is_err(),
+        "large header must surface a write failure"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn native_record_write_error_prevents_successful_finish() {
+    let f = Fixture::new();
+    let input = f.write(
+        "large.vcf",
+        format!(
+            "{}chr1\t1\t.\tA\tC\t.\t.\tOLD={}\tGT\t0/1\n",
+            header(),
+            "x".repeat(100_000)
+        ),
+    );
+    let mut reader = VariantReader::open(input, VariantLimits::default()).unwrap();
+    let mut writer = CheckedVariantWriter::create(
+        "/dev/full",
+        &bcf::Header::from_template(reader.header()),
+        VariantFormat::Vcf,
+        VariantLimits::default(),
+    )
+    .unwrap();
+    let record = reader.read().unwrap().unwrap();
+    assert!(matches!(writer.write(record), Err(EvidenceError::Io(_))));
+    assert!(writer.finish().is_err());
+}

--- a/tests/rss_exec.rs
+++ b/tests/rss_exec.rs
@@ -1,0 +1,64 @@
+//! Native worker accounting must exclude allocations retained by its caller.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+use rosalind::util::rss::peak_rss_bytes;
+
+const PARENT_BYTES: usize = 128 << 20;
+const CHILD_BYTES: usize = 32 << 20;
+
+fn resident_allocation(bytes: usize) -> Vec<u8> {
+    let mut allocation = vec![0; bytes];
+    for offset in (0..bytes).step_by(4096) {
+        allocation[offset] = 1;
+    }
+    allocation
+}
+
+#[test]
+fn native_worker_peak_excludes_parent_memory_and_retains_its_own_peak() {
+    const CHILD: &str = "ROSALIND_TEST_RSS_EXEC_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let parent_memory = resident_allocation(PARENT_BYTES);
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "native_worker_peak_excludes_parent_memory_and_retains_its_own_peak",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .output()
+            .unwrap();
+        std::hint::black_box(&parent_memory);
+        assert!(
+            output.status.success(),
+            "native worker RSS regression failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    assert_eq!(unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) }, 0);
+    let inherited_peak = (usage.ru_maxrss as u64) * 1024;
+    assert!(inherited_peak >= PARENT_BYTES as u64);
+    let initial = peak_rss_bytes();
+    assert!(
+        initial + (PARENT_BYTES as u64 / 2) < inherited_peak,
+        "worker peak {initial} must exclude inherited parent peak {inherited_peak}"
+    );
+
+    let child_memory = resident_allocation(CHILD_BYTES);
+    std::hint::black_box(&child_memory);
+    let touched = peak_rss_bytes();
+    assert!(touched >= initial + (CHILD_BYTES as u64 / 2));
+    assert!(touched >= CHILD_BYTES as u64);
+    drop(child_memory);
+    assert!(
+        peak_rss_bytes() >= touched,
+        "released native allocations must remain in the worker high-water mark"
+    );
+}


### PR DESCRIPTION
Researchers can select SNV loci from VCF, compressed VCF or BCF and preserve their original variant records while adding exact read evidence. `--annotated-variants` retains ALT/record order, duplicate records, existing INFO/FILTER and phased genotypes; optional per-allele quality and position sums distinguish evidence that pooled statistics cannot represent.

The implementation checks native header/record/final-flush failures, reads verified evidence with one retained canonical partition, and publishes evidence, annotations and receipts atomically. Annotation replay compares actual VCF/VCF.gz/BCF bytes. Original full and projected evidence byte goldens remain unchanged; extended metrics use an additive versioned field mask.

Validation: 514-test workspace run plus focused hardening checks; all 128 field masks; independent allele sums and equal-pooled-quality counterexample; record/FORMAT/sample preservation; three admitted budgets and worker layouts; corrupt/truncated input and resource-partial tests; Python 3.9/3.11; Clippy and Rust 1.83. A fresh macOS wheel completes packaged onboarding, verification, replay and external analyzer conformance. Linux-specific native I/O failure tests run in CI. This is implemented and locally verified, not yet published or externally adopted.

Stacked on #99 so physical projection is delivered first. The merged release-inventory correction from #100 is included through main. See `docs/variant-annotation.md` for the scientific and resource contract.
